### PR TITLE
changed includes of logger.h to xlogging.h to avoid redefinition errors

### DIFF
--- a/inc/consolelogger.h
+++ b/inc/consolelogger.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#include "logger.h"
+#include "xlogging.h"
 
 	extern void consolelogger_log(unsigned int options, char* format, ...);
 

--- a/inc/frame_codec.h
+++ b/inc/frame_codec.h
@@ -5,7 +5,7 @@
 #define FRAME_CODEC_H
 
 #include "xio.h"
-#include "logger.h"
+#include "xlogging.h"
 #include "amqpvalue.h"
 
 #ifdef __cplusplus

--- a/inc/message_sender.h
+++ b/inc/message_sender.h
@@ -6,7 +6,7 @@
 
 #include "link.h"
 #include "message.h"
-#include "logger.h"
+#include "xlogging.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/inc/sasl_anonymous.h
+++ b/inc/sasl_anonymous.h
@@ -5,7 +5,7 @@
 #define SASL_ANONYMOUS_H
 
 #include "sasl_mechanism.h"
-#include "logger.h"
+#include "xlogging.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/inc/saslclientio.h
+++ b/inc/saslclientio.h
@@ -13,7 +13,7 @@ extern "C" {
 
 #include "xio.h"
 #include "sasl_mechanism.h"
-#include "logger.h"
+#include "xlogging.h"
 
 typedef struct SASLCLIENTIO_CONFIG_TAG
 {

--- a/inc/wsio.h
+++ b/inc/wsio.h
@@ -15,7 +15,7 @@ extern "C" {
 
 #include "xio.h"
 #include "sasl_mechanism.h"
-#include "logger.h"
+#include "xlogging.h"
 
 typedef struct WSIO_CONFIG_TAG
 {

--- a/src/connection.c
+++ b/src/connection.c
@@ -13,7 +13,7 @@
 #include "amqp_definitions.h"
 #include "xio.h"
 #include "amqpalloc.h"
-#include "logger.h"
+#include "xlogging.h"
 #include "amqpvalue_to_string.h"
 #include "tickcounter.h"
 

--- a/src/consolelogger.c
+++ b/src/consolelogger.c
@@ -7,7 +7,7 @@
 #endif
 #include <stdarg.h>
 #include <stdio.h>
-#include "logger.h"
+#include "xlogging.h"
 
 void consolelogger_log(unsigned int options, char* format, ...)
 {

--- a/src/frame_codec.c
+++ b/src/frame_codec.c
@@ -10,7 +10,7 @@
 #include <string.h>
 #include "frame_codec.h"
 #include "amqpvalue.h"
-#include "logger.h"
+#include "xlogging.h"
 #include "xio.h"
 #include "amqpalloc.h"
 #include "list.h"

--- a/src/link.c
+++ b/src/link.c
@@ -15,7 +15,7 @@
 #include "amqpalloc.h"
 #include "amqp_frame_codec.h"
 #include "consolelogger.h"
-#include "logger.h"
+#include "xlogging.h"
 #include "list.h"
 
 #define DEFAULT_LINK_CREDIT 10000

--- a/src/message_sender.c
+++ b/src/message_sender.c
@@ -8,9 +8,9 @@
 #include <string.h>
 #include "message_sender.h"
 #include "amqpalloc.h"
-#include "logger.h"
+#include "xlogging.h"
 #include "amqpvalue_to_string.h"
-#include "logger.h"
+#include "xlogging.h"
 
 typedef enum MESSAGE_SEND_STATE_TAG
 {

--- a/src/sasl_anonymous.c
+++ b/src/sasl_anonymous.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include "sasl_anonymous.h"
 #include "amqpalloc.h"
-#include "logger.h"
+#include "xlogging.h"
 
 typedef struct SASL_ANONYMOUS_INSTANCE_TAG
 {

--- a/src/saslclientio.c
+++ b/src/saslclientio.c
@@ -14,7 +14,7 @@
 #include "frame_codec.h"
 #include "sasl_frame_codec.h"
 #include "amqp_definitions.h"
-#include "logger.h"
+#include "xlogging.h"
 #include "amqpvalue_to_string.h"
 
 typedef enum IO_STATE_TAG

--- a/src/session.c
+++ b/src/session.c
@@ -10,7 +10,7 @@
 #include "connection.h"
 #include "amqpalloc.h"
 #include "consolelogger.h"
-#include "logger.h"
+#include "xlogging.h"
 
 typedef struct LINK_ENDPOINT_INSTANCE_TAG
 {

--- a/src/wsio.c
+++ b/src/wsio.c
@@ -10,7 +10,7 @@
 #include <stdbool.h>
 #include "wsio.h"
 #include "amqpalloc.h"
-#include "logger.h"
+#include "xlogging.h"
 #include "list.h"
 #include "libwebsockets.h"
 #include "openssl/ssl.h"


### PR DESCRIPTION
When compiling with lower version of gcc(3.4.2 in my case), there will be a redefinition error of typedef 'LOGGER_LOG' - the definitions are in logger.h and xlogging.h - and these two files are actually same, so I made this change to avoid the compile error.