### PR TITLE
Correct typo

### DIFF
--- a/tests/wsio_unittests/wsio_unittests.cpp
+++ b/tests/wsio_unittests/wsio_unittests.cpp
@@ -4,7 +4,7 @@
 #include "testrunnerswitcher.h"
 #include "micromock.h"
 #include "micromockcharstararenullterminatedstrings.h"
-#include "azure_C_shared_utility/xio.h"
+#include "azure_c_shared_utility/xio.h"
 #include "azure_uamqp_c/wsio.h"
 #include "azure_c_shared_utility/list.h"
 #include "libwebsockets.h"


### PR DESCRIPTION
Here is a correction for https://github.com/Azure/azure-iot-sdks/issues/469 typo error.