### PR TITLE
Convert sasl_anonymous unit tests to use umock_c

### DIFF
--- a/src/sasl_anonymous.c
+++ b/src/sasl_anonymous.c
@@ -3,9 +3,9 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include "azure_uamqp_c/sasl_anonymous.h"
-#include "azure_uamqp_c/amqpalloc.h"
 #include "azure_c_shared_utility/optimize_size.h"
+#include "azure_c_shared_utility/gballoc.h"
+#include "azure_uamqp_c/sasl_anonymous.h"
 #include "azure_c_shared_utility/xlogging.h"
 
 typedef struct SASL_ANONYMOUS_INSTANCE_TAG
@@ -30,7 +30,7 @@ CONCRETE_SASL_MECHANISM_HANDLE saslanonymous_create(void* config)
 	(void)config;
 
 	/* Codes_SRS_SASL_ANONYMOUS_01_002: [If allocating the memory needed for the saslanonymous instance fails then saslanonymous_create shall return NULL.] */
-	return amqpalloc_malloc(sizeof(SASL_ANONYMOUS_INSTANCE));
+	return malloc(sizeof(SASL_ANONYMOUS_INSTANCE));
 }
 
 void saslanonymous_destroy(CONCRETE_SASL_MECHANISM_HANDLE sasl_mechanism_concrete_handle)
@@ -39,7 +39,7 @@ void saslanonymous_destroy(CONCRETE_SASL_MECHANISM_HANDLE sasl_mechanism_concret
 	if (sasl_mechanism_concrete_handle != NULL)
 	{
 		/* Codes_SRS_SASL_ANONYMOUS_01_004: [saslanonymous_destroy shall free all resources associated with the SASL mechanism.] */
-		amqpalloc_free(sasl_mechanism_concrete_handle);
+		free(sasl_mechanism_concrete_handle);
 	}
 }
 

--- a/tests/sasl_anonymous_ut/CMakeLists.txt
+++ b/tests/sasl_anonymous_ut/CMakeLists.txt
@@ -5,8 +5,9 @@ cmake_minimum_required(VERSION 2.8.11)
 
 compileAsC99()
 set(theseTestsName sasl_anonymous_ut)
-set(${theseTestsName}_cpp_files
-${theseTestsName}.cpp
+
+set(${theseTestsName}_test_files
+${theseTestsName}.c
 )
 
 set(${theseTestsName}_c_files
@@ -16,4 +17,4 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} ON)
+build_c_test_artifacts(${theseTestsName} ON "tests/uamqp_tests")


### PR DESCRIPTION
Convert sasl_anonymous unit tests to use umock_c rather than the old Micromock C++.
Also replaced usage of amqpalloc with gballoc.