### PR TITLE
Improve frame_codec in order to not split frames when encoded

### DIFF
--- a/inc/azure_uamqp_c/frame_codec.h
+++ b/inc/azure_uamqp_c/frame_codec.h
@@ -49,7 +49,7 @@ typedef struct PAYLOAD_TAG
 	MOCKABLE_FUNCTION(, int, frame_codec_subscribe, FRAME_CODEC_HANDLE, frame_codec, uint8_t, type, ON_FRAME_RECEIVED, on_frame_received, void*, callback_context);
 	MOCKABLE_FUNCTION(, int, frame_codec_unsubscribe, FRAME_CODEC_HANDLE, frame_codec, uint8_t, type);
 	MOCKABLE_FUNCTION(, int, frame_codec_receive_bytes, FRAME_CODEC_HANDLE, frame_codec, const unsigned char*, buffer, size_t, size);
-	MOCKABLE_FUNCTION(, int, frame_codec_encode_frame, FRAME_CODEC_HANDLE, frame_codec, uint8_t, type, const PAYLOAD*, payloads, size_t, payload_count, const unsigned char*, type_specific_bytes, uint32_t, type_specific_size, ON_BYTES_ENCODED, encoded_bytes, void*, callback_context);
+	MOCKABLE_FUNCTION(, int, frame_codec_encode_frame, FRAME_CODEC_HANDLE, frame_codec, uint8_t, type, const PAYLOAD*, payloads, size_t, payload_count, const unsigned char*, type_specific_bytes, uint32_t, type_specific_size, ON_BYTES_ENCODED, on_bytes_encoded, void*, callback_context);
 	
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Improve frame_codec in order to not split frames when encoded
Also remove useless encoder state
Also re-enable the frame codec encoder unit tests that were disabled for an unknown past reason.