### PR TITLE
Add LogError to amqpvalue

### DIFF
--- a/inc/azure_uamqp_c/amqpvalue.h
+++ b/inc/azure_uamqp_c/amqpvalue.h
@@ -114,6 +114,7 @@ extern "C" {
 	MOCKABLE_FUNCTION(, AMQP_VALUE, amqpvalue_create_composite_with_ulong_descriptor, uint64_t, descriptor);
 	MOCKABLE_FUNCTION(, AMQP_VALUE, amqpvalue_get_list_item_in_place, AMQP_VALUE, value, size_t, index);
 	MOCKABLE_FUNCTION(, AMQP_VALUE, amqpvalue_get_composite_item_in_place, AMQP_VALUE, value, size_t, index);
+    MOCKABLE_FUNCTION(, int, amqpvalue_get_composite_item_count, AMQP_VALUE, value, uint32_t*, item_count);
 
 #ifdef __cplusplus
 }

--- a/src/amqp_definitions.c
+++ b/src/amqp_definitions.c
@@ -230,78 +230,116 @@ int amqpvalue_get_error(AMQP_VALUE value, ERROR_HANDLE* error_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* condition */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					{
-						error_destroy(*error_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					const char* condition;
-					if (amqpvalue_get_symbol(item_value, &condition) != 0)
-					{
-						error_destroy(*error_handle);
-						result = __FAILURE__;
-						break;
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* condition */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        {
+						        error_destroy(*error_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        const char* condition;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        error_destroy(*error_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_symbol(item_value, &condition) != 0)
+					            {
+						            error_destroy(*error_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* description */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* description;
-					if (amqpvalue_get_string(item_value, &description) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							error_destroy(*error_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* description */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* description;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_string(item_value, &description) != 0)
+					            {
+						            error_destroy(*error_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* info */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					fields info;
-					if (amqpvalue_get_fields(item_value, &info) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							error_destroy(*error_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* info */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        fields info;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_fields(item_value, &info) != 0)
+					            {
+						            error_destroy(*error_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				error_instance->composite_value = amqpvalue_clone(value);
+				    error_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -318,22 +356,38 @@ int error_get_condition(ERROR_HANDLE error, const char** condition_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		ERROR_INSTANCE* error_instance = (ERROR_INSTANCE*)error;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(error_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_symbol(item_value, condition_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(error_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(error_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_symbol(item_value, condition_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -384,22 +438,38 @@ int error_get_description(ERROR_HANDLE error, const char** description_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		ERROR_INSTANCE* error_instance = (ERROR_INSTANCE*)error;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(error_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_string(item_value, description_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(error_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(error_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_string(item_value, description_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -450,22 +520,38 @@ int error_get_info(ERROR_HANDLE error, fields* info_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		ERROR_INSTANCE* error_instance = (ERROR_INSTANCE*)error;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(error_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_fields(item_value, info_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(error_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(error_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_fields(item_value, info_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -663,233 +749,320 @@ int amqpvalue_get_open(AMQP_VALUE value, OPEN_HANDLE* open_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* container-id */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					{
-						open_destroy(*open_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					const char* container_id;
-					if (amqpvalue_get_string(item_value, &container_id) != 0)
-					{
-						open_destroy(*open_handle);
-						result = __FAILURE__;
-						break;
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* container-id */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        {
+						        open_destroy(*open_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        const char* container_id;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        open_destroy(*open_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_string(item_value, &container_id) != 0)
+					            {
+						            open_destroy(*open_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* hostname */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* hostname;
-					if (amqpvalue_get_string(item_value, &hostname) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							open_destroy(*open_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* hostname */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* hostname;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_string(item_value, &hostname) != 0)
+					            {
+						            open_destroy(*open_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* max-frame-size */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					uint32_t max_frame_size;
-					if (amqpvalue_get_uint(item_value, &max_frame_size) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							open_destroy(*open_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* max-frame-size */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        uint32_t max_frame_size;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_uint(item_value, &max_frame_size) != 0)
+					            {
+						            open_destroy(*open_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* channel-max */
-				item_value = amqpvalue_get_list_item(list_value, 3);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					uint16_t channel_max;
-					if (amqpvalue_get_ushort(item_value, &channel_max) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							open_destroy(*open_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* channel-max */
+				    if (list_item_count > 3)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 3);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        uint16_t channel_max;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_ushort(item_value, &channel_max) != 0)
+					            {
+						            open_destroy(*open_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* idle-time-out */
-				item_value = amqpvalue_get_list_item(list_value, 4);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					milliseconds idle_time_out;
-					if (amqpvalue_get_milliseconds(item_value, &idle_time_out) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							open_destroy(*open_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* idle-time-out */
+				    if (list_item_count > 4)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 4);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        milliseconds idle_time_out;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_milliseconds(item_value, &idle_time_out) != 0)
+					            {
+						            open_destroy(*open_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* outgoing-locales */
-				item_value = amqpvalue_get_list_item(list_value, 5);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					ietf_language_tag outgoing_locales;
-					AMQP_VALUE outgoing_locales_array;
-					if ((amqpvalue_get_array(item_value, &outgoing_locales_array) != 0) &&
-						(amqpvalue_get_ietf_language_tag(item_value, &outgoing_locales) != 0))
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							open_destroy(*open_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* outgoing-locales */
+				    if (list_item_count > 5)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 5);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        ietf_language_tag outgoing_locales;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            AMQP_VALUE outgoing_locales_array;
+					            if ((amqpvalue_get_array(item_value, &outgoing_locales_array) != 0) &&
+						            (amqpvalue_get_ietf_language_tag(item_value, &outgoing_locales) != 0))
+					            {
+						            open_destroy(*open_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* incoming-locales */
-				item_value = amqpvalue_get_list_item(list_value, 6);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					ietf_language_tag incoming_locales;
-					AMQP_VALUE incoming_locales_array;
-					if ((amqpvalue_get_array(item_value, &incoming_locales_array) != 0) &&
-						(amqpvalue_get_ietf_language_tag(item_value, &incoming_locales) != 0))
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							open_destroy(*open_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* incoming-locales */
+				    if (list_item_count > 6)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 6);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        ietf_language_tag incoming_locales;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            AMQP_VALUE incoming_locales_array;
+					            if ((amqpvalue_get_array(item_value, &incoming_locales_array) != 0) &&
+						            (amqpvalue_get_ietf_language_tag(item_value, &incoming_locales) != 0))
+					            {
+						            open_destroy(*open_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* offered-capabilities */
-				item_value = amqpvalue_get_list_item(list_value, 7);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* offered_capabilities;
-					AMQP_VALUE offered_capabilities_array;
-					if ((amqpvalue_get_array(item_value, &offered_capabilities_array) != 0) &&
-						(amqpvalue_get_symbol(item_value, &offered_capabilities) != 0))
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							open_destroy(*open_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* offered-capabilities */
+				    if (list_item_count > 7)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 7);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* offered_capabilities;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            AMQP_VALUE offered_capabilities_array;
+					            if ((amqpvalue_get_array(item_value, &offered_capabilities_array) != 0) &&
+						            (amqpvalue_get_symbol(item_value, &offered_capabilities) != 0))
+					            {
+						            open_destroy(*open_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* desired-capabilities */
-				item_value = amqpvalue_get_list_item(list_value, 8);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* desired_capabilities;
-					AMQP_VALUE desired_capabilities_array;
-					if ((amqpvalue_get_array(item_value, &desired_capabilities_array) != 0) &&
-						(amqpvalue_get_symbol(item_value, &desired_capabilities) != 0))
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							open_destroy(*open_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* desired-capabilities */
+				    if (list_item_count > 8)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 8);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* desired_capabilities;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            AMQP_VALUE desired_capabilities_array;
+					            if ((amqpvalue_get_array(item_value, &desired_capabilities_array) != 0) &&
+						            (amqpvalue_get_symbol(item_value, &desired_capabilities) != 0))
+					            {
+						            open_destroy(*open_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* properties */
-				item_value = amqpvalue_get_list_item(list_value, 9);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					fields properties;
-					if (amqpvalue_get_fields(item_value, &properties) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							open_destroy(*open_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* properties */
+				    if (list_item_count > 9)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 9);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        fields properties;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_fields(item_value, &properties) != 0)
+					            {
+						            open_destroy(*open_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				open_instance->composite_value = amqpvalue_clone(value);
+				    open_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -906,22 +1079,38 @@ int open_get_container_id(OPEN_HANDLE open, const char** container_id_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_string(item_value, container_id_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(open_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_string(item_value, container_id_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -972,22 +1161,38 @@ int open_get_hostname(OPEN_HANDLE open, const char** hostname_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_string(item_value, hostname_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(open_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_string(item_value, hostname_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -1038,31 +1243,48 @@ int open_get_max_frame_size(OPEN_HANDLE open, uint32_t* max_frame_size_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-			*max_frame_size_value = 4294967295u;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_uint(item_value, max_frame_size_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(open_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
+			    *max_frame_size_value = 4294967295u;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *max_frame_size_value = 4294967295u;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_uint(item_value, max_frame_size_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *max_frame_size_value = 4294967295u;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -1113,31 +1335,48 @@ int open_get_channel_max(OPEN_HANDLE open, uint16_t* channel_max_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 3);
-		if (item_value == NULL)
-		{
-			*channel_max_value = 65535;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_ushort(item_value, channel_max_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(open_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 3)
+            {
+			    *channel_max_value = 65535;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 3);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *channel_max_value = 65535;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_ushort(item_value, channel_max_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *channel_max_value = 65535;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -1188,22 +1427,38 @@ int open_get_idle_time_out(OPEN_HANDLE open, milliseconds* idle_time_out_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 4);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_milliseconds(item_value, idle_time_out_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(open_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 4)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 4);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_milliseconds(item_value, idle_time_out_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -1254,22 +1509,38 @@ int open_get_outgoing_locales(OPEN_HANDLE open, AMQP_VALUE* outgoing_locales_val
 	}
 	else
 	{
+        uint32_t item_count;
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 5);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_array(item_value, outgoing_locales_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(open_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 5)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 5);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_array(item_value, outgoing_locales_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -1287,7 +1558,15 @@ int open_set_outgoing_locales(OPEN_HANDLE open, AMQP_VALUE outgoing_locales_valu
 	else
 	{
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE outgoing_locales_amqp_value = amqpvalue_clone(outgoing_locales_value);
+		AMQP_VALUE outgoing_locales_amqp_value;
+        if (outgoing_locales_value == NULL)
+        {
+            outgoing_locales_amqp_value = NULL;
+        }
+        else
+        {
+            outgoing_locales_amqp_value = amqpvalue_clone(outgoing_locales_value);
+        }
 		if (outgoing_locales_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -1320,22 +1599,38 @@ int open_get_incoming_locales(OPEN_HANDLE open, AMQP_VALUE* incoming_locales_val
 	}
 	else
 	{
+        uint32_t item_count;
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 6);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_array(item_value, incoming_locales_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(open_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 6)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 6);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_array(item_value, incoming_locales_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -1353,7 +1648,15 @@ int open_set_incoming_locales(OPEN_HANDLE open, AMQP_VALUE incoming_locales_valu
 	else
 	{
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE incoming_locales_amqp_value = amqpvalue_clone(incoming_locales_value);
+		AMQP_VALUE incoming_locales_amqp_value;
+        if (incoming_locales_value == NULL)
+        {
+            incoming_locales_amqp_value = NULL;
+        }
+        else
+        {
+            incoming_locales_amqp_value = amqpvalue_clone(incoming_locales_value);
+        }
 		if (incoming_locales_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -1386,22 +1689,38 @@ int open_get_offered_capabilities(OPEN_HANDLE open, AMQP_VALUE* offered_capabili
 	}
 	else
 	{
+        uint32_t item_count;
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 7);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_array(item_value, offered_capabilities_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(open_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 7)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 7);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_array(item_value, offered_capabilities_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -1419,7 +1738,15 @@ int open_set_offered_capabilities(OPEN_HANDLE open, AMQP_VALUE offered_capabilit
 	else
 	{
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE offered_capabilities_amqp_value = amqpvalue_clone(offered_capabilities_value);
+		AMQP_VALUE offered_capabilities_amqp_value;
+        if (offered_capabilities_value == NULL)
+        {
+            offered_capabilities_amqp_value = NULL;
+        }
+        else
+        {
+            offered_capabilities_amqp_value = amqpvalue_clone(offered_capabilities_value);
+        }
 		if (offered_capabilities_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -1452,22 +1779,38 @@ int open_get_desired_capabilities(OPEN_HANDLE open, AMQP_VALUE* desired_capabili
 	}
 	else
 	{
+        uint32_t item_count;
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 8);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_array(item_value, desired_capabilities_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(open_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 8)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 8);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_array(item_value, desired_capabilities_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -1485,7 +1828,15 @@ int open_set_desired_capabilities(OPEN_HANDLE open, AMQP_VALUE desired_capabilit
 	else
 	{
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE desired_capabilities_amqp_value = amqpvalue_clone(desired_capabilities_value);
+		AMQP_VALUE desired_capabilities_amqp_value;
+        if (desired_capabilities_value == NULL)
+        {
+            desired_capabilities_amqp_value = NULL;
+        }
+        else
+        {
+            desired_capabilities_amqp_value = amqpvalue_clone(desired_capabilities_value);
+        }
 		if (desired_capabilities_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -1518,22 +1869,38 @@ int open_get_properties(OPEN_HANDLE open, fields* properties_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		OPEN_INSTANCE* open_instance = (OPEN_INSTANCE*)open;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 9);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_fields(item_value, properties_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(open_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 9)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(open_instance->composite_value, 9);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_fields(item_value, properties_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -1717,189 +2084,280 @@ int amqpvalue_get_begin(AMQP_VALUE value, BEGIN_HANDLE* begin_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* remote-channel */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					uint16_t remote_channel;
-					if (amqpvalue_get_ushort(item_value, &remote_channel) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							begin_destroy(*begin_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* remote-channel */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        uint16_t remote_channel;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_ushort(item_value, &remote_channel) != 0)
+					            {
+						            begin_destroy(*begin_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* next-outgoing-id */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					{
-						begin_destroy(*begin_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					transfer_number next_outgoing_id;
-					if (amqpvalue_get_transfer_number(item_value, &next_outgoing_id) != 0)
-					{
-						begin_destroy(*begin_handle);
-						result = __FAILURE__;
-						break;
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* next-outgoing-id */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        {
+						        begin_destroy(*begin_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        transfer_number next_outgoing_id;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        begin_destroy(*begin_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_transfer_number(item_value, &next_outgoing_id) != 0)
+					            {
+						            begin_destroy(*begin_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* incoming-window */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					{
-						begin_destroy(*begin_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					uint32_t incoming_window;
-					if (amqpvalue_get_uint(item_value, &incoming_window) != 0)
-					{
-						begin_destroy(*begin_handle);
-						result = __FAILURE__;
-						break;
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* incoming-window */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        {
+						        begin_destroy(*begin_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        uint32_t incoming_window;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        begin_destroy(*begin_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_uint(item_value, &incoming_window) != 0)
+					            {
+						            begin_destroy(*begin_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* outgoing-window */
-				item_value = amqpvalue_get_list_item(list_value, 3);
-				if (item_value == NULL)
-				{
-					{
-						begin_destroy(*begin_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					uint32_t outgoing_window;
-					if (amqpvalue_get_uint(item_value, &outgoing_window) != 0)
-					{
-						begin_destroy(*begin_handle);
-						result = __FAILURE__;
-						break;
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* outgoing-window */
+				    if (list_item_count > 3)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 3);
+				        if (item_value == NULL)
+				        {
+					        {
+						        begin_destroy(*begin_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        uint32_t outgoing_window;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        begin_destroy(*begin_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_uint(item_value, &outgoing_window) != 0)
+					            {
+						            begin_destroy(*begin_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* handle-max */
-				item_value = amqpvalue_get_list_item(list_value, 4);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					handle handle_max;
-					if (amqpvalue_get_handle(item_value, &handle_max) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							begin_destroy(*begin_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* handle-max */
+				    if (list_item_count > 4)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 4);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        handle handle_max;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_handle(item_value, &handle_max) != 0)
+					            {
+						            begin_destroy(*begin_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* offered-capabilities */
-				item_value = amqpvalue_get_list_item(list_value, 5);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* offered_capabilities;
-					AMQP_VALUE offered_capabilities_array;
-					if ((amqpvalue_get_array(item_value, &offered_capabilities_array) != 0) &&
-						(amqpvalue_get_symbol(item_value, &offered_capabilities) != 0))
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							begin_destroy(*begin_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* offered-capabilities */
+				    if (list_item_count > 5)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 5);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* offered_capabilities;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            AMQP_VALUE offered_capabilities_array;
+					            if ((amqpvalue_get_array(item_value, &offered_capabilities_array) != 0) &&
+						            (amqpvalue_get_symbol(item_value, &offered_capabilities) != 0))
+					            {
+						            begin_destroy(*begin_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* desired-capabilities */
-				item_value = amqpvalue_get_list_item(list_value, 6);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* desired_capabilities;
-					AMQP_VALUE desired_capabilities_array;
-					if ((amqpvalue_get_array(item_value, &desired_capabilities_array) != 0) &&
-						(amqpvalue_get_symbol(item_value, &desired_capabilities) != 0))
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							begin_destroy(*begin_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* desired-capabilities */
+				    if (list_item_count > 6)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 6);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* desired_capabilities;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            AMQP_VALUE desired_capabilities_array;
+					            if ((amqpvalue_get_array(item_value, &desired_capabilities_array) != 0) &&
+						            (amqpvalue_get_symbol(item_value, &desired_capabilities) != 0))
+					            {
+						            begin_destroy(*begin_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* properties */
-				item_value = amqpvalue_get_list_item(list_value, 7);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					fields properties;
-					if (amqpvalue_get_fields(item_value, &properties) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							begin_destroy(*begin_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* properties */
+				    if (list_item_count > 7)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 7);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        fields properties;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_fields(item_value, &properties) != 0)
+					            {
+						            begin_destroy(*begin_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				begin_instance->composite_value = amqpvalue_clone(value);
+				    begin_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -1916,22 +2374,38 @@ int begin_get_remote_channel(BEGIN_HANDLE begin, uint16_t* remote_channel_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		BEGIN_INSTANCE* begin_instance = (BEGIN_INSTANCE*)begin;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_ushort(item_value, remote_channel_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(begin_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_ushort(item_value, remote_channel_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -1982,22 +2456,38 @@ int begin_get_next_outgoing_id(BEGIN_HANDLE begin, transfer_number* next_outgoin
 	}
 	else
 	{
+        uint32_t item_count;
 		BEGIN_INSTANCE* begin_instance = (BEGIN_INSTANCE*)begin;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_transfer_number(item_value, next_outgoing_id_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(begin_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_transfer_number(item_value, next_outgoing_id_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -2048,22 +2538,38 @@ int begin_get_incoming_window(BEGIN_HANDLE begin, uint32_t* incoming_window_valu
 	}
 	else
 	{
+        uint32_t item_count;
 		BEGIN_INSTANCE* begin_instance = (BEGIN_INSTANCE*)begin;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_uint(item_value, incoming_window_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(begin_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_uint(item_value, incoming_window_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -2114,22 +2620,38 @@ int begin_get_outgoing_window(BEGIN_HANDLE begin, uint32_t* outgoing_window_valu
 	}
 	else
 	{
+        uint32_t item_count;
 		BEGIN_INSTANCE* begin_instance = (BEGIN_INSTANCE*)begin;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 3);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_uint(item_value, outgoing_window_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(begin_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 3)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 3);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_uint(item_value, outgoing_window_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -2180,31 +2702,48 @@ int begin_get_handle_max(BEGIN_HANDLE begin, handle* handle_max_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		BEGIN_INSTANCE* begin_instance = (BEGIN_INSTANCE*)begin;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 4);
-		if (item_value == NULL)
-		{
-			*handle_max_value = 4294967295u;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_handle(item_value, handle_max_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(begin_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 4)
+            {
+			    *handle_max_value = 4294967295u;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 4);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *handle_max_value = 4294967295u;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_handle(item_value, handle_max_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *handle_max_value = 4294967295u;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -2255,22 +2794,38 @@ int begin_get_offered_capabilities(BEGIN_HANDLE begin, AMQP_VALUE* offered_capab
 	}
 	else
 	{
+        uint32_t item_count;
 		BEGIN_INSTANCE* begin_instance = (BEGIN_INSTANCE*)begin;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 5);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_array(item_value, offered_capabilities_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(begin_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 5)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 5);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_array(item_value, offered_capabilities_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -2288,7 +2843,15 @@ int begin_set_offered_capabilities(BEGIN_HANDLE begin, AMQP_VALUE offered_capabi
 	else
 	{
 		BEGIN_INSTANCE* begin_instance = (BEGIN_INSTANCE*)begin;
-		AMQP_VALUE offered_capabilities_amqp_value = amqpvalue_clone(offered_capabilities_value);
+		AMQP_VALUE offered_capabilities_amqp_value;
+        if (offered_capabilities_value == NULL)
+        {
+            offered_capabilities_amqp_value = NULL;
+        }
+        else
+        {
+            offered_capabilities_amqp_value = amqpvalue_clone(offered_capabilities_value);
+        }
 		if (offered_capabilities_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -2321,22 +2884,38 @@ int begin_get_desired_capabilities(BEGIN_HANDLE begin, AMQP_VALUE* desired_capab
 	}
 	else
 	{
+        uint32_t item_count;
 		BEGIN_INSTANCE* begin_instance = (BEGIN_INSTANCE*)begin;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 6);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_array(item_value, desired_capabilities_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(begin_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 6)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 6);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_array(item_value, desired_capabilities_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -2354,7 +2933,15 @@ int begin_set_desired_capabilities(BEGIN_HANDLE begin, AMQP_VALUE desired_capabi
 	else
 	{
 		BEGIN_INSTANCE* begin_instance = (BEGIN_INSTANCE*)begin;
-		AMQP_VALUE desired_capabilities_amqp_value = amqpvalue_clone(desired_capabilities_value);
+		AMQP_VALUE desired_capabilities_amqp_value;
+        if (desired_capabilities_value == NULL)
+        {
+            desired_capabilities_amqp_value = NULL;
+        }
+        else
+        {
+            desired_capabilities_amqp_value = amqpvalue_clone(desired_capabilities_value);
+        }
 		if (desired_capabilities_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -2387,22 +2974,38 @@ int begin_get_properties(BEGIN_HANDLE begin, fields* properties_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		BEGIN_INSTANCE* begin_instance = (BEGIN_INSTANCE*)begin;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 7);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_fields(item_value, properties_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(begin_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 7)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(begin_instance->composite_value, 7);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_fields(item_value, properties_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -2586,293 +3189,418 @@ int amqpvalue_get_attach(AMQP_VALUE value, ATTACH_HANDLE* attach_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* name */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					{
-						attach_destroy(*attach_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					const char* name;
-					if (amqpvalue_get_string(item_value, &name) != 0)
-					{
-						attach_destroy(*attach_handle);
-						result = __FAILURE__;
-						break;
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* name */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        {
+						        attach_destroy(*attach_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        const char* name;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        attach_destroy(*attach_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_string(item_value, &name) != 0)
+					            {
+						            attach_destroy(*attach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* handle */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					{
-						attach_destroy(*attach_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					handle handle;
-					if (amqpvalue_get_handle(item_value, &handle) != 0)
-					{
-						attach_destroy(*attach_handle);
-						result = __FAILURE__;
-						break;
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* handle */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        {
+						        attach_destroy(*attach_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        handle handle;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        attach_destroy(*attach_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_handle(item_value, &handle) != 0)
+					            {
+						            attach_destroy(*attach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* role */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					{
-						attach_destroy(*attach_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					role role;
-					if (amqpvalue_get_role(item_value, &role) != 0)
-					{
-						attach_destroy(*attach_handle);
-						result = __FAILURE__;
-						break;
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* role */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        {
+						        attach_destroy(*attach_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        role role;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        attach_destroy(*attach_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_role(item_value, &role) != 0)
+					            {
+						            attach_destroy(*attach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* snd-settle-mode */
-				item_value = amqpvalue_get_list_item(list_value, 3);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					sender_settle_mode snd_settle_mode;
-					if (amqpvalue_get_sender_settle_mode(item_value, &snd_settle_mode) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							attach_destroy(*attach_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* snd-settle-mode */
+				    if (list_item_count > 3)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 3);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        sender_settle_mode snd_settle_mode;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_sender_settle_mode(item_value, &snd_settle_mode) != 0)
+					            {
+						            attach_destroy(*attach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* rcv-settle-mode */
-				item_value = amqpvalue_get_list_item(list_value, 4);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					receiver_settle_mode rcv_settle_mode;
-					if (amqpvalue_get_receiver_settle_mode(item_value, &rcv_settle_mode) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							attach_destroy(*attach_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* rcv-settle-mode */
+				    if (list_item_count > 4)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 4);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        receiver_settle_mode rcv_settle_mode;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_receiver_settle_mode(item_value, &rcv_settle_mode) != 0)
+					            {
+						            attach_destroy(*attach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* source */
-				item_value = amqpvalue_get_list_item(list_value, 5);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqpvalue_destroy(item_value);
-				}
-				/* target */
-				item_value = amqpvalue_get_list_item(list_value, 6);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqpvalue_destroy(item_value);
-				}
-				/* unsettled */
-				item_value = amqpvalue_get_list_item(list_value, 7);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					AMQP_VALUE unsettled;
-					if (amqpvalue_get_map(item_value, &unsettled) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							attach_destroy(*attach_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* source */
+				    if (list_item_count > 5)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 5);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* target */
+				    if (list_item_count > 6)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 6);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* unsettled */
+				    if (list_item_count > 7)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 7);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        AMQP_VALUE unsettled;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_map(item_value, &unsettled) != 0)
+					            {
+						            attach_destroy(*attach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* incomplete-unsettled */
-				item_value = amqpvalue_get_list_item(list_value, 8);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool incomplete_unsettled;
-					if (amqpvalue_get_boolean(item_value, &incomplete_unsettled) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							attach_destroy(*attach_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* incomplete-unsettled */
+				    if (list_item_count > 8)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 8);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool incomplete_unsettled;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &incomplete_unsettled) != 0)
+					            {
+						            attach_destroy(*attach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* initial-delivery-count */
-				item_value = amqpvalue_get_list_item(list_value, 9);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					sequence_no initial_delivery_count;
-					if (amqpvalue_get_sequence_no(item_value, &initial_delivery_count) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							attach_destroy(*attach_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* initial-delivery-count */
+				    if (list_item_count > 9)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 9);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        sequence_no initial_delivery_count;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_sequence_no(item_value, &initial_delivery_count) != 0)
+					            {
+						            attach_destroy(*attach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* max-message-size */
-				item_value = amqpvalue_get_list_item(list_value, 10);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					uint64_t max_message_size;
-					if (amqpvalue_get_ulong(item_value, &max_message_size) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							attach_destroy(*attach_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* max-message-size */
+				    if (list_item_count > 10)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 10);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        uint64_t max_message_size;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_ulong(item_value, &max_message_size) != 0)
+					            {
+						            attach_destroy(*attach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* offered-capabilities */
-				item_value = amqpvalue_get_list_item(list_value, 11);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* offered_capabilities;
-					AMQP_VALUE offered_capabilities_array;
-					if ((amqpvalue_get_array(item_value, &offered_capabilities_array) != 0) &&
-						(amqpvalue_get_symbol(item_value, &offered_capabilities) != 0))
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							attach_destroy(*attach_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* offered-capabilities */
+				    if (list_item_count > 11)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 11);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* offered_capabilities;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            AMQP_VALUE offered_capabilities_array;
+					            if ((amqpvalue_get_array(item_value, &offered_capabilities_array) != 0) &&
+						            (amqpvalue_get_symbol(item_value, &offered_capabilities) != 0))
+					            {
+						            attach_destroy(*attach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* desired-capabilities */
-				item_value = amqpvalue_get_list_item(list_value, 12);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* desired_capabilities;
-					AMQP_VALUE desired_capabilities_array;
-					if ((amqpvalue_get_array(item_value, &desired_capabilities_array) != 0) &&
-						(amqpvalue_get_symbol(item_value, &desired_capabilities) != 0))
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							attach_destroy(*attach_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* desired-capabilities */
+				    if (list_item_count > 12)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 12);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* desired_capabilities;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            AMQP_VALUE desired_capabilities_array;
+					            if ((amqpvalue_get_array(item_value, &desired_capabilities_array) != 0) &&
+						            (amqpvalue_get_symbol(item_value, &desired_capabilities) != 0))
+					            {
+						            attach_destroy(*attach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* properties */
-				item_value = amqpvalue_get_list_item(list_value, 13);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					fields properties;
-					if (amqpvalue_get_fields(item_value, &properties) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							attach_destroy(*attach_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* properties */
+				    if (list_item_count > 13)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 13);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        fields properties;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_fields(item_value, &properties) != 0)
+					            {
+						            attach_destroy(*attach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				attach_instance->composite_value = amqpvalue_clone(value);
+				    attach_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -2889,22 +3617,38 @@ int attach_get_name(ATTACH_HANDLE attach, const char** name_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_string(item_value, name_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_string(item_value, name_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -2955,22 +3699,38 @@ int attach_get_handle(ATTACH_HANDLE attach, handle* handle_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_handle(item_value, handle_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_handle(item_value, handle_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -3021,22 +3781,38 @@ int attach_get_role(ATTACH_HANDLE attach, role* role_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_role(item_value, role_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_role(item_value, role_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -3087,31 +3863,48 @@ int attach_get_snd_settle_mode(ATTACH_HANDLE attach, sender_settle_mode* snd_set
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 3);
-		if (item_value == NULL)
-		{
-            *snd_settle_mode_value = sender_settle_mode_mixed;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_sender_settle_mode(item_value, snd_settle_mode_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 3)
+            {
+                *snd_settle_mode_value = sender_settle_mode_mixed;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 3);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
                     *snd_settle_mode_value = sender_settle_mode_mixed;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_sender_settle_mode(item_value, snd_settle_mode_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+                            *snd_settle_mode_value = sender_settle_mode_mixed;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -3162,31 +3955,48 @@ int attach_get_rcv_settle_mode(ATTACH_HANDLE attach, receiver_settle_mode* rcv_s
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 4);
-		if (item_value == NULL)
-		{
-            *rcv_settle_mode_value = receiver_settle_mode_first;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_receiver_settle_mode(item_value, rcv_settle_mode_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 4)
+            {
+                *rcv_settle_mode_value = receiver_settle_mode_first;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 4);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
                     *rcv_settle_mode_value = receiver_settle_mode_first;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_receiver_settle_mode(item_value, rcv_settle_mode_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+                            *rcv_settle_mode_value = receiver_settle_mode_first;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -3237,16 +4047,32 @@ int attach_get_source(ATTACH_HANDLE attach, AMQP_VALUE* source_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 5);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			*source_value = item_value;
-			result = 0;
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 5)
+            {
+			    result = __FAILURE__;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 5);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        *source_value = item_value;
+			        result = 0;
+                }
+            }
 		}
 	}
 
@@ -3264,7 +4090,15 @@ int attach_set_source(ATTACH_HANDLE attach, AMQP_VALUE source_value)
 	else
 	{
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE source_amqp_value = amqpvalue_clone(source_value);
+		AMQP_VALUE source_amqp_value;
+        if (source_value == NULL)
+        {
+            source_amqp_value = NULL;
+        }
+        else
+        {
+            source_amqp_value = amqpvalue_clone(source_value);
+        }
 		if (source_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -3297,16 +4131,32 @@ int attach_get_target(ATTACH_HANDLE attach, AMQP_VALUE* target_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 6);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			*target_value = item_value;
-			result = 0;
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 6)
+            {
+			    result = __FAILURE__;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 6);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        *target_value = item_value;
+			        result = 0;
+                }
+            }
 		}
 	}
 
@@ -3324,7 +4174,15 @@ int attach_set_target(ATTACH_HANDLE attach, AMQP_VALUE target_value)
 	else
 	{
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE target_amqp_value = amqpvalue_clone(target_value);
+		AMQP_VALUE target_amqp_value;
+        if (target_value == NULL)
+        {
+            target_amqp_value = NULL;
+        }
+        else
+        {
+            target_amqp_value = amqpvalue_clone(target_value);
+        }
 		if (target_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -3357,22 +4215,38 @@ int attach_get_unsettled(ATTACH_HANDLE attach, AMQP_VALUE* unsettled_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 7);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_map(item_value, unsettled_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 7)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 7);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_map(item_value, unsettled_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -3390,7 +4264,15 @@ int attach_set_unsettled(ATTACH_HANDLE attach, AMQP_VALUE unsettled_value)
 	else
 	{
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE unsettled_amqp_value = amqpvalue_clone(unsettled_value);
+		AMQP_VALUE unsettled_amqp_value;
+        if (unsettled_value == NULL)
+        {
+            unsettled_amqp_value = NULL;
+        }
+        else
+        {
+            unsettled_amqp_value = amqpvalue_clone(unsettled_value);
+        }
 		if (unsettled_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -3423,31 +4305,48 @@ int attach_get_incomplete_unsettled(ATTACH_HANDLE attach, bool* incomplete_unset
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 8);
-		if (item_value == NULL)
-		{
-			*incomplete_unsettled_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, incomplete_unsettled_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 8)
+            {
+			    *incomplete_unsettled_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 8);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *incomplete_unsettled_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, incomplete_unsettled_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *incomplete_unsettled_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -3498,22 +4397,38 @@ int attach_get_initial_delivery_count(ATTACH_HANDLE attach, sequence_no* initial
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 9);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_sequence_no(item_value, initial_delivery_count_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 9)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 9);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_sequence_no(item_value, initial_delivery_count_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -3564,22 +4479,38 @@ int attach_get_max_message_size(ATTACH_HANDLE attach, uint64_t* max_message_size
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 10);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_ulong(item_value, max_message_size_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 10)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 10);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_ulong(item_value, max_message_size_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -3630,22 +4561,38 @@ int attach_get_offered_capabilities(ATTACH_HANDLE attach, AMQP_VALUE* offered_ca
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 11);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_array(item_value, offered_capabilities_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 11)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 11);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_array(item_value, offered_capabilities_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -3663,7 +4610,15 @@ int attach_set_offered_capabilities(ATTACH_HANDLE attach, AMQP_VALUE offered_cap
 	else
 	{
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE offered_capabilities_amqp_value = amqpvalue_clone(offered_capabilities_value);
+		AMQP_VALUE offered_capabilities_amqp_value;
+        if (offered_capabilities_value == NULL)
+        {
+            offered_capabilities_amqp_value = NULL;
+        }
+        else
+        {
+            offered_capabilities_amqp_value = amqpvalue_clone(offered_capabilities_value);
+        }
 		if (offered_capabilities_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -3696,22 +4651,38 @@ int attach_get_desired_capabilities(ATTACH_HANDLE attach, AMQP_VALUE* desired_ca
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 12);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_array(item_value, desired_capabilities_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 12)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 12);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_array(item_value, desired_capabilities_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -3729,7 +4700,15 @@ int attach_set_desired_capabilities(ATTACH_HANDLE attach, AMQP_VALUE desired_cap
 	else
 	{
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE desired_capabilities_amqp_value = amqpvalue_clone(desired_capabilities_value);
+		AMQP_VALUE desired_capabilities_amqp_value;
+        if (desired_capabilities_value == NULL)
+        {
+            desired_capabilities_amqp_value = NULL;
+        }
+        else
+        {
+            desired_capabilities_amqp_value = amqpvalue_clone(desired_capabilities_value);
+        }
 		if (desired_capabilities_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -3762,22 +4741,38 @@ int attach_get_properties(ATTACH_HANDLE attach, fields* properties_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		ATTACH_INSTANCE* attach_instance = (ATTACH_INSTANCE*)attach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 13);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_fields(item_value, properties_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(attach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 13)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(attach_instance->composite_value, 13);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_fields(item_value, properties_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -3961,248 +4956,360 @@ int amqpvalue_get_flow(AMQP_VALUE value, FLOW_HANDLE* flow_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* next-incoming-id */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					transfer_number next_incoming_id;
-					if (amqpvalue_get_transfer_number(item_value, &next_incoming_id) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							flow_destroy(*flow_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* next-incoming-id */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        transfer_number next_incoming_id;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_transfer_number(item_value, &next_incoming_id) != 0)
+					            {
+						            flow_destroy(*flow_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* incoming-window */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					{
-						flow_destroy(*flow_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					uint32_t incoming_window;
-					if (amqpvalue_get_uint(item_value, &incoming_window) != 0)
-					{
-						flow_destroy(*flow_handle);
-						result = __FAILURE__;
-						break;
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* incoming-window */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        {
+						        flow_destroy(*flow_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        uint32_t incoming_window;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        flow_destroy(*flow_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_uint(item_value, &incoming_window) != 0)
+					            {
+						            flow_destroy(*flow_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* next-outgoing-id */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					{
-						flow_destroy(*flow_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					transfer_number next_outgoing_id;
-					if (amqpvalue_get_transfer_number(item_value, &next_outgoing_id) != 0)
-					{
-						flow_destroy(*flow_handle);
-						result = __FAILURE__;
-						break;
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* next-outgoing-id */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        {
+						        flow_destroy(*flow_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        transfer_number next_outgoing_id;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        flow_destroy(*flow_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_transfer_number(item_value, &next_outgoing_id) != 0)
+					            {
+						            flow_destroy(*flow_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* outgoing-window */
-				item_value = amqpvalue_get_list_item(list_value, 3);
-				if (item_value == NULL)
-				{
-					{
-						flow_destroy(*flow_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					uint32_t outgoing_window;
-					if (amqpvalue_get_uint(item_value, &outgoing_window) != 0)
-					{
-						flow_destroy(*flow_handle);
-						result = __FAILURE__;
-						break;
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* outgoing-window */
+				    if (list_item_count > 3)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 3);
+				        if (item_value == NULL)
+				        {
+					        {
+						        flow_destroy(*flow_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        uint32_t outgoing_window;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        flow_destroy(*flow_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_uint(item_value, &outgoing_window) != 0)
+					            {
+						            flow_destroy(*flow_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* handle */
-				item_value = amqpvalue_get_list_item(list_value, 4);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					handle handle;
-					if (amqpvalue_get_handle(item_value, &handle) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							flow_destroy(*flow_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* handle */
+				    if (list_item_count > 4)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 4);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        handle handle;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_handle(item_value, &handle) != 0)
+					            {
+						            flow_destroy(*flow_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* delivery-count */
-				item_value = amqpvalue_get_list_item(list_value, 5);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					sequence_no delivery_count;
-					if (amqpvalue_get_sequence_no(item_value, &delivery_count) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							flow_destroy(*flow_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* delivery-count */
+				    if (list_item_count > 5)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 5);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        sequence_no delivery_count;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_sequence_no(item_value, &delivery_count) != 0)
+					            {
+						            flow_destroy(*flow_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* link-credit */
-				item_value = amqpvalue_get_list_item(list_value, 6);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					uint32_t link_credit;
-					if (amqpvalue_get_uint(item_value, &link_credit) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							flow_destroy(*flow_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* link-credit */
+				    if (list_item_count > 6)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 6);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        uint32_t link_credit;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_uint(item_value, &link_credit) != 0)
+					            {
+						            flow_destroy(*flow_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* available */
-				item_value = amqpvalue_get_list_item(list_value, 7);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					uint32_t available;
-					if (amqpvalue_get_uint(item_value, &available) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							flow_destroy(*flow_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* available */
+				    if (list_item_count > 7)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 7);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        uint32_t available;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_uint(item_value, &available) != 0)
+					            {
+						            flow_destroy(*flow_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* drain */
-				item_value = amqpvalue_get_list_item(list_value, 8);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool drain;
-					if (amqpvalue_get_boolean(item_value, &drain) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							flow_destroy(*flow_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* drain */
+				    if (list_item_count > 8)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 8);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool drain;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &drain) != 0)
+					            {
+						            flow_destroy(*flow_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* echo */
-				item_value = amqpvalue_get_list_item(list_value, 9);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool echo;
-					if (amqpvalue_get_boolean(item_value, &echo) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							flow_destroy(*flow_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* echo */
+				    if (list_item_count > 9)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 9);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool echo;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &echo) != 0)
+					            {
+						            flow_destroy(*flow_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* properties */
-				item_value = amqpvalue_get_list_item(list_value, 10);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					fields properties;
-					if (amqpvalue_get_fields(item_value, &properties) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							flow_destroy(*flow_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* properties */
+				    if (list_item_count > 10)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 10);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        fields properties;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_fields(item_value, &properties) != 0)
+					            {
+						            flow_destroy(*flow_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				flow_instance->composite_value = amqpvalue_clone(value);
+				    flow_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -4219,22 +5326,38 @@ int flow_get_next_incoming_id(FLOW_HANDLE flow, transfer_number* next_incoming_i
 	}
 	else
 	{
+        uint32_t item_count;
 		FLOW_INSTANCE* flow_instance = (FLOW_INSTANCE*)flow;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_transfer_number(item_value, next_incoming_id_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(flow_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_transfer_number(item_value, next_incoming_id_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -4285,22 +5408,38 @@ int flow_get_incoming_window(FLOW_HANDLE flow, uint32_t* incoming_window_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		FLOW_INSTANCE* flow_instance = (FLOW_INSTANCE*)flow;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_uint(item_value, incoming_window_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(flow_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_uint(item_value, incoming_window_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -4351,22 +5490,38 @@ int flow_get_next_outgoing_id(FLOW_HANDLE flow, transfer_number* next_outgoing_i
 	}
 	else
 	{
+        uint32_t item_count;
 		FLOW_INSTANCE* flow_instance = (FLOW_INSTANCE*)flow;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_transfer_number(item_value, next_outgoing_id_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(flow_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_transfer_number(item_value, next_outgoing_id_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -4417,22 +5572,38 @@ int flow_get_outgoing_window(FLOW_HANDLE flow, uint32_t* outgoing_window_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		FLOW_INSTANCE* flow_instance = (FLOW_INSTANCE*)flow;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 3);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_uint(item_value, outgoing_window_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(flow_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 3)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 3);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_uint(item_value, outgoing_window_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -4483,22 +5654,38 @@ int flow_get_handle(FLOW_HANDLE flow, handle* handle_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		FLOW_INSTANCE* flow_instance = (FLOW_INSTANCE*)flow;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 4);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_handle(item_value, handle_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(flow_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 4)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 4);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_handle(item_value, handle_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -4549,22 +5736,38 @@ int flow_get_delivery_count(FLOW_HANDLE flow, sequence_no* delivery_count_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		FLOW_INSTANCE* flow_instance = (FLOW_INSTANCE*)flow;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 5);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_sequence_no(item_value, delivery_count_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(flow_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 5)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 5);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_sequence_no(item_value, delivery_count_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -4615,22 +5818,38 @@ int flow_get_link_credit(FLOW_HANDLE flow, uint32_t* link_credit_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		FLOW_INSTANCE* flow_instance = (FLOW_INSTANCE*)flow;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 6);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_uint(item_value, link_credit_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(flow_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 6)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 6);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_uint(item_value, link_credit_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -4681,22 +5900,38 @@ int flow_get_available(FLOW_HANDLE flow, uint32_t* available_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		FLOW_INSTANCE* flow_instance = (FLOW_INSTANCE*)flow;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 7);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_uint(item_value, available_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(flow_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 7)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 7);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_uint(item_value, available_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -4747,31 +5982,48 @@ int flow_get_drain(FLOW_HANDLE flow, bool* drain_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		FLOW_INSTANCE* flow_instance = (FLOW_INSTANCE*)flow;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 8);
-		if (item_value == NULL)
-		{
-			*drain_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, drain_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(flow_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 8)
+            {
+			    *drain_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 8);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *drain_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, drain_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *drain_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -4822,31 +6074,48 @@ int flow_get_echo(FLOW_HANDLE flow, bool* echo_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		FLOW_INSTANCE* flow_instance = (FLOW_INSTANCE*)flow;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 9);
-		if (item_value == NULL)
-		{
-			*echo_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, echo_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(flow_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 9)
+            {
+			    *echo_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 9);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *echo_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, echo_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *echo_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -4897,22 +6166,38 @@ int flow_get_properties(FLOW_HANDLE flow, fields* properties_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		FLOW_INSTANCE* flow_instance = (FLOW_INSTANCE*)flow;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 10);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_fields(item_value, properties_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(flow_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 10)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(flow_instance->composite_value, 10);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_fields(item_value, properties_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -5082,235 +6367,325 @@ int amqpvalue_get_transfer(AMQP_VALUE value, TRANSFER_HANDLE* transfer_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* handle */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					{
-						transfer_destroy(*transfer_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					handle handle;
-					if (amqpvalue_get_handle(item_value, &handle) != 0)
-					{
-						transfer_destroy(*transfer_handle);
-						result = __FAILURE__;
-						break;
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* handle */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        {
+						        transfer_destroy(*transfer_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        handle handle;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        transfer_destroy(*transfer_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_handle(item_value, &handle) != 0)
+					            {
+						            transfer_destroy(*transfer_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* delivery-id */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					delivery_number delivery_id;
-					if (amqpvalue_get_delivery_number(item_value, &delivery_id) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							transfer_destroy(*transfer_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* delivery-id */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        delivery_number delivery_id;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_delivery_number(item_value, &delivery_id) != 0)
+					            {
+						            transfer_destroy(*transfer_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* delivery-tag */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					delivery_tag delivery_tag;
-					if (amqpvalue_get_delivery_tag(item_value, &delivery_tag) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							transfer_destroy(*transfer_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* delivery-tag */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        delivery_tag delivery_tag;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_delivery_tag(item_value, &delivery_tag) != 0)
+					            {
+						            transfer_destroy(*transfer_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* message-format */
-				item_value = amqpvalue_get_list_item(list_value, 3);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					message_format message_format;
-					if (amqpvalue_get_message_format(item_value, &message_format) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							transfer_destroy(*transfer_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* message-format */
+				    if (list_item_count > 3)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 3);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        message_format message_format;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_message_format(item_value, &message_format) != 0)
+					            {
+						            transfer_destroy(*transfer_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* settled */
-				item_value = amqpvalue_get_list_item(list_value, 4);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool settled;
-					if (amqpvalue_get_boolean(item_value, &settled) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							transfer_destroy(*transfer_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* settled */
+				    if (list_item_count > 4)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 4);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool settled;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &settled) != 0)
+					            {
+						            transfer_destroy(*transfer_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* more */
-				item_value = amqpvalue_get_list_item(list_value, 5);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool more;
-					if (amqpvalue_get_boolean(item_value, &more) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							transfer_destroy(*transfer_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* more */
+				    if (list_item_count > 5)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 5);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool more;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &more) != 0)
+					            {
+						            transfer_destroy(*transfer_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* rcv-settle-mode */
-				item_value = amqpvalue_get_list_item(list_value, 6);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					receiver_settle_mode rcv_settle_mode;
-					if (amqpvalue_get_receiver_settle_mode(item_value, &rcv_settle_mode) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							transfer_destroy(*transfer_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* rcv-settle-mode */
+				    if (list_item_count > 6)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 6);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        receiver_settle_mode rcv_settle_mode;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_receiver_settle_mode(item_value, &rcv_settle_mode) != 0)
+					            {
+						            transfer_destroy(*transfer_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* state */
-				item_value = amqpvalue_get_list_item(list_value, 7);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqpvalue_destroy(item_value);
-				}
-				/* resume */
-				item_value = amqpvalue_get_list_item(list_value, 8);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool resume;
-					if (amqpvalue_get_boolean(item_value, &resume) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							transfer_destroy(*transfer_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* state */
+				    if (list_item_count > 7)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 7);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* resume */
+				    if (list_item_count > 8)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 8);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool resume;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &resume) != 0)
+					            {
+						            transfer_destroy(*transfer_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* aborted */
-				item_value = amqpvalue_get_list_item(list_value, 9);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool aborted;
-					if (amqpvalue_get_boolean(item_value, &aborted) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							transfer_destroy(*transfer_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* aborted */
+				    if (list_item_count > 9)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 9);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool aborted;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &aborted) != 0)
+					            {
+						            transfer_destroy(*transfer_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* batchable */
-				item_value = amqpvalue_get_list_item(list_value, 10);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool batchable;
-					if (amqpvalue_get_boolean(item_value, &batchable) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							transfer_destroy(*transfer_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* batchable */
+				    if (list_item_count > 10)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 10);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool batchable;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &batchable) != 0)
+					            {
+						            transfer_destroy(*transfer_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				transfer_instance->composite_value = amqpvalue_clone(value);
+				    transfer_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -5327,22 +6702,38 @@ int transfer_get_handle(TRANSFER_HANDLE transfer, handle* handle_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		TRANSFER_INSTANCE* transfer_instance = (TRANSFER_INSTANCE*)transfer;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_handle(item_value, handle_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(transfer_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_handle(item_value, handle_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -5393,22 +6784,38 @@ int transfer_get_delivery_id(TRANSFER_HANDLE transfer, delivery_number* delivery
 	}
 	else
 	{
+        uint32_t item_count;
 		TRANSFER_INSTANCE* transfer_instance = (TRANSFER_INSTANCE*)transfer;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_delivery_number(item_value, delivery_id_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(transfer_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_delivery_number(item_value, delivery_id_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -5459,22 +6866,38 @@ int transfer_get_delivery_tag(TRANSFER_HANDLE transfer, delivery_tag* delivery_t
 	}
 	else
 	{
+        uint32_t item_count;
 		TRANSFER_INSTANCE* transfer_instance = (TRANSFER_INSTANCE*)transfer;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_delivery_tag(item_value, delivery_tag_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(transfer_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_delivery_tag(item_value, delivery_tag_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -5525,22 +6948,38 @@ int transfer_get_message_format(TRANSFER_HANDLE transfer, message_format* messag
 	}
 	else
 	{
+        uint32_t item_count;
 		TRANSFER_INSTANCE* transfer_instance = (TRANSFER_INSTANCE*)transfer;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 3);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_message_format(item_value, message_format_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(transfer_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 3)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 3);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_message_format(item_value, message_format_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -5591,22 +7030,38 @@ int transfer_get_settled(TRANSFER_HANDLE transfer, bool* settled_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		TRANSFER_INSTANCE* transfer_instance = (TRANSFER_INSTANCE*)transfer;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 4);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, settled_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(transfer_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 4)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 4);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, settled_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -5657,31 +7112,48 @@ int transfer_get_more(TRANSFER_HANDLE transfer, bool* more_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		TRANSFER_INSTANCE* transfer_instance = (TRANSFER_INSTANCE*)transfer;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 5);
-		if (item_value == NULL)
-		{
-			*more_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, more_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(transfer_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 5)
+            {
+			    *more_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 5);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *more_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, more_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *more_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -5732,22 +7204,38 @@ int transfer_get_rcv_settle_mode(TRANSFER_HANDLE transfer, receiver_settle_mode*
 	}
 	else
 	{
+        uint32_t item_count;
 		TRANSFER_INSTANCE* transfer_instance = (TRANSFER_INSTANCE*)transfer;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 6);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_receiver_settle_mode(item_value, rcv_settle_mode_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(transfer_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 6)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 6);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_receiver_settle_mode(item_value, rcv_settle_mode_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -5798,16 +7286,32 @@ int transfer_get_state(TRANSFER_HANDLE transfer, AMQP_VALUE* state_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		TRANSFER_INSTANCE* transfer_instance = (TRANSFER_INSTANCE*)transfer;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 7);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			*state_value = item_value;
-			result = 0;
+        if (amqpvalue_get_composite_item_count(transfer_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 7)
+            {
+			    result = __FAILURE__;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 7);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        *state_value = item_value;
+			        result = 0;
+                }
+            }
 		}
 	}
 
@@ -5825,7 +7329,15 @@ int transfer_set_state(TRANSFER_HANDLE transfer, AMQP_VALUE state_value)
 	else
 	{
 		TRANSFER_INSTANCE* transfer_instance = (TRANSFER_INSTANCE*)transfer;
-		AMQP_VALUE state_amqp_value = amqpvalue_clone(state_value);
+		AMQP_VALUE state_amqp_value;
+        if (state_value == NULL)
+        {
+            state_amqp_value = NULL;
+        }
+        else
+        {
+            state_amqp_value = amqpvalue_clone(state_value);
+        }
 		if (state_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -5858,31 +7370,48 @@ int transfer_get_resume(TRANSFER_HANDLE transfer, bool* resume_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		TRANSFER_INSTANCE* transfer_instance = (TRANSFER_INSTANCE*)transfer;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 8);
-		if (item_value == NULL)
-		{
-			*resume_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, resume_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(transfer_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 8)
+            {
+			    *resume_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 8);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *resume_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, resume_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *resume_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -5933,31 +7462,48 @@ int transfer_get_aborted(TRANSFER_HANDLE transfer, bool* aborted_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		TRANSFER_INSTANCE* transfer_instance = (TRANSFER_INSTANCE*)transfer;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 9);
-		if (item_value == NULL)
-		{
-			*aborted_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, aborted_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(transfer_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 9)
+            {
+			    *aborted_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 9);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *aborted_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, aborted_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *aborted_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -6008,31 +7554,48 @@ int transfer_get_batchable(TRANSFER_HANDLE transfer, bool* batchable_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		TRANSFER_INSTANCE* transfer_instance = (TRANSFER_INSTANCE*)transfer;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 10);
-		if (item_value == NULL)
-		{
-			*batchable_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, batchable_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(transfer_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 10)
+            {
+			    *batchable_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(transfer_instance->composite_value, 10);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *batchable_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, batchable_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *batchable_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -6209,131 +7772,195 @@ int amqpvalue_get_disposition(AMQP_VALUE value, DISPOSITION_HANDLE* disposition_
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* role */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					{
-						disposition_destroy(*disposition_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					role role;
-					if (amqpvalue_get_role(item_value, &role) != 0)
-					{
-						disposition_destroy(*disposition_handle);
-						result = __FAILURE__;
-						break;
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* role */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        {
+						        disposition_destroy(*disposition_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        role role;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        disposition_destroy(*disposition_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_role(item_value, &role) != 0)
+					            {
+						            disposition_destroy(*disposition_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* first */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					{
-						disposition_destroy(*disposition_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					delivery_number first;
-					if (amqpvalue_get_delivery_number(item_value, &first) != 0)
-					{
-						disposition_destroy(*disposition_handle);
-						result = __FAILURE__;
-						break;
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* first */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        {
+						        disposition_destroy(*disposition_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        delivery_number first;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        disposition_destroy(*disposition_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_delivery_number(item_value, &first) != 0)
+					            {
+						            disposition_destroy(*disposition_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* last */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					delivery_number last;
-					if (amqpvalue_get_delivery_number(item_value, &last) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							disposition_destroy(*disposition_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* last */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        delivery_number last;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_delivery_number(item_value, &last) != 0)
+					            {
+						            disposition_destroy(*disposition_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* settled */
-				item_value = amqpvalue_get_list_item(list_value, 3);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool settled;
-					if (amqpvalue_get_boolean(item_value, &settled) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							disposition_destroy(*disposition_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* settled */
+				    if (list_item_count > 3)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 3);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool settled;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &settled) != 0)
+					            {
+						            disposition_destroy(*disposition_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* state */
-				item_value = amqpvalue_get_list_item(list_value, 4);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqpvalue_destroy(item_value);
-				}
-				/* batchable */
-				item_value = amqpvalue_get_list_item(list_value, 5);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool batchable;
-					if (amqpvalue_get_boolean(item_value, &batchable) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							disposition_destroy(*disposition_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* state */
+				    if (list_item_count > 4)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 4);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* batchable */
+				    if (list_item_count > 5)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 5);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool batchable;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &batchable) != 0)
+					            {
+						            disposition_destroy(*disposition_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				disposition_instance->composite_value = amqpvalue_clone(value);
+				    disposition_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -6350,22 +7977,38 @@ int disposition_get_role(DISPOSITION_HANDLE disposition, role* role_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		DISPOSITION_INSTANCE* disposition_instance = (DISPOSITION_INSTANCE*)disposition;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(disposition_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_role(item_value, role_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(disposition_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(disposition_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_role(item_value, role_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -6416,22 +8059,38 @@ int disposition_get_first(DISPOSITION_HANDLE disposition, delivery_number* first
 	}
 	else
 	{
+        uint32_t item_count;
 		DISPOSITION_INSTANCE* disposition_instance = (DISPOSITION_INSTANCE*)disposition;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(disposition_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_delivery_number(item_value, first_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(disposition_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(disposition_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_delivery_number(item_value, first_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -6482,22 +8141,38 @@ int disposition_get_last(DISPOSITION_HANDLE disposition, delivery_number* last_v
 	}
 	else
 	{
+        uint32_t item_count;
 		DISPOSITION_INSTANCE* disposition_instance = (DISPOSITION_INSTANCE*)disposition;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(disposition_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_delivery_number(item_value, last_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(disposition_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(disposition_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_delivery_number(item_value, last_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -6548,31 +8223,48 @@ int disposition_get_settled(DISPOSITION_HANDLE disposition, bool* settled_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		DISPOSITION_INSTANCE* disposition_instance = (DISPOSITION_INSTANCE*)disposition;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(disposition_instance->composite_value, 3);
-		if (item_value == NULL)
-		{
-			*settled_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, settled_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(disposition_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 3)
+            {
+			    *settled_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(disposition_instance->composite_value, 3);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *settled_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, settled_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *settled_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -6623,16 +8315,32 @@ int disposition_get_state(DISPOSITION_HANDLE disposition, AMQP_VALUE* state_valu
 	}
 	else
 	{
+        uint32_t item_count;
 		DISPOSITION_INSTANCE* disposition_instance = (DISPOSITION_INSTANCE*)disposition;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(disposition_instance->composite_value, 4);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			*state_value = item_value;
-			result = 0;
+        if (amqpvalue_get_composite_item_count(disposition_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 4)
+            {
+			    result = __FAILURE__;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(disposition_instance->composite_value, 4);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        *state_value = item_value;
+			        result = 0;
+                }
+            }
 		}
 	}
 
@@ -6650,7 +8358,15 @@ int disposition_set_state(DISPOSITION_HANDLE disposition, AMQP_VALUE state_value
 	else
 	{
 		DISPOSITION_INSTANCE* disposition_instance = (DISPOSITION_INSTANCE*)disposition;
-		AMQP_VALUE state_amqp_value = amqpvalue_clone(state_value);
+		AMQP_VALUE state_amqp_value;
+        if (state_value == NULL)
+        {
+            state_amqp_value = NULL;
+        }
+        else
+        {
+            state_amqp_value = amqpvalue_clone(state_value);
+        }
 		if (state_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -6683,31 +8399,48 @@ int disposition_get_batchable(DISPOSITION_HANDLE disposition, bool* batchable_va
 	}
 	else
 	{
+        uint32_t item_count;
 		DISPOSITION_INSTANCE* disposition_instance = (DISPOSITION_INSTANCE*)disposition;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(disposition_instance->composite_value, 5);
-		if (item_value == NULL)
-		{
-			*batchable_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, batchable_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(disposition_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 5)
+            {
+			    *batchable_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(disposition_instance->composite_value, 5);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *batchable_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, batchable_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *batchable_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -6877,78 +8610,116 @@ int amqpvalue_get_detach(AMQP_VALUE value, DETACH_HANDLE* detach_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* handle */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					{
-						detach_destroy(*detach_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					handle handle;
-					if (amqpvalue_get_handle(item_value, &handle) != 0)
-					{
-						detach_destroy(*detach_handle);
-						result = __FAILURE__;
-						break;
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* handle */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        {
+						        detach_destroy(*detach_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        handle handle;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        detach_destroy(*detach_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_handle(item_value, &handle) != 0)
+					            {
+						            detach_destroy(*detach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* closed */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool closed;
-					if (amqpvalue_get_boolean(item_value, &closed) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							detach_destroy(*detach_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* closed */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool closed;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &closed) != 0)
+					            {
+						            detach_destroy(*detach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* error */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					ERROR_HANDLE error;
-					if (amqpvalue_get_error(item_value, &error) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							detach_destroy(*detach_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* error */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        ERROR_HANDLE error;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_error(item_value, &error) != 0)
+					            {
+						            detach_destroy(*detach_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				detach_instance->composite_value = amqpvalue_clone(value);
+				    detach_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -6965,22 +8736,38 @@ int detach_get_handle(DETACH_HANDLE detach, handle* handle_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		DETACH_INSTANCE* detach_instance = (DETACH_INSTANCE*)detach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(detach_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_handle(item_value, handle_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(detach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(detach_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_handle(item_value, handle_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -7031,31 +8818,48 @@ int detach_get_closed(DETACH_HANDLE detach, bool* closed_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		DETACH_INSTANCE* detach_instance = (DETACH_INSTANCE*)detach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(detach_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			*closed_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, closed_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(detach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
+			    *closed_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(detach_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *closed_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, closed_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *closed_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -7106,22 +8910,38 @@ int detach_get_error(DETACH_HANDLE detach, ERROR_HANDLE* error_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		DETACH_INSTANCE* detach_instance = (DETACH_INSTANCE*)detach;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(detach_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_error(item_value, error_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(detach_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(detach_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_error(item_value, error_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -7278,35 +9098,50 @@ int amqpvalue_get_end(AMQP_VALUE value, END_HANDLE* end_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* error */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					ERROR_HANDLE error;
-					if (amqpvalue_get_error(item_value, &error) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							end_destroy(*end_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* error */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        ERROR_HANDLE error;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_error(item_value, &error) != 0)
+					            {
+						            end_destroy(*end_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				end_instance->composite_value = amqpvalue_clone(value);
+				    end_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -7323,22 +9158,38 @@ int end_get_error(END_HANDLE end, ERROR_HANDLE* error_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		END_INSTANCE* end_instance = (END_INSTANCE*)end;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(end_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_error(item_value, error_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(end_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(end_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_error(item_value, error_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -7495,35 +9346,50 @@ int amqpvalue_get_close(AMQP_VALUE value, CLOSE_HANDLE* close_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* error */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					ERROR_HANDLE error;
-					if (amqpvalue_get_error(item_value, &error) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							close_destroy(*close_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* error */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        ERROR_HANDLE error;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_error(item_value, &error) != 0)
+					            {
+						            close_destroy(*close_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				close_instance->composite_value = amqpvalue_clone(value);
+				    close_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -7540,22 +9406,38 @@ int close_get_error(CLOSE_HANDLE close, ERROR_HANDLE* error_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		CLOSE_INSTANCE* close_instance = (CLOSE_INSTANCE*)close;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(close_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_error(item_value, error_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(close_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(close_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_error(item_value, error_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -7732,38 +9614,62 @@ int amqpvalue_get_sasl_mechanisms(AMQP_VALUE value, SASL_MECHANISMS_HANDLE* sasl
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* sasl-server-mechanisms */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					{
-						sasl_mechanisms_destroy(*sasl_mechanisms_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					const char* sasl_server_mechanisms;
-					AMQP_VALUE sasl_server_mechanisms_array;
-					if ((amqpvalue_get_array(item_value, &sasl_server_mechanisms_array) != 0) &&
-						(amqpvalue_get_symbol(item_value, &sasl_server_mechanisms) != 0))
-					{
-						sasl_mechanisms_destroy(*sasl_mechanisms_handle);
-						result = __FAILURE__;
-						break;
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* sasl-server-mechanisms */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        {
+						        sasl_mechanisms_destroy(*sasl_mechanisms_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        const char* sasl_server_mechanisms;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        sasl_mechanisms_destroy(*sasl_mechanisms_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            AMQP_VALUE sasl_server_mechanisms_array;
+					            if ((amqpvalue_get_array(item_value, &sasl_server_mechanisms_array) != 0) &&
+						            (amqpvalue_get_symbol(item_value, &sasl_server_mechanisms) != 0))
+					            {
+						            sasl_mechanisms_destroy(*sasl_mechanisms_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
 
-				sasl_mechanisms_instance->composite_value = amqpvalue_clone(value);
+				    sasl_mechanisms_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -7780,22 +9686,38 @@ int sasl_mechanisms_get_sasl_server_mechanisms(SASL_MECHANISMS_HANDLE sasl_mecha
 	}
 	else
 	{
+        uint32_t item_count;
 		SASL_MECHANISMS_INSTANCE* sasl_mechanisms_instance = (SASL_MECHANISMS_INSTANCE*)sasl_mechanisms;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_mechanisms_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_array(item_value, sasl_server_mechanisms_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(sasl_mechanisms_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_mechanisms_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_array(item_value, sasl_server_mechanisms_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -7813,7 +9735,15 @@ int sasl_mechanisms_set_sasl_server_mechanisms(SASL_MECHANISMS_HANDLE sasl_mecha
 	else
 	{
 		SASL_MECHANISMS_INSTANCE* sasl_mechanisms_instance = (SASL_MECHANISMS_INSTANCE*)sasl_mechanisms;
-		AMQP_VALUE sasl_server_mechanisms_amqp_value = amqpvalue_clone(sasl_server_mechanisms_value);
+		AMQP_VALUE sasl_server_mechanisms_amqp_value;
+        if (sasl_server_mechanisms_value == NULL)
+        {
+            sasl_server_mechanisms_amqp_value = NULL;
+        }
+        else
+        {
+            sasl_server_mechanisms_amqp_value = amqpvalue_clone(sasl_server_mechanisms_value);
+        }
 		if (sasl_server_mechanisms_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -7965,78 +9895,116 @@ int amqpvalue_get_sasl_init(AMQP_VALUE value, SASL_INIT_HANDLE* sasl_init_handle
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* mechanism */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					{
-						sasl_init_destroy(*sasl_init_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					const char* mechanism;
-					if (amqpvalue_get_symbol(item_value, &mechanism) != 0)
-					{
-						sasl_init_destroy(*sasl_init_handle);
-						result = __FAILURE__;
-						break;
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* mechanism */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        {
+						        sasl_init_destroy(*sasl_init_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        const char* mechanism;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        sasl_init_destroy(*sasl_init_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_symbol(item_value, &mechanism) != 0)
+					            {
+						            sasl_init_destroy(*sasl_init_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* initial-response */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqp_binary initial_response;
-					if (amqpvalue_get_binary(item_value, &initial_response) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							sasl_init_destroy(*sasl_init_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* initial-response */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqp_binary initial_response;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_binary(item_value, &initial_response) != 0)
+					            {
+						            sasl_init_destroy(*sasl_init_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* hostname */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* hostname;
-					if (amqpvalue_get_string(item_value, &hostname) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							sasl_init_destroy(*sasl_init_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* hostname */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* hostname;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_string(item_value, &hostname) != 0)
+					            {
+						            sasl_init_destroy(*sasl_init_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				sasl_init_instance->composite_value = amqpvalue_clone(value);
+				    sasl_init_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -8053,22 +10021,38 @@ int sasl_init_get_mechanism(SASL_INIT_HANDLE sasl_init, const char** mechanism_v
 	}
 	else
 	{
+        uint32_t item_count;
 		SASL_INIT_INSTANCE* sasl_init_instance = (SASL_INIT_INSTANCE*)sasl_init;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_init_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_symbol(item_value, mechanism_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(sasl_init_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_init_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_symbol(item_value, mechanism_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -8119,22 +10103,38 @@ int sasl_init_get_initial_response(SASL_INIT_HANDLE sasl_init, amqp_binary* init
 	}
 	else
 	{
+        uint32_t item_count;
 		SASL_INIT_INSTANCE* sasl_init_instance = (SASL_INIT_INSTANCE*)sasl_init;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_init_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_binary(item_value, initial_response_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(sasl_init_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_init_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_binary(item_value, initial_response_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -8185,22 +10185,38 @@ int sasl_init_get_hostname(SASL_INIT_HANDLE sasl_init, const char** hostname_val
 	}
 	else
 	{
+        uint32_t item_count;
 		SASL_INIT_INSTANCE* sasl_init_instance = (SASL_INIT_INSTANCE*)sasl_init;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_init_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_string(item_value, hostname_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(sasl_init_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_init_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_string(item_value, hostname_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -8370,36 +10386,60 @@ int amqpvalue_get_sasl_challenge(AMQP_VALUE value, SASL_CHALLENGE_HANDLE* sasl_c
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* challenge */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					{
-						sasl_challenge_destroy(*sasl_challenge_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					amqp_binary challenge;
-					if (amqpvalue_get_binary(item_value, &challenge) != 0)
-					{
-						sasl_challenge_destroy(*sasl_challenge_handle);
-						result = __FAILURE__;
-						break;
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* challenge */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        {
+						        sasl_challenge_destroy(*sasl_challenge_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        amqp_binary challenge;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        sasl_challenge_destroy(*sasl_challenge_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_binary(item_value, &challenge) != 0)
+					            {
+						            sasl_challenge_destroy(*sasl_challenge_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
 
-				sasl_challenge_instance->composite_value = amqpvalue_clone(value);
+				    sasl_challenge_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -8416,22 +10456,38 @@ int sasl_challenge_get_challenge(SASL_CHALLENGE_HANDLE sasl_challenge, amqp_bina
 	}
 	else
 	{
+        uint32_t item_count;
 		SASL_CHALLENGE_INSTANCE* sasl_challenge_instance = (SASL_CHALLENGE_INSTANCE*)sasl_challenge;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_challenge_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_binary(item_value, challenge_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(sasl_challenge_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_challenge_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_binary(item_value, challenge_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -8601,36 +10657,60 @@ int amqpvalue_get_sasl_response(AMQP_VALUE value, SASL_RESPONSE_HANDLE* sasl_res
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* response */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					{
-						sasl_response_destroy(*sasl_response_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					amqp_binary response;
-					if (amqpvalue_get_binary(item_value, &response) != 0)
-					{
-						sasl_response_destroy(*sasl_response_handle);
-						result = __FAILURE__;
-						break;
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* response */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        {
+						        sasl_response_destroy(*sasl_response_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        amqp_binary response;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        sasl_response_destroy(*sasl_response_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_binary(item_value, &response) != 0)
+					            {
+						            sasl_response_destroy(*sasl_response_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
 
-				sasl_response_instance->composite_value = amqpvalue_clone(value);
+				    sasl_response_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -8647,22 +10727,38 @@ int sasl_response_get_response(SASL_RESPONSE_HANDLE sasl_response, amqp_binary* 
 	}
 	else
 	{
+        uint32_t item_count;
 		SASL_RESPONSE_INSTANCE* sasl_response_instance = (SASL_RESPONSE_INSTANCE*)sasl_response;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_response_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_binary(item_value, response_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(sasl_response_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_response_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_binary(item_value, response_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -8832,57 +10928,88 @@ int amqpvalue_get_sasl_outcome(AMQP_VALUE value, SASL_OUTCOME_HANDLE* sasl_outco
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* code */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					{
-						sasl_outcome_destroy(*sasl_outcome_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					sasl_code code;
-					if (amqpvalue_get_sasl_code(item_value, &code) != 0)
-					{
-						sasl_outcome_destroy(*sasl_outcome_handle);
-						result = __FAILURE__;
-						break;
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* code */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        {
+						        sasl_outcome_destroy(*sasl_outcome_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        sasl_code code;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        sasl_outcome_destroy(*sasl_outcome_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_sasl_code(item_value, &code) != 0)
+					            {
+						            sasl_outcome_destroy(*sasl_outcome_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* additional-data */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqp_binary additional_data;
-					if (amqpvalue_get_binary(item_value, &additional_data) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							sasl_outcome_destroy(*sasl_outcome_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* additional-data */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqp_binary additional_data;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_binary(item_value, &additional_data) != 0)
+					            {
+						            sasl_outcome_destroy(*sasl_outcome_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				sasl_outcome_instance->composite_value = amqpvalue_clone(value);
+				    sasl_outcome_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -8899,22 +11026,38 @@ int sasl_outcome_get_code(SASL_OUTCOME_HANDLE sasl_outcome, sasl_code* code_valu
 	}
 	else
 	{
+        uint32_t item_count;
 		SASL_OUTCOME_INSTANCE* sasl_outcome_instance = (SASL_OUTCOME_INSTANCE*)sasl_outcome;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_outcome_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_sasl_code(item_value, code_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(sasl_outcome_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_outcome_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_sasl_code(item_value, code_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -8965,22 +11108,38 @@ int sasl_outcome_get_additional_data(SASL_OUTCOME_HANDLE sasl_outcome, amqp_bina
 	}
 	else
 	{
+        uint32_t item_count;
 		SASL_OUTCOME_INSTANCE* sasl_outcome_instance = (SASL_OUTCOME_INSTANCE*)sasl_outcome;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_outcome_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_binary(item_value, additional_data_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(sasl_outcome_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(sasl_outcome_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_binary(item_value, additional_data_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -9165,227 +11324,304 @@ int amqpvalue_get_source(AMQP_VALUE value, SOURCE_HANDLE* source_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* address */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqpvalue_destroy(item_value);
-				}
-				/* durable */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					terminus_durability durable;
-					if (amqpvalue_get_terminus_durability(item_value, &durable) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							source_destroy(*source_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* address */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* durable */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        terminus_durability durable;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_terminus_durability(item_value, &durable) != 0)
+					            {
+						            source_destroy(*source_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* expiry-policy */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					terminus_expiry_policy expiry_policy;
-					if (amqpvalue_get_terminus_expiry_policy(item_value, &expiry_policy) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							source_destroy(*source_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* expiry-policy */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        terminus_expiry_policy expiry_policy;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_terminus_expiry_policy(item_value, &expiry_policy) != 0)
+					            {
+						            source_destroy(*source_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* timeout */
-				item_value = amqpvalue_get_list_item(list_value, 3);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					seconds timeout;
-					if (amqpvalue_get_seconds(item_value, &timeout) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							source_destroy(*source_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* timeout */
+				    if (list_item_count > 3)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 3);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        seconds timeout;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_seconds(item_value, &timeout) != 0)
+					            {
+						            source_destroy(*source_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* dynamic */
-				item_value = amqpvalue_get_list_item(list_value, 4);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool dynamic;
-					if (amqpvalue_get_boolean(item_value, &dynamic) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							source_destroy(*source_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* dynamic */
+				    if (list_item_count > 4)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 4);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool dynamic;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &dynamic) != 0)
+					            {
+						            source_destroy(*source_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* dynamic-node-properties */
-				item_value = amqpvalue_get_list_item(list_value, 5);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					node_properties dynamic_node_properties;
-					if (amqpvalue_get_node_properties(item_value, &dynamic_node_properties) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							source_destroy(*source_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* dynamic-node-properties */
+				    if (list_item_count > 5)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 5);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        node_properties dynamic_node_properties;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_node_properties(item_value, &dynamic_node_properties) != 0)
+					            {
+						            source_destroy(*source_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* distribution-mode */
-				item_value = amqpvalue_get_list_item(list_value, 6);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* distribution_mode;
-					if (amqpvalue_get_symbol(item_value, &distribution_mode) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							source_destroy(*source_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* distribution-mode */
+				    if (list_item_count > 6)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 6);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* distribution_mode;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_symbol(item_value, &distribution_mode) != 0)
+					            {
+						            source_destroy(*source_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* filter */
-				item_value = amqpvalue_get_list_item(list_value, 7);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					filter_set filter;
-					if (amqpvalue_get_filter_set(item_value, &filter) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							source_destroy(*source_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* filter */
+				    if (list_item_count > 7)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 7);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        filter_set filter;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_filter_set(item_value, &filter) != 0)
+					            {
+						            source_destroy(*source_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* default-outcome */
-				item_value = amqpvalue_get_list_item(list_value, 8);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqpvalue_destroy(item_value);
-				}
-				/* outcomes */
-				item_value = amqpvalue_get_list_item(list_value, 9);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* outcomes;
-					AMQP_VALUE outcomes_array;
-					if ((amqpvalue_get_array(item_value, &outcomes_array) != 0) &&
-						(amqpvalue_get_symbol(item_value, &outcomes) != 0))
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							source_destroy(*source_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* default-outcome */
+				    if (list_item_count > 8)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 8);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* outcomes */
+				    if (list_item_count > 9)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 9);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* outcomes;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            AMQP_VALUE outcomes_array;
+					            if ((amqpvalue_get_array(item_value, &outcomes_array) != 0) &&
+						            (amqpvalue_get_symbol(item_value, &outcomes) != 0))
+					            {
+						            source_destroy(*source_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* capabilities */
-				item_value = amqpvalue_get_list_item(list_value, 10);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* capabilities;
-					AMQP_VALUE capabilities_array;
-					if ((amqpvalue_get_array(item_value, &capabilities_array) != 0) &&
-						(amqpvalue_get_symbol(item_value, &capabilities) != 0))
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							source_destroy(*source_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* capabilities */
+				    if (list_item_count > 10)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 10);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* capabilities;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            AMQP_VALUE capabilities_array;
+					            if ((amqpvalue_get_array(item_value, &capabilities_array) != 0) &&
+						            (amqpvalue_get_symbol(item_value, &capabilities) != 0))
+					            {
+						            source_destroy(*source_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				source_instance->composite_value = amqpvalue_clone(value);
+				    source_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -9402,16 +11638,32 @@ int source_get_address(SOURCE_HANDLE source, AMQP_VALUE* address_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			*address_value = item_value;
-			result = 0;
+        if (amqpvalue_get_composite_item_count(source_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
+			    result = __FAILURE__;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        *address_value = item_value;
+			        result = 0;
+                }
+            }
 		}
 	}
 
@@ -9429,7 +11681,15 @@ int source_set_address(SOURCE_HANDLE source, AMQP_VALUE address_value)
 	else
 	{
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE address_amqp_value = amqpvalue_clone(address_value);
+		AMQP_VALUE address_amqp_value;
+        if (address_value == NULL)
+        {
+            address_amqp_value = NULL;
+        }
+        else
+        {
+            address_amqp_value = amqpvalue_clone(address_value);
+        }
 		if (address_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -9462,31 +11722,48 @@ int source_get_durable(SOURCE_HANDLE source, terminus_durability* durable_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-            *durable_value = terminus_durability_none;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_terminus_durability(item_value, durable_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(source_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
+                *durable_value = terminus_durability_none;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
                     *durable_value = terminus_durability_none;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_terminus_durability(item_value, durable_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+                            *durable_value = terminus_durability_none;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -9537,31 +11814,48 @@ int source_get_expiry_policy(SOURCE_HANDLE source, terminus_expiry_policy* expir
 	}
 	else
 	{
+        uint32_t item_count;
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-            *expiry_policy_value = terminus_expiry_policy_session_end;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_terminus_expiry_policy(item_value, expiry_policy_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(source_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
+                *expiry_policy_value = terminus_expiry_policy_session_end;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
                     *expiry_policy_value = terminus_expiry_policy_session_end;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_terminus_expiry_policy(item_value, expiry_policy_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+                            *expiry_policy_value = terminus_expiry_policy_session_end;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -9612,31 +11906,48 @@ int source_get_timeout(SOURCE_HANDLE source, seconds* timeout_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 3);
-		if (item_value == NULL)
-		{
-			*timeout_value = 0;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_seconds(item_value, timeout_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(source_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 3)
+            {
+			    *timeout_value = 0;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 3);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *timeout_value = 0;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_seconds(item_value, timeout_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *timeout_value = 0;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -9687,31 +11998,48 @@ int source_get_dynamic(SOURCE_HANDLE source, bool* dynamic_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 4);
-		if (item_value == NULL)
-		{
-			*dynamic_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, dynamic_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(source_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 4)
+            {
+			    *dynamic_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 4);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *dynamic_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, dynamic_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *dynamic_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -9762,22 +12090,38 @@ int source_get_dynamic_node_properties(SOURCE_HANDLE source, node_properties* dy
 	}
 	else
 	{
+        uint32_t item_count;
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 5);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_node_properties(item_value, dynamic_node_properties_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(source_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 5)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 5);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_node_properties(item_value, dynamic_node_properties_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -9828,22 +12172,38 @@ int source_get_distribution_mode(SOURCE_HANDLE source, const char** distribution
 	}
 	else
 	{
+        uint32_t item_count;
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 6);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_symbol(item_value, distribution_mode_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(source_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 6)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 6);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_symbol(item_value, distribution_mode_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -9894,22 +12254,38 @@ int source_get_filter(SOURCE_HANDLE source, filter_set* filter_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 7);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_filter_set(item_value, filter_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(source_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 7)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 7);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_filter_set(item_value, filter_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -9960,16 +12336,32 @@ int source_get_default_outcome(SOURCE_HANDLE source, AMQP_VALUE* default_outcome
 	}
 	else
 	{
+        uint32_t item_count;
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 8);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			*default_outcome_value = item_value;
-			result = 0;
+        if (amqpvalue_get_composite_item_count(source_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 8)
+            {
+			    result = __FAILURE__;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 8);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        *default_outcome_value = item_value;
+			        result = 0;
+                }
+            }
 		}
 	}
 
@@ -9987,7 +12379,15 @@ int source_set_default_outcome(SOURCE_HANDLE source, AMQP_VALUE default_outcome_
 	else
 	{
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE default_outcome_amqp_value = amqpvalue_clone(default_outcome_value);
+		AMQP_VALUE default_outcome_amqp_value;
+        if (default_outcome_value == NULL)
+        {
+            default_outcome_amqp_value = NULL;
+        }
+        else
+        {
+            default_outcome_amqp_value = amqpvalue_clone(default_outcome_value);
+        }
 		if (default_outcome_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -10020,22 +12420,38 @@ int source_get_outcomes(SOURCE_HANDLE source, AMQP_VALUE* outcomes_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 9);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_array(item_value, outcomes_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(source_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 9)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 9);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_array(item_value, outcomes_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -10053,7 +12469,15 @@ int source_set_outcomes(SOURCE_HANDLE source, AMQP_VALUE outcomes_value)
 	else
 	{
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE outcomes_amqp_value = amqpvalue_clone(outcomes_value);
+		AMQP_VALUE outcomes_amqp_value;
+        if (outcomes_value == NULL)
+        {
+            outcomes_amqp_value = NULL;
+        }
+        else
+        {
+            outcomes_amqp_value = amqpvalue_clone(outcomes_value);
+        }
 		if (outcomes_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -10086,22 +12510,38 @@ int source_get_capabilities(SOURCE_HANDLE source, AMQP_VALUE* capabilities_value
 	}
 	else
 	{
+        uint32_t item_count;
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 10);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_array(item_value, capabilities_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(source_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 10)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(source_instance->composite_value, 10);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_array(item_value, capabilities_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -10119,7 +12559,15 @@ int source_set_capabilities(SOURCE_HANDLE source, AMQP_VALUE capabilities_value)
 	else
 	{
 		SOURCE_INSTANCE* source_instance = (SOURCE_INSTANCE*)source;
-		AMQP_VALUE capabilities_amqp_value = amqpvalue_clone(capabilities_value);
+		AMQP_VALUE capabilities_amqp_value;
+        if (capabilities_value == NULL)
+        {
+            capabilities_amqp_value = NULL;
+        }
+        else
+        {
+            capabilities_amqp_value = amqpvalue_clone(capabilities_value);
+        }
 		if (capabilities_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -10258,152 +12706,205 @@ int amqpvalue_get_target(AMQP_VALUE value, TARGET_HANDLE* target_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* address */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqpvalue_destroy(item_value);
-				}
-				/* durable */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					terminus_durability durable;
-					if (amqpvalue_get_terminus_durability(item_value, &durable) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							target_destroy(*target_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* address */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* durable */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        terminus_durability durable;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_terminus_durability(item_value, &durable) != 0)
+					            {
+						            target_destroy(*target_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* expiry-policy */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					terminus_expiry_policy expiry_policy;
-					if (amqpvalue_get_terminus_expiry_policy(item_value, &expiry_policy) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							target_destroy(*target_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* expiry-policy */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        terminus_expiry_policy expiry_policy;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_terminus_expiry_policy(item_value, &expiry_policy) != 0)
+					            {
+						            target_destroy(*target_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* timeout */
-				item_value = amqpvalue_get_list_item(list_value, 3);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					seconds timeout;
-					if (amqpvalue_get_seconds(item_value, &timeout) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							target_destroy(*target_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* timeout */
+				    if (list_item_count > 3)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 3);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        seconds timeout;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_seconds(item_value, &timeout) != 0)
+					            {
+						            target_destroy(*target_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* dynamic */
-				item_value = amqpvalue_get_list_item(list_value, 4);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool dynamic;
-					if (amqpvalue_get_boolean(item_value, &dynamic) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							target_destroy(*target_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* dynamic */
+				    if (list_item_count > 4)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 4);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool dynamic;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &dynamic) != 0)
+					            {
+						            target_destroy(*target_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* dynamic-node-properties */
-				item_value = amqpvalue_get_list_item(list_value, 5);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					node_properties dynamic_node_properties;
-					if (amqpvalue_get_node_properties(item_value, &dynamic_node_properties) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							target_destroy(*target_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* dynamic-node-properties */
+				    if (list_item_count > 5)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 5);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        node_properties dynamic_node_properties;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_node_properties(item_value, &dynamic_node_properties) != 0)
+					            {
+						            target_destroy(*target_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* capabilities */
-				item_value = amqpvalue_get_list_item(list_value, 6);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* capabilities;
-					AMQP_VALUE capabilities_array;
-					if ((amqpvalue_get_array(item_value, &capabilities_array) != 0) &&
-						(amqpvalue_get_symbol(item_value, &capabilities) != 0))
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							target_destroy(*target_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* capabilities */
+				    if (list_item_count > 6)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 6);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* capabilities;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            AMQP_VALUE capabilities_array;
+					            if ((amqpvalue_get_array(item_value, &capabilities_array) != 0) &&
+						            (amqpvalue_get_symbol(item_value, &capabilities) != 0))
+					            {
+						            target_destroy(*target_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				target_instance->composite_value = amqpvalue_clone(value);
+				    target_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -10420,16 +12921,32 @@ int target_get_address(TARGET_HANDLE target, AMQP_VALUE* address_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		TARGET_INSTANCE* target_instance = (TARGET_INSTANCE*)target;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			*address_value = item_value;
-			result = 0;
+        if (amqpvalue_get_composite_item_count(target_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
+			    result = __FAILURE__;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        *address_value = item_value;
+			        result = 0;
+                }
+            }
 		}
 	}
 
@@ -10447,7 +12964,15 @@ int target_set_address(TARGET_HANDLE target, AMQP_VALUE address_value)
 	else
 	{
 		TARGET_INSTANCE* target_instance = (TARGET_INSTANCE*)target;
-		AMQP_VALUE address_amqp_value = amqpvalue_clone(address_value);
+		AMQP_VALUE address_amqp_value;
+        if (address_value == NULL)
+        {
+            address_amqp_value = NULL;
+        }
+        else
+        {
+            address_amqp_value = amqpvalue_clone(address_value);
+        }
 		if (address_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -10480,31 +13005,48 @@ int target_get_durable(TARGET_HANDLE target, terminus_durability* durable_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		TARGET_INSTANCE* target_instance = (TARGET_INSTANCE*)target;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-            *durable_value = terminus_durability_none;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_terminus_durability(item_value, durable_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(target_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
+                *durable_value = terminus_durability_none;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
                     *durable_value = terminus_durability_none;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_terminus_durability(item_value, durable_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+                            *durable_value = terminus_durability_none;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -10555,31 +13097,48 @@ int target_get_expiry_policy(TARGET_HANDLE target, terminus_expiry_policy* expir
 	}
 	else
 	{
+        uint32_t item_count;
 		TARGET_INSTANCE* target_instance = (TARGET_INSTANCE*)target;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-            *expiry_policy_value = terminus_expiry_policy_session_end;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_terminus_expiry_policy(item_value, expiry_policy_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(target_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
+                *expiry_policy_value = terminus_expiry_policy_session_end;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
                     *expiry_policy_value = terminus_expiry_policy_session_end;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_terminus_expiry_policy(item_value, expiry_policy_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+                            *expiry_policy_value = terminus_expiry_policy_session_end;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -10630,31 +13189,48 @@ int target_get_timeout(TARGET_HANDLE target, seconds* timeout_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		TARGET_INSTANCE* target_instance = (TARGET_INSTANCE*)target;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 3);
-		if (item_value == NULL)
-		{
-			*timeout_value = 0;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_seconds(item_value, timeout_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(target_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 3)
+            {
+			    *timeout_value = 0;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 3);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *timeout_value = 0;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_seconds(item_value, timeout_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *timeout_value = 0;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -10705,31 +13281,48 @@ int target_get_dynamic(TARGET_HANDLE target, bool* dynamic_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		TARGET_INSTANCE* target_instance = (TARGET_INSTANCE*)target;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 4);
-		if (item_value == NULL)
-		{
-			*dynamic_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, dynamic_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(target_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 4)
+            {
+			    *dynamic_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 4);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *dynamic_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, dynamic_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *dynamic_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -10780,22 +13373,38 @@ int target_get_dynamic_node_properties(TARGET_HANDLE target, node_properties* dy
 	}
 	else
 	{
+        uint32_t item_count;
 		TARGET_INSTANCE* target_instance = (TARGET_INSTANCE*)target;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 5);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_node_properties(item_value, dynamic_node_properties_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(target_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 5)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 5);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_node_properties(item_value, dynamic_node_properties_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -10846,22 +13455,38 @@ int target_get_capabilities(TARGET_HANDLE target, AMQP_VALUE* capabilities_value
 	}
 	else
 	{
+        uint32_t item_count;
 		TARGET_INSTANCE* target_instance = (TARGET_INSTANCE*)target;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 6);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_array(item_value, capabilities_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(target_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 6)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(target_instance->composite_value, 6);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_array(item_value, capabilities_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -10879,7 +13504,15 @@ int target_set_capabilities(TARGET_HANDLE target, AMQP_VALUE capabilities_value)
 	else
 	{
 		TARGET_INSTANCE* target_instance = (TARGET_INSTANCE*)target;
-		AMQP_VALUE capabilities_amqp_value = amqpvalue_clone(capabilities_value);
+		AMQP_VALUE capabilities_amqp_value;
+        if (capabilities_value == NULL)
+        {
+            capabilities_amqp_value = NULL;
+        }
+        else
+        {
+            capabilities_amqp_value = amqpvalue_clone(capabilities_value);
+        }
 		if (capabilities_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -11060,119 +13693,162 @@ int amqpvalue_get_header(AMQP_VALUE value, HEADER_HANDLE* header_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* durable */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool durable;
-					if (amqpvalue_get_boolean(item_value, &durable) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							header_destroy(*header_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* durable */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool durable;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &durable) != 0)
+					            {
+						            header_destroy(*header_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* priority */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					uint8_t priority;
-					if (amqpvalue_get_ubyte(item_value, &priority) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							header_destroy(*header_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* priority */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        uint8_t priority;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_ubyte(item_value, &priority) != 0)
+					            {
+						            header_destroy(*header_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* ttl */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					milliseconds ttl;
-					if (amqpvalue_get_milliseconds(item_value, &ttl) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							header_destroy(*header_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* ttl */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        milliseconds ttl;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_milliseconds(item_value, &ttl) != 0)
+					            {
+						            header_destroy(*header_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* first-acquirer */
-				item_value = amqpvalue_get_list_item(list_value, 3);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool first_acquirer;
-					if (amqpvalue_get_boolean(item_value, &first_acquirer) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							header_destroy(*header_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* first-acquirer */
+				    if (list_item_count > 3)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 3);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool first_acquirer;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &first_acquirer) != 0)
+					            {
+						            header_destroy(*header_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* delivery-count */
-				item_value = amqpvalue_get_list_item(list_value, 4);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					uint32_t delivery_count;
-					if (amqpvalue_get_uint(item_value, &delivery_count) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							header_destroy(*header_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* delivery-count */
+				    if (list_item_count > 4)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 4);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        uint32_t delivery_count;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_uint(item_value, &delivery_count) != 0)
+					            {
+						            header_destroy(*header_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				header_instance->composite_value = amqpvalue_clone(value);
+				    header_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -11189,31 +13865,48 @@ int header_get_durable(HEADER_HANDLE header, bool* durable_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		HEADER_INSTANCE* header_instance = (HEADER_INSTANCE*)header;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(header_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			*durable_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, durable_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(header_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
+			    *durable_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(header_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *durable_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, durable_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *durable_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -11264,31 +13957,48 @@ int header_get_priority(HEADER_HANDLE header, uint8_t* priority_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		HEADER_INSTANCE* header_instance = (HEADER_INSTANCE*)header;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(header_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			*priority_value = 4;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_ubyte(item_value, priority_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(header_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
+			    *priority_value = 4;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(header_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *priority_value = 4;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_ubyte(item_value, priority_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *priority_value = 4;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -11339,22 +14049,38 @@ int header_get_ttl(HEADER_HANDLE header, milliseconds* ttl_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		HEADER_INSTANCE* header_instance = (HEADER_INSTANCE*)header;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(header_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_milliseconds(item_value, ttl_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(header_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(header_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_milliseconds(item_value, ttl_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -11405,31 +14131,48 @@ int header_get_first_acquirer(HEADER_HANDLE header, bool* first_acquirer_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		HEADER_INSTANCE* header_instance = (HEADER_INSTANCE*)header;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(header_instance->composite_value, 3);
-		if (item_value == NULL)
-		{
-			*first_acquirer_value = false;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, first_acquirer_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(header_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 3)
+            {
+			    *first_acquirer_value = false;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(header_instance->composite_value, 3);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *first_acquirer_value = false;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, first_acquirer_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *first_acquirer_value = false;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -11480,31 +14223,48 @@ int header_get_delivery_count(HEADER_HANDLE header, uint32_t* delivery_count_val
 	}
 	else
 	{
+        uint32_t item_count;
 		HEADER_INSTANCE* header_instance = (HEADER_INSTANCE*)header;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(header_instance->composite_value, 4);
-		if (item_value == NULL)
-		{
-			*delivery_count_value = 0;
-            result = 0;
-		}
-		else
-		{
-			if (amqpvalue_get_uint(item_value, delivery_count_value) != 0)
-			{
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
+        if (amqpvalue_get_composite_item_count(header_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 4)
+            {
+			    *delivery_count_value = 0;
+                result = 0;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(header_instance->composite_value, 4);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 			        *delivery_count_value = 0;
                     result = 0;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_uint(item_value, delivery_count_value) != 0)
+			        {
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+			                *delivery_count_value = 0;
+                            result = 0;
+                        }
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
                 }
-			}
-			else
-			{
-				result = 0;
-			}
+            }
 		}
 	}
 
@@ -11997,243 +14757,326 @@ int amqpvalue_get_properties(AMQP_VALUE value, PROPERTIES_HANDLE* properties_han
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* message-id */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqpvalue_destroy(item_value);
-				}
-				/* user-id */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqp_binary user_id;
-					if (amqpvalue_get_binary(item_value, &user_id) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							properties_destroy(*properties_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* message-id */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* user-id */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqp_binary user_id;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_binary(item_value, &user_id) != 0)
+					            {
+						            properties_destroy(*properties_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* to */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqpvalue_destroy(item_value);
-				}
-				/* subject */
-				item_value = amqpvalue_get_list_item(list_value, 3);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* subject;
-					if (amqpvalue_get_string(item_value, &subject) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							properties_destroy(*properties_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* to */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* subject */
+				    if (list_item_count > 3)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 3);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* subject;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_string(item_value, &subject) != 0)
+					            {
+						            properties_destroy(*properties_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* reply-to */
-				item_value = amqpvalue_get_list_item(list_value, 4);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqpvalue_destroy(item_value);
-				}
-				/* correlation-id */
-				item_value = amqpvalue_get_list_item(list_value, 5);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					amqpvalue_destroy(item_value);
-				}
-				/* content-type */
-				item_value = amqpvalue_get_list_item(list_value, 6);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* content_type;
-					if (amqpvalue_get_symbol(item_value, &content_type) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							properties_destroy(*properties_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* reply-to */
+				    if (list_item_count > 4)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 4);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* correlation-id */
+				    if (list_item_count > 5)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 5);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* content-type */
+				    if (list_item_count > 6)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 6);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* content_type;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_symbol(item_value, &content_type) != 0)
+					            {
+						            properties_destroy(*properties_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* content-encoding */
-				item_value = amqpvalue_get_list_item(list_value, 7);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* content_encoding;
-					if (amqpvalue_get_symbol(item_value, &content_encoding) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							properties_destroy(*properties_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* content-encoding */
+				    if (list_item_count > 7)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 7);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* content_encoding;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_symbol(item_value, &content_encoding) != 0)
+					            {
+						            properties_destroy(*properties_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* absolute-expiry-time */
-				item_value = amqpvalue_get_list_item(list_value, 8);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					timestamp absolute_expiry_time;
-					if (amqpvalue_get_timestamp(item_value, &absolute_expiry_time) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							properties_destroy(*properties_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* absolute-expiry-time */
+				    if (list_item_count > 8)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 8);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        timestamp absolute_expiry_time;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_timestamp(item_value, &absolute_expiry_time) != 0)
+					            {
+						            properties_destroy(*properties_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* creation-time */
-				item_value = amqpvalue_get_list_item(list_value, 9);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					timestamp creation_time;
-					if (amqpvalue_get_timestamp(item_value, &creation_time) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							properties_destroy(*properties_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* creation-time */
+				    if (list_item_count > 9)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 9);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        timestamp creation_time;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_timestamp(item_value, &creation_time) != 0)
+					            {
+						            properties_destroy(*properties_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* group-id */
-				item_value = amqpvalue_get_list_item(list_value, 10);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* group_id;
-					if (amqpvalue_get_string(item_value, &group_id) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							properties_destroy(*properties_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* group-id */
+				    if (list_item_count > 10)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 10);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* group_id;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_string(item_value, &group_id) != 0)
+					            {
+						            properties_destroy(*properties_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* group-sequence */
-				item_value = amqpvalue_get_list_item(list_value, 11);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					sequence_no group_sequence;
-					if (amqpvalue_get_sequence_no(item_value, &group_sequence) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							properties_destroy(*properties_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* group-sequence */
+				    if (list_item_count > 11)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 11);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        sequence_no group_sequence;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_sequence_no(item_value, &group_sequence) != 0)
+					            {
+						            properties_destroy(*properties_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* reply-to-group-id */
-				item_value = amqpvalue_get_list_item(list_value, 12);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					const char* reply_to_group_id;
-					if (amqpvalue_get_string(item_value, &reply_to_group_id) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							properties_destroy(*properties_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* reply-to-group-id */
+				    if (list_item_count > 12)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 12);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        const char* reply_to_group_id;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_string(item_value, &reply_to_group_id) != 0)
+					            {
+						            properties_destroy(*properties_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				properties_instance->composite_value = amqpvalue_clone(value);
+				    properties_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -12250,16 +15093,32 @@ int properties_get_message_id(PROPERTIES_HANDLE properties, AMQP_VALUE* message_
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			*message_id_value = item_value;
-			result = 0;
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
+			    result = __FAILURE__;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        *message_id_value = item_value;
+			        result = 0;
+                }
+            }
 		}
 	}
 
@@ -12277,7 +15136,15 @@ int properties_set_message_id(PROPERTIES_HANDLE properties, AMQP_VALUE message_i
 	else
 	{
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE message_id_amqp_value = amqpvalue_clone(message_id_value);
+		AMQP_VALUE message_id_amqp_value;
+        if (message_id_value == NULL)
+        {
+            message_id_amqp_value = NULL;
+        }
+        else
+        {
+            message_id_amqp_value = amqpvalue_clone(message_id_value);
+        }
 		if (message_id_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -12310,22 +15177,38 @@ int properties_get_user_id(PROPERTIES_HANDLE properties, amqp_binary* user_id_va
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_binary(item_value, user_id_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_binary(item_value, user_id_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -12376,16 +15259,32 @@ int properties_get_to(PROPERTIES_HANDLE properties, AMQP_VALUE* to_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			*to_value = item_value;
-			result = 0;
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
+			    result = __FAILURE__;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        *to_value = item_value;
+			        result = 0;
+                }
+            }
 		}
 	}
 
@@ -12403,7 +15302,15 @@ int properties_set_to(PROPERTIES_HANDLE properties, AMQP_VALUE to_value)
 	else
 	{
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE to_amqp_value = amqpvalue_clone(to_value);
+		AMQP_VALUE to_amqp_value;
+        if (to_value == NULL)
+        {
+            to_amqp_value = NULL;
+        }
+        else
+        {
+            to_amqp_value = amqpvalue_clone(to_value);
+        }
 		if (to_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -12436,22 +15343,38 @@ int properties_get_subject(PROPERTIES_HANDLE properties, const char** subject_va
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 3);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_string(item_value, subject_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 3)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 3);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_string(item_value, subject_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -12502,16 +15425,32 @@ int properties_get_reply_to(PROPERTIES_HANDLE properties, AMQP_VALUE* reply_to_v
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 4);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			*reply_to_value = item_value;
-			result = 0;
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 4)
+            {
+			    result = __FAILURE__;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 4);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        *reply_to_value = item_value;
+			        result = 0;
+                }
+            }
 		}
 	}
 
@@ -12529,7 +15468,15 @@ int properties_set_reply_to(PROPERTIES_HANDLE properties, AMQP_VALUE reply_to_va
 	else
 	{
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE reply_to_amqp_value = amqpvalue_clone(reply_to_value);
+		AMQP_VALUE reply_to_amqp_value;
+        if (reply_to_value == NULL)
+        {
+            reply_to_amqp_value = NULL;
+        }
+        else
+        {
+            reply_to_amqp_value = amqpvalue_clone(reply_to_value);
+        }
 		if (reply_to_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -12562,16 +15509,32 @@ int properties_get_correlation_id(PROPERTIES_HANDLE properties, AMQP_VALUE* corr
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 5);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			*correlation_id_value = item_value;
-			result = 0;
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 5)
+            {
+			    result = __FAILURE__;
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 5);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        *correlation_id_value = item_value;
+			        result = 0;
+                }
+            }
 		}
 	}
 
@@ -12589,7 +15552,15 @@ int properties_set_correlation_id(PROPERTIES_HANDLE properties, AMQP_VALUE corre
 	else
 	{
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE correlation_id_amqp_value = amqpvalue_clone(correlation_id_value);
+		AMQP_VALUE correlation_id_amqp_value;
+        if (correlation_id_value == NULL)
+        {
+            correlation_id_amqp_value = NULL;
+        }
+        else
+        {
+            correlation_id_amqp_value = amqpvalue_clone(correlation_id_value);
+        }
 		if (correlation_id_amqp_value == NULL)
 		{
 			result = __FAILURE__;
@@ -12622,22 +15593,38 @@ int properties_get_content_type(PROPERTIES_HANDLE properties, const char** conte
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 6);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_symbol(item_value, content_type_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 6)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 6);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_symbol(item_value, content_type_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -12688,22 +15675,38 @@ int properties_get_content_encoding(PROPERTIES_HANDLE properties, const char** c
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 7);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_symbol(item_value, content_encoding_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 7)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 7);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_symbol(item_value, content_encoding_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -12754,22 +15757,38 @@ int properties_get_absolute_expiry_time(PROPERTIES_HANDLE properties, timestamp*
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 8);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_timestamp(item_value, absolute_expiry_time_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 8)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 8);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_timestamp(item_value, absolute_expiry_time_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -12820,22 +15839,38 @@ int properties_get_creation_time(PROPERTIES_HANDLE properties, timestamp* creati
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 9);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_timestamp(item_value, creation_time_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 9)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 9);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_timestamp(item_value, creation_time_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -12886,22 +15921,38 @@ int properties_get_group_id(PROPERTIES_HANDLE properties, const char** group_id_
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 10);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_string(item_value, group_id_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 10)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 10);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_string(item_value, group_id_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -12952,22 +16003,38 @@ int properties_get_group_sequence(PROPERTIES_HANDLE properties, sequence_no* gro
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 11);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_sequence_no(item_value, group_sequence_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 11)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 11);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_sequence_no(item_value, group_sequence_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -13018,22 +16085,38 @@ int properties_get_reply_to_group_id(PROPERTIES_HANDLE properties, const char** 
 	}
 	else
 	{
+        uint32_t item_count;
 		PROPERTIES_INSTANCE* properties_instance = (PROPERTIES_INSTANCE*)properties;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 12);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_string(item_value, reply_to_group_id_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(properties_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 12)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(properties_instance->composite_value, 12);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_string(item_value, reply_to_group_id_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -13210,58 +16293,98 @@ int amqpvalue_get_received(AMQP_VALUE value, RECEIVED_HANDLE* received_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* section-number */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					{
-						received_destroy(*received_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					uint32_t section_number;
-					if (amqpvalue_get_uint(item_value, &section_number) != 0)
-					{
-						received_destroy(*received_handle);
-						result = __FAILURE__;
-						break;
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* section-number */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        {
+						        received_destroy(*received_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        uint32_t section_number;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        received_destroy(*received_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_uint(item_value, &section_number) != 0)
+					            {
+						            received_destroy(*received_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* section-offset */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					{
-						received_destroy(*received_handle);
-						result = __FAILURE__;
-						break;
-					}
-				}
-				else
-				{
-					uint64_t section_offset;
-					if (amqpvalue_get_ulong(item_value, &section_offset) != 0)
-					{
-						received_destroy(*received_handle);
-						result = __FAILURE__;
-						break;
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+				    /* section-offset */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        {
+						        received_destroy(*received_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
+				        }
+				        else
+				        {
+					        uint64_t section_offset;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        received_destroy(*received_handle);
+						        result = __FAILURE__;
+						        break;
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_ulong(item_value, &section_offset) != 0)
+					            {
+						            received_destroy(*received_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
 
-				received_instance->composite_value = amqpvalue_clone(value);
+				    received_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -13278,22 +16401,38 @@ int received_get_section_number(RECEIVED_HANDLE received, uint32_t* section_numb
 	}
 	else
 	{
+        uint32_t item_count;
 		RECEIVED_INSTANCE* received_instance = (RECEIVED_INSTANCE*)received;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(received_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_uint(item_value, section_number_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(received_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(received_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_uint(item_value, section_number_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -13344,22 +16483,38 @@ int received_get_section_offset(RECEIVED_HANDLE received, uint64_t* section_offs
 	}
 	else
 	{
+        uint32_t item_count;
 		RECEIVED_INSTANCE* received_instance = (RECEIVED_INSTANCE*)received;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(received_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_ulong(item_value, section_offset_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(received_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(received_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_ulong(item_value, section_offset_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -13516,13 +16671,21 @@ int amqpvalue_get_accepted(AMQP_VALUE value, ACCEPTED_HANDLE* accepted_handle)
 		}
 		else
 		{
-			do
-			{
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
 
-				accepted_instance->composite_value = amqpvalue_clone(value);
+				    accepted_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -13645,35 +16808,50 @@ int amqpvalue_get_rejected(AMQP_VALUE value, REJECTED_HANDLE* rejected_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* error */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					ERROR_HANDLE error;
-					if (amqpvalue_get_error(item_value, &error) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							rejected_destroy(*rejected_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* error */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        ERROR_HANDLE error;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_error(item_value, &error) != 0)
+					            {
+						            rejected_destroy(*rejected_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				rejected_instance->composite_value = amqpvalue_clone(value);
+				    rejected_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -13690,22 +16868,38 @@ int rejected_get_error(REJECTED_HANDLE rejected, ERROR_HANDLE* error_value)
 	}
 	else
 	{
+        uint32_t item_count;
 		REJECTED_INSTANCE* rejected_instance = (REJECTED_INSTANCE*)rejected;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(rejected_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_error(item_value, error_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(rejected_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(rejected_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_error(item_value, error_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -13862,13 +17056,21 @@ int amqpvalue_get_released(AMQP_VALUE value, RELEASED_HANDLE* released_handle)
 		}
 		else
 		{
-			do
-			{
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
 
-				released_instance->composite_value = amqpvalue_clone(value);
+				    released_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -13991,77 +17193,106 @@ int amqpvalue_get_modified(AMQP_VALUE value, MODIFIED_HANDLE* modified_handle)
 		}
 		else
 		{
-			do
-			{
-				AMQP_VALUE item_value;
-				/* delivery-failed */
-				item_value = amqpvalue_get_list_item(list_value, 0);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool delivery_failed;
-					if (amqpvalue_get_boolean(item_value, &delivery_failed) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							modified_destroy(*modified_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+    				AMQP_VALUE item_value;
+				    /* delivery-failed */
+				    if (list_item_count > 0)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 0);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool delivery_failed;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &delivery_failed) != 0)
+					            {
+						            modified_destroy(*modified_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* undeliverable-here */
-				item_value = amqpvalue_get_list_item(list_value, 1);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					bool undeliverable_here;
-					if (amqpvalue_get_boolean(item_value, &undeliverable_here) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							modified_destroy(*modified_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* undeliverable-here */
+				    if (list_item_count > 1)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 1);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        bool undeliverable_here;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_boolean(item_value, &undeliverable_here) != 0)
+					            {
+						            modified_destroy(*modified_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
-				/* message-annotations */
-				item_value = amqpvalue_get_list_item(list_value, 2);
-				if (item_value == NULL)
-				{
-					/* do nothing */
-				}
-				else
-				{
-					fields message_annotations;
-					if (amqpvalue_get_fields(item_value, &message_annotations) != 0)
-					{
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							modified_destroy(*modified_handle);
-							result = __FAILURE__;
-							break;
-						}
-					}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+				    /* message-annotations */
+				    if (list_item_count > 2)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, 2);
+				        if (item_value == NULL)
+				        {
+					        /* do nothing */
+				        }
+				        else
+				        {
+					        fields message_annotations;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+						        /* no error, field is not mandatory */
+                            }
+                            else
+                            {
+					            if (amqpvalue_get_fields(item_value, &message_annotations) != 0)
+					            {
+						            modified_destroy(*modified_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
 
-				modified_instance->composite_value = amqpvalue_clone(value);
+				    modified_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -14078,22 +17309,38 @@ int modified_get_delivery_failed(MODIFIED_HANDLE modified, bool* delivery_failed
 	}
 	else
 	{
+        uint32_t item_count;
 		MODIFIED_INSTANCE* modified_instance = (MODIFIED_INSTANCE*)modified;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(modified_instance->composite_value, 0);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, delivery_failed_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(modified_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 0)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(modified_instance->composite_value, 0);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, delivery_failed_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -14144,22 +17391,38 @@ int modified_get_undeliverable_here(MODIFIED_HANDLE modified, bool* undeliverabl
 	}
 	else
 	{
+        uint32_t item_count;
 		MODIFIED_INSTANCE* modified_instance = (MODIFIED_INSTANCE*)modified;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(modified_instance->composite_value, 1);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_boolean(item_value, undeliverable_here_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(modified_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 1)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(modified_instance->composite_value, 1);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_boolean(item_value, undeliverable_here_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 
@@ -14210,22 +17473,38 @@ int modified_get_message_annotations(MODIFIED_HANDLE modified, fields* message_a
 	}
 	else
 	{
+        uint32_t item_count;
 		MODIFIED_INSTANCE* modified_instance = (MODIFIED_INSTANCE*)modified;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(modified_instance->composite_value, 2);
-		if (item_value == NULL)
-		{
-			result = __FAILURE__;
-		}
-		else
-		{
-			if (amqpvalue_get_fields(item_value, message_annotations_value) != 0)
-			{
+        if (amqpvalue_get_composite_item_count(modified_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= 2)
+            {
 			    result = __FAILURE__;
-			}
-			else
-			{
-				result = 0;
-			}
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(modified_instance->composite_value, 2);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
+			        result = __FAILURE__;
+		        }
+		        else
+		        {
+			        if (amqpvalue_get_fields(item_value, message_annotations_value) != 0)
+			        {
+			            result = __FAILURE__;
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+                }
+            }
 		}
 	}
 

--- a/src/amqpvalue.c
+++ b/src/amqpvalue.c
@@ -193,22 +193,31 @@ typedef struct AMQPVALUE_DECODER_HANDLE_DATA_TAG
 /* Codes_SRS_AMQPVALUE_01_003: [1.6.1 null Indicates an empty value.] */
 AMQP_VALUE amqpvalue_create_null(void)
 {
-	/* Codes_SRS_AMQPVALUE_01_002: [If allocating the AMQP_VALUE fails then amqpvalue_create_null shall return NULL.] */
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_002: [If allocating the AMQP_VALUE fails then amqpvalue_create_null shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		/* Codes_SRS_AMQPVALUE_01_001: [amqpvalue_create_null shall return a handle to an AMQP_VALUE that stores a null value.] */
 		result->type = AMQP_TYPE_NULL;
 	}
+
 	return result;
 }
 
 /* Codes_SRS_AMQPVALUE_01_004: [1.6.2 boolean Represents a true or false value.] */
 AMQP_VALUE amqpvalue_create_boolean(bool value)
 {
-	/* Codes_SRS_AMQPVALUE_01_007: [If allocating the AMQP_VALUE fails then amqpvalue_create_boolean shall return NULL.] */
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	if (result != NULL)
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_007: [If allocating the AMQP_VALUE fails then amqpvalue_create_boolean shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
 	{
 		/* Codes_SRS_AMQPVALUE_01_006: [amqpvalue_create_boolean shall return a handle to an AMQP_VALUE that stores a boolean value.] */
 		result->type = AMQP_TYPE_BOOL;
@@ -226,7 +235,9 @@ int amqpvalue_get_boolean(AMQP_VALUE value, bool* bool_value)
 	if ((value == NULL) ||
 		(bool_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, bool_value = %p",
+            value, bool_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -234,7 +245,8 @@ int amqpvalue_get_boolean(AMQP_VALUE value, bool* bool_value)
 		/* Codes_SRS_AMQPVALUE_01_011: [If the type of the value is not Boolean, then amqpvalue_get_boolean shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_BOOL)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type bool");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -271,7 +283,9 @@ int amqpvalue_get_ubyte(AMQP_VALUE value, unsigned char* ubyte_value)
 	if ((value == NULL) ||
 		(ubyte_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, ubyte_value = %p",
+            value, ubyte_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -279,7 +293,8 @@ int amqpvalue_get_ubyte(AMQP_VALUE value, unsigned char* ubyte_value)
 		/* Codes_SRS_AMQPVALUE_01_037: [If the type of the value is not ubyte (was not created with amqpvalue_create_ubyte), then amqpvalue_get_ubyte shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_UBYTE)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type UBYTE");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -298,13 +313,18 @@ int amqpvalue_get_ubyte(AMQP_VALUE value, unsigned char* ubyte_value)
 AMQP_VALUE amqpvalue_create_ushort(uint16_t value)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	/* Codes_SRS_AMQPVALUE_01_039: [If allocating the AMQP_VALUE fails then amqpvalue_create_ushort shall return NULL.] */
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_039: [If allocating the AMQP_VALUE fails then amqpvalue_create_ushort shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		/* Codes_SRS_AMQPVALUE_01_038: [amqpvalue_create_ushort shall return a handle to an AMQP_VALUE that stores an uint16_t value.] */
 		result->type = AMQP_TYPE_USHORT;
 		result->value.ushort_value = value;
 	}
+
 	return result;
 }
 
@@ -316,7 +336,9 @@ int amqpvalue_get_ushort(AMQP_VALUE value, uint16_t* ushort_value)
 	if ((value == NULL) ||
 		(ushort_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, ushort_value = %p",
+            value, ushort_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -324,7 +346,8 @@ int amqpvalue_get_ushort(AMQP_VALUE value, uint16_t* ushort_value)
 		/* Codes_SRS_AMQPVALUE_01_043: [If the type of the value is not ushort (was not created with amqpvalue_create_ushort), then amqpvalue_get_ushort shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_USHORT)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type USHORT");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -343,13 +366,18 @@ int amqpvalue_get_ushort(AMQP_VALUE value, uint16_t* ushort_value)
 AMQP_VALUE amqpvalue_create_uint(uint32_t value)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	/* Codes_SRS_AMQPVALUE_01_045: [If allocating the AMQP_VALUE fails then amqpvalue_create_uint shall return NULL.] */
-	if (result != NULL)
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_045: [If allocating the AMQP_VALUE fails then amqpvalue_create_uint shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
 	{
 		/* Codes_SRS_AMQPVALUE_01_044: [amqpvalue_create_uint shall return a handle to an AMQP_VALUE that stores an uint32_t value.] */
 		result->type = AMQP_TYPE_UINT;
 		result->value.uint_value = value;
 	}
+
 	return result;
 }
 
@@ -361,7 +389,9 @@ int amqpvalue_get_uint(AMQP_VALUE value, uint32_t* uint_value)
 	if ((value == NULL) ||
 		(uint_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, uint_value = %p",
+            value, uint_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -369,7 +399,8 @@ int amqpvalue_get_uint(AMQP_VALUE value, uint32_t* uint_value)
 		/* Codes_SRS_AMQPVALUE_01_048: [If the type of the value is not uint (was not created with amqpvalue_create_uint), then amqpvalue_get_uint shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_UINT)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type UINT");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -388,13 +419,18 @@ int amqpvalue_get_uint(AMQP_VALUE value, uint32_t* uint_value)
 AMQP_VALUE amqpvalue_create_ulong(uint64_t value)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	/* Codes_SRS_AMQPVALUE_01_050: [If allocating the AMQP_VALUE fails then amqpvalue_create_ulong shall return NULL.] */
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_050: [If allocating the AMQP_VALUE fails then amqpvalue_create_ulong shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		/* Codes_SRS_AMQPVALUE_01_049: [amqpvalue_create_ulong shall return a handle to an AMQP_VALUE that stores an uint64_t value.] */
 		result->type = AMQP_TYPE_ULONG;
 		result->value.ulong_value = value;
 	}
+
 	return result;
 }
 
@@ -406,7 +442,9 @@ int amqpvalue_get_ulong(AMQP_VALUE value, uint64_t* ulong_value)
 	if ((value == NULL) ||
 		(ulong_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, ulong_value = %p",
+            value, ulong_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -414,7 +452,8 @@ int amqpvalue_get_ulong(AMQP_VALUE value, uint64_t* ulong_value)
 		/* Codes_SRS_AMQPVALUE_01_054: [If the type of the value is not ulong (was not created with amqpvalue_create_ulong), then amqpvalue_get_ulong shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_ULONG)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type ULONG");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -433,13 +472,18 @@ int amqpvalue_get_ulong(AMQP_VALUE value, uint64_t* ulong_value)
 AMQP_VALUE amqpvalue_create_byte(char value)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	/* Codes_SRS_AMQPVALUE_01_056: [If allocating the AMQP_VALUE fails then amqpvalue_create_byte shall return NULL.] */
-	if (result != NULL)
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_056: [If allocating the AMQP_VALUE fails then amqpvalue_create_byte shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
 	{
 		/* Codes_SRS_AMQPVALUE_01_055: [amqpvalue_create_byte shall return a handle to an AMQP_VALUE that stores a char value.] */
 		result->type = AMQP_TYPE_BYTE;
 		result->value.byte_value = value;
 	}
+
 	return result;
 }
 
@@ -451,7 +495,9 @@ int amqpvalue_get_byte(AMQP_VALUE value, char* byte_value)
 	if ((value == NULL) ||
 		(byte_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, byte_value = %p",
+            value, byte_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -459,7 +505,8 @@ int amqpvalue_get_byte(AMQP_VALUE value, char* byte_value)
 		/* Codes_SRS_AMQPVALUE_01_060: [If the type of the value is not byte (was not created with amqpvalue_create_byte), then amqpvalue_get_byte shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_BYTE)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type BYTE");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -478,9 +525,13 @@ int amqpvalue_get_byte(AMQP_VALUE value, char* byte_value)
 AMQP_VALUE amqpvalue_create_short(int16_t value)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	/* Codes_SRS_AMQPVALUE_01_062: [If allocating the AMQP_VALUE fails then amqpvalue_create_short shall return NULL.] */
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_062: [If allocating the AMQP_VALUE fails then amqpvalue_create_short shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		/* Codes_SRS_AMQPVALUE_01_061: [amqpvalue_create_short shall return a handle to an AMQP_VALUE that stores an int16_t value.] */
 		result->type = AMQP_TYPE_SHORT;
 		result->value.short_value = value;
@@ -496,7 +547,9 @@ int amqpvalue_get_short(AMQP_VALUE value, int16_t* short_value)
 	if ((value == NULL) ||
 		(short_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, short_value = %p",
+            value, short_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -504,7 +557,8 @@ int amqpvalue_get_short(AMQP_VALUE value, int16_t* short_value)
 		/* Codes_SRS_AMQPVALUE_01_066: [If the type of the value is not short (was not created with amqpvalue_create_short), then amqpvalue_get_short shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_SHORT)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type SHORT");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -523,13 +577,18 @@ int amqpvalue_get_short(AMQP_VALUE value, int16_t* short_value)
 AMQP_VALUE amqpvalue_create_int(int32_t value)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	/* Codes_SRS_AMQPVALUE_01_068: [If allocating the AMQP_VALUE fails then amqpvalue_create_int shall return NULL.] */
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_068: [If allocating the AMQP_VALUE fails then amqpvalue_create_int shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		/* Codes_SRS_AMQPVALUE_01_067: [amqpvalue_create_int shall return a handle to an AMQP_VALUE that stores an int32_t value.] */
 		result->type = AMQP_TYPE_INT;
 		result->value.int_value = value;
 	}
+
 	return result;
 }
 
@@ -541,7 +600,9 @@ int amqpvalue_get_int(AMQP_VALUE value, int32_t* int_value)
 	if ((value == NULL) ||
 		(int_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, int_value = %p",
+            value, int_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -549,7 +610,8 @@ int amqpvalue_get_int(AMQP_VALUE value, int32_t* int_value)
 		/* Codes_SRS_AMQPVALUE_01_072: [If the type of the value is not int (was not created with amqpvalue_create_int), then amqpvalue_get_int shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_INT)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type INT");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -568,13 +630,18 @@ int amqpvalue_get_int(AMQP_VALUE value, int32_t* int_value)
 AMQP_VALUE amqpvalue_create_long(int64_t value)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	/* Codes_SRS_AMQPVALUE_01_074: [If allocating the AMQP_VALUE fails then amqpvalue_create_long shall return NULL.] */
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_074: [If allocating the AMQP_VALUE fails then amqpvalue_create_long shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		/* Codes_SRS_AMQPVALUE_01_073: [amqpvalue_create_long shall return a handle to an AMQP_VALUE that stores an int64_t value.] */
 		result->type = AMQP_TYPE_LONG;
 		result->value.long_value = value;
 	}
+
 	return result;
 }
 
@@ -586,7 +653,9 @@ int amqpvalue_get_long(AMQP_VALUE value, int64_t* long_value)
 	if ((value == NULL) ||
 		(long_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, long_value = %p",
+            value, long_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -594,7 +663,8 @@ int amqpvalue_get_long(AMQP_VALUE value, int64_t* long_value)
 		/* Codes_SRS_AMQPVALUE_01_078: [If the type of the value is not long (was not created with amqpvalue_create_long), then amqpvalue_get_long shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_LONG)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type LONG");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -613,13 +683,18 @@ int amqpvalue_get_long(AMQP_VALUE value, int64_t* long_value)
 AMQP_VALUE amqpvalue_create_float(float value)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	/* Codes_SRS_AMQPVALUE_01_081: [If allocating the AMQP_VALUE fails then amqpvalue_create_float shall return NULL.] */
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_081: [If allocating the AMQP_VALUE fails then amqpvalue_create_float shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		/* Codes_SRS_AMQPVALUE_01_080: [amqpvalue_create_float shall return a handle to an AMQP_VALUE that stores a float value.] */
 		result->type = AMQP_TYPE_FLOAT;
 		result->value.float_value = value;
 	}
+
 	return result;
 }
 
@@ -631,7 +706,9 @@ int amqpvalue_get_float(AMQP_VALUE value, float* float_value)
 	if ((value == NULL) ||
 		(float_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, float_value = %p",
+            value, float_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -639,7 +716,8 @@ int amqpvalue_get_float(AMQP_VALUE value, float* float_value)
 		/* Codes_SRS_AMQPVALUE_01_085: [If the type of the value is not float (was not created with amqpvalue_create_float), then amqpvalue_get_float shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_FLOAT)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type FLOAT");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -658,13 +736,18 @@ int amqpvalue_get_float(AMQP_VALUE value, float* float_value)
 AMQP_VALUE amqpvalue_create_double(double value)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	/* Codes_SRS_AMQPVALUE_01_087: [If allocating the AMQP_VALUE fails then amqpvalue_create_double shall return NULL.] */
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_087: [If allocating the AMQP_VALUE fails then amqpvalue_create_double shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		/* Codes_SRS_AMQPVALUE_01_086: [amqpvalue_create_double shall return a handle to an AMQP_VALUE that stores a double value.] */
 		result->type = AMQP_TYPE_DOUBLE;
 		result->value.double_value = value;
 	}
+
 	return result;
 }
 
@@ -676,7 +759,9 @@ int amqpvalue_get_double(AMQP_VALUE value, double* double_value)
 	if ((value == NULL) ||
 		(double_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, double_value = %p",
+            value, double_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -684,7 +769,8 @@ int amqpvalue_get_double(AMQP_VALUE value, double* double_value)
 		/* Codes_SRS_AMQPVALUE_01_091: [If the type of the value is not double (was not created with amqpvalue_create_double), then amqpvalue_get_double shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_DOUBLE)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type DOUBLE");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -707,14 +793,19 @@ AMQP_VALUE amqpvalue_create_char(uint32_t value)
 	/* Codes_SRS_AMQPVALUE_01_098: [If the code point value is outside of the allowed range [0, 0x10FFFF] then amqpvalue_create_char shall return NULL.] */
 	if (value > 0x10FFFF)
 	{
+        LogError("Invalid value for a Unicode char");
 		result = NULL;
 	}
 	else
 	{
 		result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-		/* Codes_SRS_AMQPVALUE_01_093: [If allocating the AMQP_VALUE fails then amqpvalue_create_char shall return NULL.] */
-		if (result != NULL)
-		{
+        if (result == NULL)
+        {
+            /* Codes_SRS_AMQPVALUE_01_093: [If allocating the AMQP_VALUE fails then amqpvalue_create_char shall return NULL.] */
+            LogError("Could not allocate memory for AMQP value");
+        }
+        else
+        {
 			/* Codes_SRS_AMQPVALUE_01_092: [amqpvalue_create_char shall return a handle to an AMQP_VALUE that stores a single UTF-32 character value.] */
 			result->type = AMQP_TYPE_CHAR;
 			result->value.char_value = value;
@@ -732,7 +823,9 @@ int amqpvalue_get_char(AMQP_VALUE value, uint32_t* char_value)
 	if ((value == NULL) ||
 		(char_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, double_value = %p",
+            value, char_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -740,7 +833,8 @@ int amqpvalue_get_char(AMQP_VALUE value, uint32_t* char_value)
 		/* Codes_SRS_AMQPVALUE_01_097: [If the type of the value is not char (was not created with amqpvalue_create_char), then amqpvalue_get_char shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_CHAR)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type CHAR");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -759,13 +853,18 @@ int amqpvalue_get_char(AMQP_VALUE value, uint32_t* char_value)
 AMQP_VALUE amqpvalue_create_timestamp(int64_t value)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	/* Codes_SRS_AMQPVALUE_01_108: [If allocating the AMQP_VALUE fails then amqpvalue_create_timestamp shall return NULL.] */
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_108: [If allocating the AMQP_VALUE fails then amqpvalue_create_timestamp shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		/* Codes_SRS_AMQPVALUE_01_107: [amqpvalue_create_timestamp shall return a handle to an AMQP_VALUE that stores an uint64_t value that represents a millisecond precision Unix time.] */
 		result->type = AMQP_TYPE_TIMESTAMP;
 		result->value.timestamp_value = value;
 	}
+
 	return result;
 }
 
@@ -777,7 +876,9 @@ int amqpvalue_get_timestamp(AMQP_VALUE value, int64_t* timestamp_value)
 	if ((value == NULL) ||
 		(timestamp_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, timestamp_value = %p",
+            value, timestamp_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -785,7 +886,8 @@ int amqpvalue_get_timestamp(AMQP_VALUE value, int64_t* timestamp_value)
 		/* Codes_SRS_AMQPVALUE_01_112: [If the type of the value is not timestamp (was not created with amqpvalue_create_timestamp), then amqpvalue_get_timestamp shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_TIMESTAMP)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type TIMESTAMP");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -804,13 +906,18 @@ int amqpvalue_get_timestamp(AMQP_VALUE value, int64_t* timestamp_value)
 AMQP_VALUE amqpvalue_create_uuid(uuid value)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	/* Codes_SRS_AMQPVALUE_01_114: [If allocating the AMQP_VALUE fails then amqpvalue_create_uuid shall return NULL.] */
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_114: [If allocating the AMQP_VALUE fails then amqpvalue_create_uuid shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		/* Codes_SRS_AMQPVALUE_01_113: [amqpvalue_create_uuid shall return a handle to an AMQP_VALUE that stores an uuid value that represents a unique identifier per RFC-4122 section 4.1.2.] */
 		result->type = AMQP_TYPE_UUID;
 		(void)memcpy(&result->value.uuid_value, value, 16);
 	}
+
 	return result;
 }
 
@@ -822,7 +929,9 @@ int amqpvalue_get_uuid(AMQP_VALUE value, uuid* uuid_value)
 	if ((value == NULL) ||
 		(uuid_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, uuid_value = %p",
+            value, uuid_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -830,7 +939,8 @@ int amqpvalue_get_uuid(AMQP_VALUE value, uuid* uuid_value)
 		/* Codes_SRS_AMQPVALUE_01_118: [If the type of the value is not uuid (was not created with amqpvalue_create_uuid), then amqpvalue_get_uuid shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_UUID)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type UUID");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -853,14 +963,19 @@ AMQP_VALUE amqpvalue_create_binary(amqp_binary value)
 		(value.length > 0))
 	{
 		/* Codes_SRS_AMQPVALUE_01_129: [If value.data is NULL and value.length is positive then amqpvalue_create_binary shall return NULL.] */
+        LogError("NULL bytes with non-zero length");
 		result = NULL;
 	}
 	else
 	{
-		/* Codes_SRS_AMQPVALUE_01_128: [If allocating the AMQP_VALUE fails then amqpvalue_create_binary shall return NULL.] */
 		result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-		if (result != NULL)
-		{
+        if (result == NULL)
+        {
+            /* Codes_SRS_AMQPVALUE_01_128: [If allocating the AMQP_VALUE fails then amqpvalue_create_binary shall return NULL.] */
+            LogError("Could not allocate memory for AMQP value");
+        }
+        else
+        {
 			/* Codes_SRS_AMQPVALUE_01_127: [amqpvalue_create_binary shall return a handle to an AMQP_VALUE that stores a sequence of bytes.] */
 			result->type = AMQP_TYPE_BINARY;
 			if (value.length > 0)
@@ -877,7 +992,8 @@ AMQP_VALUE amqpvalue_create_binary(amqp_binary value)
 			if ((result->value.binary_value.bytes == NULL) && (value.length > 0))
 			{
 				/* Codes_SRS_AMQPVALUE_01_128: [If allocating the AMQP_VALUE fails then amqpvalue_create_binary shall return NULL.] */
-				free(result);
+                LogError("Could not allocate memory for binary payload of AMQP value");
+                free(result);
 				result = NULL;
 			}
 			else
@@ -889,6 +1005,7 @@ AMQP_VALUE amqpvalue_create_binary(amqp_binary value)
 			}
 		}
 	}
+
 	return result;
 }
 
@@ -900,7 +1017,9 @@ int amqpvalue_get_binary(AMQP_VALUE value, amqp_binary* binary_value)
 	if ((value == NULL) ||
 		(binary_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, binary_value = %p",
+            value, binary_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -908,7 +1027,8 @@ int amqpvalue_get_binary(AMQP_VALUE value, amqp_binary* binary_value)
 		/* Codes_SRS_AMQPVALUE_01_133: [If the type of the value is not binary (was not created with amqpvalue_create_binary), then amqpvalue_get_binary shall return NULL.] */
 		if (value_data->type != AMQP_TYPE_BINARY)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type BINARY");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -930,22 +1050,28 @@ AMQP_VALUE amqpvalue_create_string(const char* value)
 	AMQP_VALUE_DATA* result;
 	if (value == NULL)
 	{
-		result = NULL;
+        LogError("NULL argument value");
+        result = NULL;
 	}
 	else
 	{
 		size_t length = strlen(value);
 		
-		/* Codes_SRS_AMQPVALUE_01_136: [If allocating the AMQP_VALUE fails then amqpvalue_create_string shall return NULL.] */
 		result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-		if (result != NULL)
-		{
+        if (result == NULL)
+        {
+            /* Codes_SRS_AMQPVALUE_01_136: [If allocating the AMQP_VALUE fails then amqpvalue_create_string shall return NULL.] */
+            LogError("Could not allocate memory for AMQP value");
+        }
+        else
+        {
 			result->type = AMQP_TYPE_STRING;
 			result->value.string_value.chars = malloc(length + 1);
 			if (result->value.string_value.chars == NULL)
 			{
 				/* Codes_SRS_AMQPVALUE_01_136: [If allocating the AMQP_VALUE fails then amqpvalue_create_string shall return NULL.] */
-				free(result);
+                LogError("Could not allocate memory for string AMQP value");
+                free(result);
 				result = NULL;
 			}
 			else
@@ -969,7 +1095,9 @@ int amqpvalue_get_string(AMQP_VALUE value, const char** string_value)
 	if ((value == NULL) ||
 		(string_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, string_value = %p",
+            value, string_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -978,7 +1106,8 @@ int amqpvalue_get_string(AMQP_VALUE value, const char** string_value)
 		/* Codes_SRS_AMQPVALUE_01_140: [If the type of the value is not string (was not created with amqpvalue_create_string), then amqpvalue_get_string shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_STRING)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type STRING");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -1051,7 +1180,9 @@ int amqpvalue_get_symbol(AMQP_VALUE value, const char** symbol_value)
 	if ((value == NULL) ||
 		(symbol_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, symbol_value = %p",
+            value, symbol_value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -1060,7 +1191,8 @@ int amqpvalue_get_symbol(AMQP_VALUE value, const char** symbol_value)
 		/* Codes_SRS_AMQPVALUE_01_148: [If the type of the value is not symbol (was not created with amqpvalue_create_symbol), then amqpvalue_get_symbol shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_SYMBOL)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type SYMBOL");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -1078,10 +1210,14 @@ int amqpvalue_get_symbol(AMQP_VALUE value, const char** symbol_value)
 /* Codes_SRS_AMQPVALUE_01_030: [1.6.22 list A sequence of polymorphic values.] */
 AMQP_VALUE amqpvalue_create_list(void)
 {
-	/* Codes_SRS_AMQPVALUE_01_150: [If allocating the AMQP_VALUE fails then amqpvalue_create_list shall return NULL.] */
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_150: [If allocating the AMQP_VALUE fails then amqpvalue_create_list shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		/* Codes_SRS_AMQPVALUE_01_149: [amqpvalue_create_list shall return a handle to an AMQP_VALUE that stores a list.] */
 		result->type = AMQP_TYPE_LIST;
 
@@ -1100,16 +1236,17 @@ int amqpvalue_set_list_item_count(AMQP_VALUE value, uint32_t list_size)
 	/* Codes_SRS_AMQPVALUE_01_155: [If the value argument is NULL, amqpvalue_set_list_item_count shall return a non-zero value.] */
 	if (value == NULL)
 	{
-		result = __FAILURE__;
+        LogError("NULL list value");
+        result = __FAILURE__;
 	}
 	else
 	{
 		AMQP_VALUE_DATA* value_data = (AMQP_VALUE_DATA*)value;
-
 		if (value_data->type != AMQP_TYPE_LIST)
 		{
 			/* Codes_SRS_AMQPVALUE_01_156: [If the value is not of type list, then amqpvalue_set_list_item_count shall return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Value is not of type LIST");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -1122,7 +1259,8 @@ int amqpvalue_set_list_item_count(AMQP_VALUE value, uint32_t list_size)
 				if (new_list == NULL)
 				{
 					/* Codes_SRS_AMQPVALUE_01_154: [If allocating memory for the list according to the new size fails, then amqpvalue_set_list_item_count shall return a non-zero value, while preserving the existing list contents.] */
-					result = __FAILURE__;
+                    LogError("Could not reallocate list memory");
+                    result = __FAILURE__;
 				}
 				else
 				{
@@ -1137,7 +1275,8 @@ int amqpvalue_set_list_item_count(AMQP_VALUE value, uint32_t list_size)
 						new_list[i] = amqpvalue_create_null();
 						if (new_list[i] == NULL)
 						{
-							break;
+                            LogError("Could not create NULL AMQP value to be inserted in list");
+                            break;
 						}
 					}
 
@@ -1195,7 +1334,9 @@ int amqpvalue_get_list_item_count(AMQP_VALUE value, uint32_t* size)
 	if ((value == NULL) ||
 		(size == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, size = %p",
+            value, size);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -1204,7 +1345,8 @@ int amqpvalue_get_list_item_count(AMQP_VALUE value, uint32_t* size)
 		/* Codes_SRS_AMQPVALUE_01_160: [If the AMQP_VALUE is not a list then amqpvalue_get_list_item_count shall return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_LIST)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type LIST");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -1226,25 +1368,27 @@ int amqpvalue_set_list_item(AMQP_VALUE value, uint32_t index, AMQP_VALUE list_it
 	/* Codes_SRS_AMQPVALUE_01_165: [If value or list_item_value is NULL, amqpvalue_set_list_item shall fail and return a non-zero value.] */
 	if (value == NULL)
 	{
-		result = __FAILURE__;
+        LogError("NULL list value");
+        result = __FAILURE__;
 	}
 	else
 	{
 		AMQP_VALUE_DATA* value_data = (AMQP_VALUE_DATA*)value;
 		if (value_data->type != AMQP_TYPE_LIST)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type LIST");
+            result = __FAILURE__;
 		}
 		else
 		{
 			/* Codes_SRS_AMQPVALUE_01_168: [The item stored at the index-th position in the list shall be a clone of list_item_value.] */
 			AMQP_VALUE cloned_item = amqpvalue_clone(list_item_value);
-
 			if (cloned_item == NULL)
 			{
 				/* Codes_SRS_AMQPVALUE_01_170: [When amqpvalue_set_list_item fails due to not being able to clone the item or grow the list, the list shall not be altered.] */
 				/* Codes_SRS_AMQPVALUE_01_169: [If cloning the item fails, amqpvalue_set_list_item shall fail and return a non-zero value.] */
-				result = __FAILURE__;
+                LogError("Could not clone list item");
+                result = __FAILURE__;
 			}
 			else
 			{
@@ -1254,7 +1398,8 @@ int amqpvalue_set_list_item(AMQP_VALUE value, uint32_t index, AMQP_VALUE list_it
 					if (new_list == NULL)
 					{
 						/* Codes_SRS_AMQPVALUE_01_170: [When amqpvalue_set_list_item fails due to not being able to clone the item or grow the list, the list shall not be altered.] */
-						amqpvalue_destroy(cloned_item);
+                        LogError("Could not reallocate list storage");
+                        amqpvalue_destroy(cloned_item);
 						result = __FAILURE__;
 					}
 					else
@@ -1268,7 +1413,8 @@ int amqpvalue_set_list_item(AMQP_VALUE value, uint32_t index, AMQP_VALUE list_it
 							new_list[i] = amqpvalue_create_null();
 							if (new_list[i] == NULL)
 							{
-								break;
+                                LogError("Could not allocate NULL value for list entries");
+                                break;
 							}
 						}
 
@@ -1322,18 +1468,24 @@ AMQP_VALUE amqpvalue_get_list_item(AMQP_VALUE value, size_t index)
 	if (value == NULL)
 	{
 		/* Codes_SRS_AMQPVALUE_01_174: [If the value argument is NULL, amqpvalue_get_list_item shall fail and return NULL.] */
-		result = NULL;
+        LogError("NULL list value");
+        result = NULL;
 	}
 	else
 	{
 		AMQP_VALUE_DATA* value_data = (AMQP_VALUE_DATA*)value;
 
 		/* Codes_SRS_AMQPVALUE_01_177: [If value is not a list then amqpvalue_get_list_item shall fail and return NULL.] */
-		if ((value_data->type != AMQP_TYPE_LIST) ||
-			/* Codes_SRS_AMQPVALUE_01_175: [If index is greater or equal to the number of items in the list then amqpvalue_get_list_item shall fail and return NULL.] */
-			(value_data->value.list_value.count <= index))
+        if (value_data->type != AMQP_TYPE_LIST)
+        {
+            LogError("Value is not of type LIST");
+            result = NULL;
+        }
+        /* Codes_SRS_AMQPVALUE_01_175: [If index is greater or equal to the number of items in the list then amqpvalue_get_list_item shall fail and return NULL.] */
+        else if (value_data->value.list_value.count <= index)
 		{
-			result = NULL;
+            LogError("Bad index value %u", (unsigned int)index);
+            result = NULL;
 		}
 		else
 		{
@@ -1352,9 +1504,13 @@ AMQP_VALUE amqpvalue_create_map(void)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
 
-	/* Codes_SRS_AMQPVALUE_01_179: [If allocating memory for the map fails, then amqpvalue_create_map shall return NULL.] */
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_179: [If allocating memory for the map fails, then amqpvalue_create_map shall return NULL.] */
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		result->type = AMQP_TYPE_MAP;
 
 		/* Codes_SRS_AMQPVALUE_01_180: [The number of key/value pairs in the newly created map shall be zero.] */
@@ -1374,7 +1530,9 @@ int amqpvalue_set_map_value(AMQP_VALUE map, AMQP_VALUE key, AMQP_VALUE value)
 		(key == NULL) ||
 		(value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: map = %p, key = %p, value = %p",
+            map, key, value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -1383,7 +1541,8 @@ int amqpvalue_set_map_value(AMQP_VALUE map, AMQP_VALUE key, AMQP_VALUE value)
 		/* Codes_SRS_AMQPVALUE_01_196: [If the map argument is not an AMQP value created with the amqpvalue_create_map function than amqpvalue_set_map_value shall fail and return a non-zero value.] */
 		if (value_data->type != AMQP_TYPE_MAP)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type MAP");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -1394,7 +1553,8 @@ int amqpvalue_set_map_value(AMQP_VALUE map, AMQP_VALUE key, AMQP_VALUE value)
 			if (cloned_value == NULL)
 			{
 				/* Codes_SRS_AMQPVALUE_01_188: [If cloning the value fails, amqpvalue_set_map_value shall fail and return a non-zero value.] */
-				result = __FAILURE__;
+                LogError("Could not clone value to set in the map");
+                result = __FAILURE__;
 			}
 			else
 			{
@@ -1405,7 +1565,8 @@ int amqpvalue_set_map_value(AMQP_VALUE map, AMQP_VALUE key, AMQP_VALUE value)
 				{
 					if (amqpvalue_are_equal(value_data->value.map_value.pairs[i].key, key))
 					{
-						break;
+                        LogError("Could not allocate NULL value for map entries");
+                        break;
 					}
 				}
 
@@ -1427,7 +1588,8 @@ int amqpvalue_set_map_value(AMQP_VALUE map, AMQP_VALUE key, AMQP_VALUE value)
 					{
 						/* Codes_SRS_AMQPVALUE_01_187: [If cloning the key fails, amqpvalue_set_map_value shall fail and return a non-zero value.] */
 						amqpvalue_destroy(cloned_value);
-						result = __FAILURE__;
+                        LogError("Could not clone key for map");
+                        result = __FAILURE__;
 					}
 					else
 					{
@@ -1437,7 +1599,8 @@ int amqpvalue_set_map_value(AMQP_VALUE map, AMQP_VALUE key, AMQP_VALUE value)
 							/* Codes_SRS_AMQPVALUE_01_186: [If allocating memory to hold a new key/value pair fails, amqpvalue_set_map_value shall fail and return a non-zero value.] */
 							amqpvalue_destroy(cloned_key);
 							amqpvalue_destroy(cloned_value);
-							result = __FAILURE__;
+                            LogError("Could not reallocate memory for map");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -1468,7 +1631,9 @@ AMQP_VALUE amqpvalue_get_map_value(AMQP_VALUE map, AMQP_VALUE key)
 	if ((map == NULL) ||
 		(key == NULL))
 	{
-		result = NULL;
+        LogError("Bad arguments: map = %p, key = %p",
+            map, key);
+        result = NULL;
 	}
 	else
 	{
@@ -1477,7 +1642,8 @@ AMQP_VALUE amqpvalue_get_map_value(AMQP_VALUE map, AMQP_VALUE key)
 		/* Codes_SRS_AMQPVALUE_01_197: [If the map argument is not an AMQP value created with the amqpvalue_create_map function than amqpvalue_get_map_value shall return NULL.] */
 		if (value_data->type != AMQP_TYPE_MAP)
 		{
-			result = NULL;
+            LogError("Value is not of type MAP");
+            result = NULL;
 		}
 		else
 		{
@@ -1487,7 +1653,8 @@ AMQP_VALUE amqpvalue_get_map_value(AMQP_VALUE map, AMQP_VALUE key)
 			{
 				if (amqpvalue_are_equal(value_data->value.map_value.pairs[i].key, key))
 				{
-					break;
+                    LogError("Map comparing key values failed");
+                    break;
 				}
 			}
 
@@ -1516,7 +1683,9 @@ int amqpvalue_get_map_pair_count(AMQP_VALUE map, uint32_t* pair_count)
 	if ((map == NULL) ||
 		(pair_count == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: map = %p, pair_count = %p",
+            map, pair_count);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -1525,7 +1694,8 @@ int amqpvalue_get_map_pair_count(AMQP_VALUE map, uint32_t* pair_count)
 		if (value_data->type != AMQP_TYPE_MAP)
 		{
 			/* Codes_SRS_AMQPVALUE_01_198: [If the map argument is not an AMQP value created with the amqpvalue_create_map function then amqpvalue_get_map_pair_count shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Value is not of type MAP");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -1549,7 +1719,9 @@ int amqpvalue_get_map_key_value_pair(AMQP_VALUE map, uint32_t index, AMQP_VALUE*
 		(key == NULL) ||
 		(value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: map = %p, key = %p, value = %p",
+            map, key, value);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -1558,12 +1730,14 @@ int amqpvalue_get_map_key_value_pair(AMQP_VALUE map, uint32_t index, AMQP_VALUE*
 		if (value_data->type != AMQP_TYPE_MAP)
 		{
 			/* Codes_SRS_AMQPVALUE_01_205: [If the map argument is not an AMQP value created with the amqpvalue_create_map function then amqpvalue_get_map_key_value_pair shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Value is not of type MAP");
+            result = __FAILURE__;
 		}
 		else if (value_data->value.map_value.pair_count <= index)
 		{
 			/* Codes_SRS_AMQPVALUE_01_204: [If the index argument is greater or equal to the number of key/value pairs in the map then amqpvalue_get_map_key_value_pair shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Index out of range: %u", (unsigned int)index);
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -1572,7 +1746,8 @@ int amqpvalue_get_map_key_value_pair(AMQP_VALUE map, uint32_t index, AMQP_VALUE*
 			if (*key == NULL)
 			{
 				/* Codes_SRS_AMQPVALUE_01_202: [If cloning the key fails, amqpvalue_get_map_key_value_pair shall fail and return a non-zero value.] */
-				result = __FAILURE__;
+                LogError("Could not clone index %u key", (unsigned int)index);
+                result = __FAILURE__;
 			}
 			else
 			{
@@ -1581,7 +1756,8 @@ int amqpvalue_get_map_key_value_pair(AMQP_VALUE map, uint32_t index, AMQP_VALUE*
 				{
 					/* Codes_SRS_AMQPVALUE_01_203: [If cloning the value fails, amqpvalue_get_map_key_value_pair shall fail and return a non-zero value.] */
 					amqpvalue_destroy(*key);
-					result = __FAILURE__;
+                    LogError("Could not clone index %u value", (unsigned int)index);
+                    result = __FAILURE__;
 				}
 				else
 				{
@@ -1602,26 +1778,22 @@ int amqpvalue_get_map(AMQP_VALUE value, AMQP_VALUE* map_value)
 	if ((value == NULL) ||
 		(map_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, map_value = %p",
+            value, map_value);
+        result = __FAILURE__;
 	}
 	else
 	{
 		AMQP_VALUE_DATA* value_data = (AMQP_VALUE_DATA*)value;
 		if (value_data->type != AMQP_TYPE_MAP)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type MAP");
+            result = __FAILURE__;
 		}
 		else
 		{
-			if (map_value == NULL)
-			{
-				result = __FAILURE__;
-			}
-			else
-			{
-				*map_value = value;
-				result = 0;
-			}
+			*map_value = value;
+			result = 0;
 		}
 	}
 
@@ -1631,10 +1803,15 @@ int amqpvalue_get_map(AMQP_VALUE value, AMQP_VALUE* map_value)
 AMQP_VALUE amqpvalue_create_array(void)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        LogError("Could not allocate memory for AMQP value");
+    }
+    else
+    {
 		result->type = AMQP_TYPE_ARRAY;
 	}
+
 	return result;
 }
 
@@ -1645,7 +1822,9 @@ int amqpvalue_get_array_item_count(AMQP_VALUE value, uint32_t* size)
 	if ((value == NULL) ||
 		(size == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, size = %p",
+            value, size);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -1653,7 +1832,8 @@ int amqpvalue_get_array_item_count(AMQP_VALUE value, uint32_t* size)
 
 		if (value_data->type != AMQP_TYPE_ARRAY)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type ARRAY");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -1671,31 +1851,33 @@ int amqpvalue_add_array_item(AMQP_VALUE value, AMQP_VALUE array_item_value)
 
 	if (value == NULL)
 	{
-		result = __FAILURE__;
+        LogError("NULL value");
+        result = __FAILURE__;
 	}
 	else
 	{
 		AMQP_VALUE_DATA* value_data = (AMQP_VALUE_DATA*)value;
 		if (value_data->type != AMQP_TYPE_ARRAY)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type ARRAY");
+            result = __FAILURE__;
 		}
 		else
 		{
 			AMQP_VALUE_DATA* array_item_value_data = (AMQP_VALUE_DATA*)array_item_value;
-
 			if ((value_data->value.array_value.count > 0) &&
 				(array_item_value_data->type != value_data->value.array_value.items[0]->type))
 			{
-				result = __FAILURE__;
+                LogError("Cannot put different types in the same array");
+                result = __FAILURE__;
 			}
 			else
 			{
 				AMQP_VALUE cloned_item = amqpvalue_clone(array_item_value);
-
 				if (cloned_item == NULL)
 				{
-					result = __FAILURE__;
+                    LogError("Cannot clone value to put in the array");
+                    result = __FAILURE__;
 				}
 				else
 				{
@@ -1703,7 +1885,8 @@ int amqpvalue_add_array_item(AMQP_VALUE value, AMQP_VALUE array_item_value)
 					if (new_array == NULL)
 					{
 						amqpvalue_destroy(cloned_item);
-						result = __FAILURE__;
+                        LogError("Cannot resize array");
+                        result = __FAILURE__;
 					}
 					else
 					{
@@ -1728,16 +1911,22 @@ AMQP_VALUE amqpvalue_get_array_item(AMQP_VALUE value, uint32_t index)
 
 	if (value == NULL)
 	{
-		result = NULL;
+        LogError("NULL value");
+        result = NULL;
 	}
 	else
 	{
 		AMQP_VALUE_DATA* value_data = (AMQP_VALUE_DATA*)value;
 
-		if ((value_data->type != AMQP_TYPE_ARRAY) ||
-			(value_data->value.array_value.count <= index))
+        if (value_data->type != AMQP_TYPE_ARRAY)
+        {
+            LogError("Value is not of type ARRAY");
+            result = NULL;
+        }
+        else if (value_data->value.array_value.count <= index)
 		{
-			result = NULL;
+            LogError("Index out of range: %u", (unsigned int)index);
+            result = NULL;
 		}
 		else
 		{
@@ -1755,26 +1944,22 @@ int amqpvalue_get_array(AMQP_VALUE value, AMQP_VALUE* array_value)
 	if ((value == NULL) ||
 		(array_value == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, array_value = %p",
+            value, array_value);
+        result = __FAILURE__;
 	}
 	else
 	{
 		AMQP_VALUE_DATA* value_data = (AMQP_VALUE_DATA*)value;
 		if (value_data->type != AMQP_TYPE_ARRAY)
 		{
-			result = __FAILURE__;
+            LogError("Value is not of type ARRAY");
+            result = __FAILURE__;
 		}
 		else
 		{
-			if (array_value == NULL)
-			{
-				result = __FAILURE__;
-			}
-			else
-			{
-				*array_value = value;
-				result = 0;
-			}
+			*array_value = value;
+			result = 0;
 		}
 	}
 
@@ -1790,7 +1975,9 @@ bool amqpvalue_are_equal(AMQP_VALUE value1, AMQP_VALUE value2)
 	if ((value1 == NULL) &&
 		(value2 == NULL))
 	{
-		result = true;
+        LogError("Bad arguments: value1 = %p, value2 = %p",
+            value1, value2);
+        result = true;
 	}
 	/* Codes_SRS_AMQPVALUE_01_208: [If one of the arguments is NULL and the other is not, amqpvalue_are_equal shall return false.] */
 	else if ((value1 != value2) && ((value1 == NULL) || (value2 == NULL)))
@@ -1974,7 +2161,8 @@ AMQP_VALUE amqpvalue_clone(AMQP_VALUE value)
 
 	if (value == NULL)
 	{
-		result = NULL;
+        LogError("NULL value");
+        result = NULL;
 	}
 	else
 	{
@@ -1982,7 +2170,8 @@ AMQP_VALUE amqpvalue_clone(AMQP_VALUE value)
 		switch (value_data->type)
 		{
 		default:
-			result = NULL;
+            LogError("Invalid data type: %d", (int)value_data->type);
+            result = NULL;
 			break;
 
 		case AMQP_TYPE_NULL:
@@ -2083,7 +2272,8 @@ AMQP_VALUE amqpvalue_clone(AMQP_VALUE value)
 			if (result_data == NULL)
 			{
 				/* Codes_SRS_AMQPVALUE_01_236: [If creating the cloned value fails, amqpvalue_clone shall return NULL.] */
-				result = NULL;
+                LogError("Cannot allocate memory for cloned value");
+                result = NULL;
 			}
 			else
 			{
@@ -2096,7 +2286,8 @@ AMQP_VALUE amqpvalue_clone(AMQP_VALUE value)
 					if (result_data->value.list_value.items == NULL)
 					{
 						/* Codes_SRS_AMQPVALUE_01_236: [If creating the cloned value fails, amqpvalue_clone shall return NULL.] */
-						free(result_data);
+                        LogError("Cannot allocate memory for cloned list");
+                        free(result_data);
 						result = NULL;
 					}
 					else
@@ -2106,7 +2297,8 @@ AMQP_VALUE amqpvalue_clone(AMQP_VALUE value)
 							result_data->value.list_value.items[i] = amqpvalue_clone(value_data->value.list_value.items[i]);
 							if (result_data->value.list_value.items[i] == NULL)
 							{
-								break;
+                                LogError("Cannot clone list item %u", (unsigned int)i);
+                                break;
 							}
 						}
 
@@ -2148,7 +2340,8 @@ AMQP_VALUE amqpvalue_clone(AMQP_VALUE value)
 			if (result_data == NULL)
 			{
 				/* Codes_SRS_AMQPVALUE_01_236: [If creating the cloned value fails, amqpvalue_clone shall return NULL.] */
-				result = NULL;
+                LogError("Cannot allocate memory for cloned map");
+                result = NULL;
 			}
 			else
 			{
@@ -2161,6 +2354,7 @@ AMQP_VALUE amqpvalue_clone(AMQP_VALUE value)
 					if (result_data->value.map_value.pairs == NULL)
 					{
 						/* Codes_SRS_AMQPVALUE_01_236: [If creating the cloned value fails, amqpvalue_clone shall return NULL.] */
+                        LogError("Cannot allocate memory for cloned map storage");
                         free(result_data);
 						result = NULL;
 					}
@@ -2171,13 +2365,15 @@ AMQP_VALUE amqpvalue_clone(AMQP_VALUE value)
 							result_data->value.map_value.pairs[i].key = amqpvalue_clone(value_data->value.map_value.pairs[i].key);
 							if (result_data->value.map_value.pairs[i].key == NULL)
 							{
-								break;
+                                LogError("Cannot clone map key index %u", (unsigned int)i);
+                                break;
 							}
 
 							result_data->value.map_value.pairs[i].value = amqpvalue_clone(value_data->value.map_value.pairs[i].value);
 							if (result_data->value.map_value.pairs[i].value == NULL)
 							{
-								amqpvalue_destroy(result_data->value.map_value.pairs[i].key);
+                                LogError("Cannot clone map value index %u", (unsigned int)i);
+                                amqpvalue_destroy(result_data->value.map_value.pairs[i].key);
 								break;
 							}
 						}
@@ -2218,7 +2414,8 @@ AMQP_VALUE amqpvalue_clone(AMQP_VALUE value)
 			AMQP_VALUE_DATA* result_data = malloc(sizeof(AMQP_VALUE_DATA));
 			if (result_data == NULL)
 			{
-				result = NULL;
+                LogError("Cannot allocate memory for cloned array");
+                result = NULL;
 			}
 			else
 			{
@@ -2230,7 +2427,8 @@ AMQP_VALUE amqpvalue_clone(AMQP_VALUE value)
 					result_data->value.array_value.items = (AMQP_VALUE*)malloc(value_data->value.array_value.count * sizeof(AMQP_VALUE));
 					if (result_data->value.array_value.items == NULL)
 					{
-						free(result_data);
+                        LogError("Cannot allocate memory for cloned array storage");
+                        free(result_data);
 						result = NULL;
 					}
 					else
@@ -2240,7 +2438,8 @@ AMQP_VALUE amqpvalue_clone(AMQP_VALUE value)
 							result_data->value.array_value.items[i] = amqpvalue_clone(value_data->value.array_value.items[i]);
 							if (result_data->value.array_value.items[i] == NULL)
 							{
-								break;
+                                LogError("Cannot allocate memory for cloned array item %u", (unsigned int)i);
+                                break;
 							}
 						}
 
@@ -2284,16 +2483,19 @@ AMQP_VALUE amqpvalue_clone(AMQP_VALUE value)
 
 			if (result_data == NULL)
 			{
-				result = NULL;
+                LogError("Cannot allocate memory for cloned composite value");
+                result = NULL;
 			}
 			else if ((cloned_descriptor = amqpvalue_clone(value_data->value.described_value.descriptor)) == NULL)
 			{
-				free(result_data);
+                LogError("Cannot clone descriptor");
+                free(result_data);
 				result = NULL;
 			}
 			else if ((cloned_list = amqpvalue_clone(value_data->value.described_value.value)) == NULL)
 			{
-				amqpvalue_destroy(cloned_descriptor);
+                LogError("Cannot clone described value");
+                amqpvalue_destroy(cloned_descriptor);
 				free(result_data);
 				result = NULL;
 			}
@@ -2366,7 +2568,8 @@ static int encode_boolean(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context
 		if (output_byte(encoder_output, context, 0x42) != 0)
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding boolean");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2379,7 +2582,8 @@ static int encode_boolean(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context
 		if (output_byte(encoder_output, context, 0x41) != 0)
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding boolean");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2399,7 +2603,8 @@ static int encode_ubyte(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, 
 		(output_byte(encoder_output, context, value) != 0))
 	{
 		/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-		result = __FAILURE__;
+        LogError("Failed encoding ubyte");
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -2420,7 +2625,8 @@ static int encode_ushort(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context,
 		(output_byte(encoder_output, context, (value & 0xFF)) != 0))
 	{
 		/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-		result = __FAILURE__;
+        LogError("Failed encoding ushort");
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -2441,7 +2647,8 @@ static int encode_uint(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, u
 		/* Codes_SRS_AMQPVALUE_01_279: [<encoding name="uint0" code="0x43" category="fixed" width="0" label="the uint value 0"/>] */
 		if (output_byte(encoder_output, context, 0x43) != 0)
 		{
-			result = __FAILURE__;
+            LogError("Failed encoding uint");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2457,7 +2664,8 @@ static int encode_uint(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, u
 			(output_byte(encoder_output, context, value & 0xFF) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding uint");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2475,7 +2683,8 @@ static int encode_uint(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, u
 			(output_byte(encoder_output, context, value & 0xFF) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding uint");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2497,7 +2706,8 @@ static int encode_ulong(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, 
 		if (output_byte(encoder_output, context, 0x44) != 0)
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding ulong");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2513,7 +2723,8 @@ static int encode_ulong(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, 
 			(output_byte(encoder_output, context, value & 0xFF) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding ulong");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2535,7 +2746,8 @@ static int encode_ulong(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, 
 			(output_byte(encoder_output, context, value & 0xFF) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding ulong");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2556,7 +2768,8 @@ static int encode_byte(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, c
 		(output_byte(encoder_output, context, value) != 0))
 	{
 		/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-		result = __FAILURE__;
+        LogError("Failed encoding byte");
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -2577,7 +2790,8 @@ static int encode_short(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, 
 		(output_byte(encoder_output, context, (value & 0xFF)) != 0))
 	{
 		/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-		result = __FAILURE__;
+        LogError("Failed encoding short");
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -2599,7 +2813,8 @@ static int encode_int(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, in
 			(output_byte(encoder_output, context, value & 0xFF) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding int");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2617,7 +2832,8 @@ static int encode_int(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, in
 			(output_byte(encoder_output, context, value & 0xFF) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding int");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2640,7 +2856,8 @@ static int encode_long(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, i
 			(output_byte(encoder_output, context, value & 0xFF) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding long");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2662,7 +2879,8 @@ static int encode_long(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, i
 			(output_byte(encoder_output, context, value & 0xFF) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding long");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2744,7 +2962,8 @@ static int encode_timestamp(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* conte
 		(output_byte(encoder_output, context, value & 0xFF) != 0))
 	{
 		/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-		result = __FAILURE__;
+        LogError("Failed encoding timestamp");
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -2764,7 +2983,8 @@ static int encode_uuid(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, u
 		(output_bytes(encoder_output, context, uuid, 16)  != 0))
 	{
 		/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-		result = __FAILURE__;
+        LogError("Failed encoding uuid");
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -2786,7 +3006,8 @@ static int encode_binary(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context,
 			((length > 0) && (output_bytes(encoder_output, context, value, length) != 0)))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding binary");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2805,7 +3026,8 @@ static int encode_binary(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context,
 			(output_bytes(encoder_output, context, value, length) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding binary");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2830,7 +3052,8 @@ static int encode_string(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context,
 			(output_bytes(encoder_output, context, value, length) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding string");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2849,7 +3072,8 @@ static int encode_string(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context,
 			(output_bytes(encoder_output, context, value, length) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding string");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2874,7 +3098,8 @@ static int encode_symbol(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context,
 			(output_bytes(encoder_output, context, value, length) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding symbol");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2894,7 +3119,8 @@ static int encode_symbol(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context,
 			(output_bytes(encoder_output, context, value, length) != 0))
 		{
 			/* Codes_SRS_AMQPVALUE_01_274: [When the encoder output function fails, amqpvalue_encode shall fail and return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Failed encoding symbol");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -2936,7 +3162,7 @@ static int encode_list(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, u
 			size_t item_size;
 			if (amqpvalue_get_encoded_size(items[i], &item_size) != 0)
 			{
-                LogError("Could not get encoded size for element %zu of the list", i);
+                LogError("Could not get encoded size for element %u of the list", (unsigned int)i);
 				break;
 			}
 
@@ -3012,13 +3238,13 @@ static int encode_list(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, u
 				{
 					if (amqpvalue_encode(items[i], encoder_output, context) != 0)
 					{
-						break;
+                        break;
 					}
 				}
 
 				if (i < count)
 				{
-                    LogError("Failed encoding element %zu of the list", i);
+                    LogError("Failed encoding element %u of the list", (unsigned int)i);
 					result = __FAILURE__;
 				}
 				else
@@ -3048,7 +3274,7 @@ static int encode_map(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, ui
 		size_t item_size;
 		if (amqpvalue_get_encoded_size(pairs[i].key, &item_size) != 0)
 		{
-            LogError("Could not get encoded size for key element %zu of the map", i);
+            LogError("Could not get encoded size for key element %u of the map", (unsigned int)i);
 			break;
 		}
 
@@ -3063,7 +3289,7 @@ static int encode_map(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, ui
 
 		if (amqpvalue_get_encoded_size(pairs[i].value, &item_size) != 0)
 		{
-            LogError("Could not get encoded size for value element %zu of the map", i);
+            LogError("Could not get encoded size for value element %u of the map", (unsigned int)i);
 			break;
 		}
 
@@ -3141,7 +3367,8 @@ static int encode_map(AMQPVALUE_ENCODER_OUTPUT encoder_output, void* context, ui
 				if ((amqpvalue_encode(pairs[i].key, encoder_output, context) != 0) ||
 					(amqpvalue_encode(pairs[i].value, encoder_output, context) != 0))
 				{
-					break;
+                    LogError("Failed encoding map element %u", (unsigned int)i);
+                    break;
 				}
 			}
 
@@ -3164,8 +3391,15 @@ static int encode_descriptor_header(AMQPVALUE_ENCODER_OUTPUT encoder_output, voi
 {
 	int result;
 
-	output_byte(encoder_output, context, 0x00);
-	result = 0;
+    if (output_byte(encoder_output, context, 0x00) != 0)
+    {
+        LogError("Failed encoding descriptor header");
+        result = __FAILURE__;
+    }
+    else
+    {
+        result = 0;
+    }
 
 	return result;
 }
@@ -3179,7 +3413,9 @@ int amqpvalue_encode(AMQP_VALUE value, AMQPVALUE_ENCODER_OUTPUT encoder_output, 
 	if ((value == NULL) ||
 		(encoder_output == NULL))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: value = %p, encoder_output = %p",
+            value, encoder_output);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -3189,7 +3425,8 @@ int amqpvalue_encode(AMQP_VALUE value, AMQPVALUE_ENCODER_OUTPUT encoder_output, 
 		{
 		default:
 			/* Codes_SRS_AMQPVALUE_01_271: [If encoding fails due to any error not specifically mentioned here, it shall return a non-zero value.] */
-			result = __FAILURE__;
+            LogError("Invalid type: %d", (int)value_data->type);
+            result = __FAILURE__;
 			break;
 
 		case AMQP_TYPE_NULL:
@@ -3277,12 +3514,14 @@ int amqpvalue_encode(AMQP_VALUE value, AMQPVALUE_ENCODER_OUTPUT encoder_output, 
 				(amqpvalue_encode(value_data->value.described_value.descriptor, encoder_output, context) != 0) ||
 				(amqpvalue_encode(value_data->value.described_value.value, encoder_output, context) != 0))
 			{
-				result = __FAILURE__;
+                LogError("Failed encoding described or composite type");
+                result = __FAILURE__;
 			}
 			else
 			{
 				result = 0;
 			}
+
 			break;
 		}
 		}
@@ -3309,6 +3548,8 @@ int amqpvalue_get_encoded_size(AMQP_VALUE value, size_t* encoded_size)
     if ((value == NULL) ||
         (encoded_size == NULL))
     {
+        LogError("Bad arguments: value = %p, encoded_size = %p",
+            value, encoded_size);
         result = __FAILURE__;
     }
     else
@@ -3325,7 +3566,8 @@ static void amqpvalue_clear(AMQP_VALUE_DATA* value_data)
 	switch (value_data->type)
 	{
 	default:
-		break;
+        break;
+
 	case AMQP_TYPE_BINARY:
 		if (value_data->value.binary_value.bytes != NULL)
 		{
@@ -3394,8 +3636,12 @@ static void amqpvalue_clear(AMQP_VALUE_DATA* value_data)
 void amqpvalue_destroy(AMQP_VALUE value)
 {
 	/* Codes_SRS_AMQPVALUE_01_315: [If the value argument is NULL, amqpvalue_destroy shall do nothing.] */
-	if (value != NULL)
-	{
+    if (value == NULL)
+    {
+        LogError("NULL value");
+    }
+    else
+    {
 		/* Codes_SRS_AMQPVALUE_01_314: [amqpvalue_destroy shall free all resources allocated by any of the amqpvalue_create_xxx functions or amqpvalue_clone.] */
 		AMQP_VALUE_DATA* value_data = (AMQP_VALUE_DATA*)value;
 		amqpvalue_clear(value_data);
@@ -3406,8 +3652,12 @@ void amqpvalue_destroy(AMQP_VALUE value)
 static INTERNAL_DECODER_DATA* internal_decoder_create(ON_VALUE_DECODED on_value_decoded, void* callback_context, AMQP_VALUE_DATA* value_data)
 {
 	INTERNAL_DECODER_DATA* internal_decoder_data = (INTERNAL_DECODER_DATA*)malloc(sizeof(INTERNAL_DECODER_DATA));
-	if (internal_decoder_data != NULL)
-	{
+    if (internal_decoder_data == NULL)
+    {
+        LogError("Cannot allocate memory for internal decoder structure");
+    }
+    else
+    {
 		internal_decoder_data->on_value_decoded = on_value_decoded;
 		internal_decoder_data->on_value_decoded_context = callback_context;
 		internal_decoder_data->decoder_state = DECODER_STATE_CONSTRUCTOR;
@@ -3430,21 +3680,23 @@ static void internal_decoder_destroy(INTERNAL_DECODER_DATA* internal_decoder)
 static void inner_decoder_callback(void* context, AMQP_VALUE decoded_value)
 {
     /* API issue: the decoded_value should be removed completely:
-    Filed: uAMQP: inner_decoder_callback in amqpvalue.c could probably do without the decoded_value ... */
+    TODO: uAMQP: inner_decoder_callback in amqpvalue.c could probably do without the decoded_value ... */
     (void)decoded_value;
 	INTERNAL_DECODER_DATA* internal_decoder_data = (INTERNAL_DECODER_DATA*)context;
 	INTERNAL_DECODER_DATA* inner_decoder = (INTERNAL_DECODER_DATA*)internal_decoder_data->inner_decoder;
 	inner_decoder->decoder_state = DECODER_STATE_DONE;
 }
 
-int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, const unsigned char* buffer, size_t size, size_t* used_bytes)
+static int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, const unsigned char* buffer, size_t size, size_t* used_bytes)
 {
 	int result;
 	size_t initial_size = size;
 
 	if (internal_decoder_data == NULL)
 	{
-		result = __FAILURE__;
+        /* TODO: investigate if this check is even needed */
+        LogError("NULL internal_decoder_data");
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -3455,8 +3707,10 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 			switch (internal_decoder_data->decoder_state)
 			{
 			default:
+                LogError("Invalid decoder state: %d", (int)internal_decoder_data->decoder_state);
 				result = __FAILURE__;
 				break;
+
 			case DECODER_STATE_CONSTRUCTOR:
 			{
 				amqpvalue_clear(internal_decoder_data->decode_to_value);
@@ -3468,15 +3722,18 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 				{
 				default:
 					internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-					result = __FAILURE__;
+                    LogError("Invalid constructor byte: 0x%02x", internal_decoder_data->constructor_byte);
+                    result = __FAILURE__;
 					break;
+
 				case 0x00: /* descriptor */
 					internal_decoder_data->decode_to_value->type = AMQP_TYPE_DESCRIBED;
 					AMQP_VALUE_DATA* descriptor = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
 					if (descriptor == NULL)
 					{
 						internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-						result = __FAILURE__;
+                        LogError("Could not allocate memory for descriptor");
+                        result = __FAILURE__;
 					}
 					else
 					{
@@ -3486,7 +3743,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 						if (internal_decoder_data->inner_decoder == NULL)
 						{
 							internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-							result = __FAILURE__;
+                            LogError("Could not create inner decoder for descriptor");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -3887,8 +4145,9 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 				switch (internal_decoder_data->constructor_byte)
 				{
 				default:
-					result = __FAILURE__;
-					break;
+                    LogError("Invalid constructor byte: 0x%02x", internal_decoder_data->constructor_byte);
+                    result = __FAILURE__;
+                    break;
 
 				case 0x00: /* descriptor */
 				{
@@ -3896,7 +4155,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 					switch (step)
 					{
 					default:
-						result = __FAILURE__;
+                        LogError("Invalid described value decode step: %d", step);
+                        result = __FAILURE__;
 						break;
 
 					case DECODE_DESCRIBED_VALUE_STEP_DESCRIPTOR:
@@ -3904,7 +4164,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 						size_t inner_used_bytes;
 						if (internal_decoder_decode_bytes(internal_decoder_data->inner_decoder, buffer, size, &inner_used_bytes) != 0)
 						{
-							result = __FAILURE__;
+                            LogError("Decoding bytes for described value failed");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -3920,7 +4181,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 								if (described_value == NULL)
 								{
 									internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-									result = __FAILURE__;
+                                    LogError("Could not allocate memory for AMQP value");
+                                    result = __FAILURE__;
 								}
 								else
 								{
@@ -3930,7 +4192,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 									if (internal_decoder_data->inner_decoder == NULL)
 									{
 										internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-										result = __FAILURE__;
+                                        LogError("Could not create inner decoder");
+                                        result = __FAILURE__;
 									}
 									else
 									{
@@ -3951,7 +4214,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 						size_t inner_used_bytes;
 						if (internal_decoder_decode_bytes(internal_decoder_data->inner_decoder, buffer, size, &inner_used_bytes) != 0)
 						{
-							result = __FAILURE__;
+                            LogError("Decoding bytes for described value failed");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -3980,7 +4244,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 					/* Codes_SRS_AMQPVALUE_01_331: [<encoding code="0x56" category="fixed" width="1" label="boolean with the octet 0x00 being false and octet 0x01 being true"/>] */
 					if (buffer[0] >= 2)
 					{
-						result = __FAILURE__;
+                        LogError("Bad boolean value: %02X", buffer[0]);
+                        result = __FAILURE__;
 					}
 					else
 					{
@@ -4338,8 +4603,9 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 							internal_decoder_data->decode_to_value->value.binary_value.bytes = (unsigned char*)malloc(internal_decoder_data->decode_to_value->value.binary_value.length);
 							if (internal_decoder_data->decode_to_value->value.binary_value.bytes == NULL)
 							{
-								/* Codes_SRS_AMQPVALUE_01_326: [If any allocation failure occurs during decoding, amqpvalue_decode_bytes shall fail and return a non-zero value.] */
-								internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
+                                /* Codes_SRS_AMQPVALUE_01_326: [If any allocation failure occurs during decoding, amqpvalue_decode_bytes shall fail and return a non-zero value.] */
+                                LogError("Cannot allocate memory for decoded binary value");
+                                internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
 								result = __FAILURE__;
 							}
 							else
@@ -4406,7 +4672,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 								{
 									/* Codes_SRS_AMQPVALUE_01_326: [If any allocation failure occurs during decoding, amqpvalue_decode_bytes shall fail and return a non-zero value.] */
 									internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-									result = __FAILURE__;
+                                    LogError("Cannot allocate memory for decoded binary value");
+                                    result = __FAILURE__;
 								}
 								else
 								{
@@ -4430,7 +4697,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 						if (memcpy((unsigned char*)(internal_decoder_data->decode_to_value->value.binary_value.bytes) + (internal_decoder_data->bytes_decoded - 4), buffer, to_copy) == NULL)
 						{
 							internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-							result = __FAILURE__;
+                            LogError("Could not copy memory");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -4465,7 +4733,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 						{
 							/* Codes_SRS_AMQPVALUE_01_326: [If any allocation failure occurs during decoding, amqpvalue_decode_bytes shall fail and return a non-zero value.] */
 							internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-							result = __FAILURE__;
+                            LogError("Could not allocate memory for decoded string value");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -4493,7 +4762,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 						if (memcpy(internal_decoder_data->decode_to_value->value.string_value.chars + (internal_decoder_data->bytes_decoded - 1), buffer, to_copy) == NULL)
 						{
 							internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-							result = __FAILURE__;
+                            LogError("Could not copy memory");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -4534,7 +4804,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 							{
 								/* Codes_SRS_AMQPVALUE_01_326: [If any allocation failure occurs during decoding, amqpvalue_decode_bytes shall fail and return a non-zero value.] */
 								internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-								result = __FAILURE__;
+                                LogError("Could not allocate memory for decoded string value");
+                                result = __FAILURE__;
 							}
 							else
 							{
@@ -4567,7 +4838,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 						if (memcpy(internal_decoder_data->decode_to_value->value.string_value.chars + (internal_decoder_data->bytes_decoded - 4), buffer, to_copy) == NULL)
 						{
 							internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-							result = __FAILURE__;
+                            LogError("Could not copy memory");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -4606,7 +4878,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 						{
 							/* Codes_SRS_AMQPVALUE_01_326: [If any allocation failure occurs during decoding, amqpvalue_decode_bytes shall fail and return a non-zero value.] */
 							internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-							result = __FAILURE__;
+                            LogError("Could not allocate memory for decoded symbol value");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -4634,7 +4907,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 						if (memcpy(internal_decoder_data->decode_to_value->value.symbol_value.chars + (internal_decoder_data->bytes_decoded - 1), buffer, to_copy) == NULL)
 						{
 							internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-							result = __FAILURE__;
+                            LogError("Could not copy memory");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -4675,7 +4949,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 							{
 								/* Codes_SRS_AMQPVALUE_01_326: [If any allocation failure occurs during decoding, amqpvalue_decode_bytes shall fail and return a non-zero value.] */
 								internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-								result = __FAILURE__;
+                                LogError("Could not allocate memory for decoded symbol value");
+                                result = __FAILURE__;
 							}
 							else
 							{
@@ -4708,7 +4983,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 						if (memcpy(internal_decoder_data->decode_to_value->value.symbol_value.chars + (internal_decoder_data->bytes_decoded - 4), buffer, to_copy) == NULL)
 						{
 							internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-							result = __FAILURE__;
+                            LogError("Could not copy memory");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -4742,7 +5018,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 					switch (step)
 					{
 					default:
-						result = __FAILURE__;
+                        LogError("Invalid step in decoding list value: %d", step);
+                        result = __FAILURE__;
 						break;
 
 					case DECODE_LIST_STEP_SIZE:
@@ -4765,6 +5042,7 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 								internal_decoder_data->bytes_decoded = 0;
 								internal_decoder_data->decode_to_value->value.list_value.count = 0;
 							}
+
 							result = 0;
 						}
 
@@ -4779,6 +5057,7 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 						{
 							internal_decoder_data->decode_to_value->value.list_value.count += buffer[0] << ((3 - internal_decoder_data->bytes_decoded) * 8);
 						}
+
 						internal_decoder_data->bytes_decoded++;
 						buffer++;
 						size--;
@@ -4801,7 +5080,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 								internal_decoder_data->decode_to_value->value.list_value.items = (AMQP_VALUE*)malloc(sizeof(AMQP_VALUE) * internal_decoder_data->decode_to_value->value.list_value.count);
 								if (internal_decoder_data->decode_to_value->value.list_value.items == NULL)
 								{
-									result = __FAILURE__;
+                                    LogError("Could not allocate memory for decoded list value");
+                                    result = __FAILURE__;
 								}
 								else
 								{
@@ -4835,10 +5115,12 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 								else
 								{
 									uint32_t i;
+
 									internal_decoder_data->decode_to_value->value.list_value.items = (AMQP_VALUE*)malloc(sizeof(AMQP_VALUE) * internal_decoder_data->decode_to_value->value.list_value.count);
 									if (internal_decoder_data->decode_to_value->value.list_value.items == NULL)
 									{
-										result = __FAILURE__;
+                                        LogError("Could not allocate memory for decoded list value");
+                                        result = __FAILURE__;
 									}
 									else
 									{
@@ -4846,6 +5128,7 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 										{
 											internal_decoder_data->decode_to_value->value.list_value.items[i] = NULL;
 										}
+
 										internal_decoder_data->decode_value_state.list_value_state.list_value_state = DECODE_LIST_STEP_ITEMS;
 										internal_decoder_data->bytes_decoded = 0;
 										internal_decoder_data->inner_decoder = NULL;
@@ -4880,8 +5163,9 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 								internal_decoder_data->inner_decoder = internal_decoder_create(inner_decoder_callback, internal_decoder_data, list_item);
 								if (internal_decoder_data->inner_decoder == NULL)
 								{
-									internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-									result = __FAILURE__;
+                                    LogError("Could not create inner decoder for list items");
+                                    internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
+                                    result = __FAILURE__;
 								}
 								else
 								{
@@ -4892,11 +5176,13 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 
 						if (internal_decoder_data->inner_decoder == NULL)
 						{
-							result = __FAILURE__;
+                            LogError("NULL inner decoder. This should not happen under normal circumstances");
+                            result = __FAILURE__;
 						}
 						else if (internal_decoder_decode_bytes(internal_decoder_data->inner_decoder, buffer, size, &inner_used_bytes) != 0)
 						{
-							result = __FAILURE__;
+                            LogError("Decoding list items failed");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -4941,7 +5227,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 					switch (step)
 					{
 					default:
-						result = __FAILURE__;
+                        LogError("Invalid step in decoding map value: %d", step);
+                        result = __FAILURE__;
 						break;
 
 					case DECODE_MAP_STEP_SIZE:
@@ -5000,7 +5287,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 								internal_decoder_data->decode_to_value->value.map_value.pairs = (AMQP_MAP_KEY_VALUE_PAIR*)malloc(sizeof(AMQP_MAP_KEY_VALUE_PAIR) * (internal_decoder_data->decode_to_value->value.map_value.pair_count * 2));
 								if (internal_decoder_data->decode_to_value->value.map_value.pairs == NULL)
 								{
-									result = __FAILURE__;
+                                    LogError("Could not allocate memory for map value items");
+                                    result = __FAILURE__;
 								}
 								else
 								{
@@ -5038,7 +5326,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 									internal_decoder_data->decode_to_value->value.map_value.pairs = (AMQP_MAP_KEY_VALUE_PAIR*)malloc(sizeof(AMQP_MAP_KEY_VALUE_PAIR) * (internal_decoder_data->decode_to_value->value.map_value.pair_count * 2));
 									if (internal_decoder_data->decode_to_value->value.map_value.pairs == NULL)
 									{
-										result = __FAILURE__;
+                                        LogError("Could not allocate memory for map value items");
+                                        result = __FAILURE__;
 									}
 									else
 									{
@@ -5047,6 +5336,7 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 											internal_decoder_data->decode_to_value->value.map_value.pairs[i].key = NULL;
 											internal_decoder_data->decode_to_value->value.map_value.pairs[i].value = NULL;
 										}
+
 										internal_decoder_data->decode_value_state.map_value_state.map_value_state = DECODE_MAP_STEP_PAIRS;
 										internal_decoder_data->bytes_decoded = 0;
 										internal_decoder_data->inner_decoder = NULL;
@@ -5071,7 +5361,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 							AMQP_VALUE_DATA* map_item = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
 							if (map_item == NULL)
 							{
-								internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
+                                LogError("Could not allocate memory for map item");
+                                internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
 								result = __FAILURE__;
 							}
 							else
@@ -5088,7 +5379,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 								internal_decoder_data->inner_decoder = internal_decoder_create(inner_decoder_callback, internal_decoder_data, map_item);
 								if (internal_decoder_data->inner_decoder == NULL)
 								{
-									internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
+                                    LogError("Could not create inner decoder for map item");
+                                    internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
 									result = __FAILURE__;
 								}
 								else
@@ -5100,11 +5392,13 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 
 						if (internal_decoder_data->inner_decoder == NULL)
 						{
-							result = __FAILURE__;
+                            LogError("NULL inner decoder. This should not happen under normal circumstances");
+                            result = __FAILURE__;
 						}
 						else if (internal_decoder_decode_bytes(internal_decoder_data->inner_decoder, buffer, size, &inner_used_bytes) != 0)
 						{
-							result = __FAILURE__;
+                            LogError("Could not decode map item");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -5148,7 +5442,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 					switch (step)
 					{
 					default:
-						result = __FAILURE__;
+                        LogError("Invalid step in decoding array value: %d", step);
+                        result = __FAILURE__;
 						break;
 
 					case DECODE_ARRAY_STEP_SIZE:
@@ -5185,6 +5480,7 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 						{
 							internal_decoder_data->decode_to_value->value.array_value.count += buffer[0] << ((3 - internal_decoder_data->bytes_decoded) * 8);
 						}
+
 						internal_decoder_data->bytes_decoded++;
 						buffer++;
 						size--;
@@ -5204,7 +5500,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 								internal_decoder_data->decode_to_value->value.array_value.items = (AMQP_VALUE*)malloc(sizeof(AMQP_VALUE) * internal_decoder_data->decode_to_value->value.array_value.count);
 								if (internal_decoder_data->decode_to_value->value.array_value.items == NULL)
 								{
-									result = __FAILURE__;
+                                    LogError("Could not allocate memory for array items");
+                                    result = __FAILURE__;
 								}
 								else
 								{
@@ -5237,7 +5534,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 									internal_decoder_data->decode_to_value->value.array_value.items = (AMQP_VALUE*)malloc(sizeof(AMQP_VALUE) * internal_decoder_data->decode_to_value->value.array_value.count);
 									if (internal_decoder_data->decode_to_value->value.array_value.items == NULL)
 									{
-										result = __FAILURE__;
+                                        LogError("Could not allocate memory for array items");
+                                        result = __FAILURE__;
 									}
 									else
 									{
@@ -5271,8 +5569,9 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 							AMQP_VALUE_DATA* array_item = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
 							if (array_item == NULL)
 							{
-								internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-								result = __FAILURE__;
+                                LogError("Could not allocate memory for array item to be decoded");
+                                internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
+                                result = __FAILURE__;
 							}
 							else
 							{
@@ -5282,7 +5581,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 								if (internal_decoder_data->inner_decoder == NULL)
 								{
 									internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
-									result = __FAILURE__;
+                                    LogError("Could not create inner decoder for array items");
+                                    result = __FAILURE__;
 								}
 								else
 								{
@@ -5293,11 +5593,13 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 
 						if (internal_decoder_data->inner_decoder == NULL)
 						{
-							result = __FAILURE__;
+                            LogError("NULL inner decoder. This should not happen under normal circumstances");
+                            result = __FAILURE__;
 						}
 						else if (internal_decoder_decode_bytes(internal_decoder_data->inner_decoder, buffer, size, &inner_used_bytes) != 0)
 						{
-							result = __FAILURE__;
+                            LogError("Could not decode array item");
+                            result = __FAILURE__;
 						}
 						else
 						{
@@ -5324,7 +5626,8 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 									AMQP_VALUE_DATA* array_item = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
 									if (array_item == NULL)
 									{
-										internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
+                                        LogError("Could not allocate memory for array item");
+                                        internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
 										result = __FAILURE__;
 									}
 									else
@@ -5334,14 +5637,16 @@ int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder_data, 
 										internal_decoder_data->inner_decoder = internal_decoder_create(inner_decoder_callback, internal_decoder_data, array_item);
 										if (internal_decoder_data->inner_decoder == NULL)
 										{
-											internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
+                                            LogError("Could not create inner decoder for array item");
+                                            internal_decoder_data->decoder_state = DECODER_STATE_ERROR;
 											result = __FAILURE__;
 										}
 										else
 										{
 											if (internal_decoder_decode_bytes(internal_decoder_data->inner_decoder, &internal_decoder_data->decode_value_state.array_value_state.constructor_byte, 1, NULL) != 0)
 											{
-												result = __FAILURE__;
+                                                LogError("Could not decode array item data");
+                                                result = __FAILURE__;
 											}
 											else
 											{
@@ -5390,19 +5695,25 @@ AMQPVALUE_DECODER_HANDLE amqpvalue_decoder_create(ON_VALUE_DECODED on_value_deco
 	/* Codes_SRS_AMQPVALUE_01_312: [If the on_value_decoded argument is NULL, amqpvalue_decoder_create shall return NULL.] */
 	if (on_value_decoded == NULL)
 	{
-		decoder_instance = NULL;
+        LogError("NULL on_value_decoded");
+        decoder_instance = NULL;
 	}
 	else
 	{
 		decoder_instance = (AMQPVALUE_DECODER_HANDLE_DATA*)malloc(sizeof(AMQPVALUE_DECODER_HANDLE_DATA));
 		/* Codes_SRS_AMQPVALUE_01_313: [If creating the decoder fails, amqpvalue_decoder_create shall return NULL.] */
-		if (decoder_instance != NULL)
-		{
+        if (decoder_instance == NULL)
+        {
+            LogError("Could not allocate memory for AMQP value decoder");
+        }
+        else
+        {
 			decoder_instance->decode_to_value = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
 			if (decoder_instance->decode_to_value == NULL)
 			{
 				/* Codes_SRS_AMQPVALUE_01_313: [If creating the decoder fails, amqpvalue_decoder_create shall return NULL.] */
-				free(decoder_instance);
+                LogError("Could not allocate memory for decoded AMQP value");
+                free(decoder_instance);
 				decoder_instance = NULL;
 			}
 			else
@@ -5412,7 +5723,8 @@ AMQPVALUE_DECODER_HANDLE amqpvalue_decoder_create(ON_VALUE_DECODED on_value_deco
 				if (decoder_instance->internal_decoder == NULL)
 				{
 					/* Codes_SRS_AMQPVALUE_01_313: [If creating the decoder fails, amqpvalue_decoder_create shall return NULL.] */
-					free(decoder_instance->decode_to_value);
+                    LogError("Could not create the internal decoder");
+                    free(decoder_instance->decode_to_value);
 					free(decoder_instance);
 					decoder_instance = NULL;
 				}
@@ -5426,11 +5738,14 @@ AMQPVALUE_DECODER_HANDLE amqpvalue_decoder_create(ON_VALUE_DECODED on_value_deco
 
 void amqpvalue_decoder_destroy(AMQPVALUE_DECODER_HANDLE handle)
 {
-	AMQPVALUE_DECODER_HANDLE_DATA* decoder_instance = (AMQPVALUE_DECODER_HANDLE_DATA*)handle;
-	
-	/* Codes_SRS_AMQPVALUE_01_317: [If handle is NULL, amqpvalue_decoder_destroy shall do nothing.] */
-	if (decoder_instance != NULL)
-	{
+    if (handle == NULL)
+    {
+        /* Codes_SRS_AMQPVALUE_01_317: [If handle is NULL, amqpvalue_decoder_destroy shall do nothing.] */
+        LogError("NULL handle");
+    }
+    else
+    {
+    	AMQPVALUE_DECODER_HANDLE_DATA* decoder_instance = (AMQPVALUE_DECODER_HANDLE_DATA*)handle;
 		/* Codes_SRS_AMQPVALUE_01_316: [amqpvalue_decoder_destroy shall free all resources associated with the amqpvalue_decoder.] */
 		amqpvalue_destroy(decoder_instance->decode_to_value);
 		internal_decoder_destroy(decoder_instance->internal_decoder);
@@ -5450,7 +5765,9 @@ int amqpvalue_decode_bytes(AMQPVALUE_DECODER_HANDLE handle, const unsigned char*
 		/* Codes_SRS_AMQPVALUE_01_321: [If size is 0, amqpvalue_decode_bytes shall return a non-zero value.] */
 		(size == 0))
 	{
-		result = __FAILURE__;
+        LogError("Bad arguments: decoder_instance = %p, buffer = %p, size = %u",
+            decoder_instance, buffer, size);
+        result = __FAILURE__;
 	}
 	else
 	{
@@ -5459,7 +5776,8 @@ int amqpvalue_decode_bytes(AMQPVALUE_DECODER_HANDLE handle, const unsigned char*
 		/* Codes_SRS_AMQPVALUE_01_318: [amqpvalue_decode_bytes shall decode size bytes that are passed in the buffer argument.] */
 		if (internal_decoder_decode_bytes(decoder_instance->internal_decoder, buffer, size, &used_bytes) != 0)
 		{
-			result = __FAILURE__;
+            LogError("Failed decoding bytes");
+            result = __FAILURE__;
 		}
 		else
 		{
@@ -5477,7 +5795,8 @@ AMQP_VALUE amqpvalue_get_inplace_descriptor(AMQP_VALUE value)
 
 	if (value == NULL)
 	{
-		result = NULL;
+        LogError("NULL value");
+        result = NULL;
 	}
 	else
 	{
@@ -5485,7 +5804,8 @@ AMQP_VALUE amqpvalue_get_inplace_descriptor(AMQP_VALUE value)
 		if ((value_data->type != AMQP_TYPE_DESCRIBED) &&
 			(value_data->type != AMQP_TYPE_COMPOSITE))
 		{
-			result = NULL;
+            LogError("Type is not described or composite");
+            result = NULL;
 		}
 		else
 		{
@@ -5502,7 +5822,8 @@ AMQP_VALUE amqpvalue_get_inplace_described_value(AMQP_VALUE value)
 
 	if (value == NULL)
 	{
-		result = NULL;
+        LogError("NULL value");
+        result = NULL;
 	}
 	else
 	{
@@ -5510,7 +5831,8 @@ AMQP_VALUE amqpvalue_get_inplace_described_value(AMQP_VALUE value)
 		if ((value_data->type != AMQP_TYPE_DESCRIBED) &&
 			(value_data->type != AMQP_TYPE_COMPOSITE))
 		{
-			result = NULL;
+            LogError("Type is not described or composite");
+            result = NULL;
 		}
 		else
 		{
@@ -5524,25 +5846,35 @@ AMQP_VALUE amqpvalue_get_inplace_described_value(AMQP_VALUE value)
 AMQP_VALUE amqpvalue_create_described(AMQP_VALUE descriptor, AMQP_VALUE value)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        LogError("Cannot allocate memory for described type");
+    }
+    else
+    {
 		result->type = AMQP_TYPE_DESCRIBED;
 		result->value.described_value.descriptor = descriptor;
 		result->value.described_value.value = value;
 	}
+
 	return result;
 }
 
 AMQP_VALUE amqpvalue_create_composite(AMQP_VALUE descriptor, uint32_t list_size)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        LogError("Cannot allocate memory for composite type");
+    }
+    else
+    {
 		result->type = AMQP_TYPE_COMPOSITE;
 		result->value.described_value.descriptor = amqpvalue_clone(descriptor);
 		if (result->value.described_value.descriptor == NULL)
 		{
-			free(result);
+            LogError("Cannot clone descriptor for composite type");
+            free(result);
 			result = NULL;
 		}
 		else
@@ -5550,7 +5882,8 @@ AMQP_VALUE amqpvalue_create_composite(AMQP_VALUE descriptor, uint32_t list_size)
 			result->value.described_value.value = amqpvalue_create_list();
 			if (result->value.described_value.value == NULL)
 			{
-				amqpvalue_destroy(result->value.described_value.descriptor);
+                LogError("Cannot create list for composite type");
+                amqpvalue_destroy(result->value.described_value.descriptor);
 				free(result);
 				result = NULL;
 			}
@@ -5558,7 +5891,8 @@ AMQP_VALUE amqpvalue_create_composite(AMQP_VALUE descriptor, uint32_t list_size)
 			{
 				if (amqpvalue_set_list_item_count(result->value.described_value.value, list_size) != 0)
 				{
-					amqpvalue_destroy(result->value.described_value.descriptor);
+                    LogError("Cannot set list item count for composite type");
+                    amqpvalue_destroy(result->value.described_value.descriptor);
 					amqpvalue_destroy(result->value.described_value.value);
 					free(result);
 					result = NULL;
@@ -5573,32 +5907,30 @@ AMQP_VALUE amqpvalue_create_composite(AMQP_VALUE descriptor, uint32_t list_size)
 AMQP_VALUE amqpvalue_create_composite_with_ulong_descriptor(uint64_t descriptor)
 {
 	AMQP_VALUE_DATA* result = (AMQP_VALUE_DATA*)malloc(sizeof(AMQP_VALUE_DATA));
-	if (result != NULL)
-	{
+    if (result == NULL)
+    {
+        LogError("Cannot allocate memory for composite type");
+    }
+    else
+    {
 		AMQP_VALUE descriptor_ulong_value = amqpvalue_create_ulong(descriptor);
 		if (descriptor_ulong_value == NULL)
 		{
-			free(result);
+            LogError("Cannot create ulong descriptor for composite type");
+            free(result);
 			result = NULL;
 		}
 		else
 		{
 			result->type = AMQP_TYPE_COMPOSITE;
 			result->value.described_value.descriptor = descriptor_ulong_value;
-			if (result->value.described_value.descriptor == NULL)
+			result->value.described_value.value = amqpvalue_create_list();
+			if (result->value.described_value.value == NULL)
 			{
-				free(descriptor_ulong_value);
+                LogError("Cannot create list for composite type");
+                amqpvalue_destroy(descriptor_ulong_value);
 				free(result);
 				result = NULL;
-			}
-			else
-			{
-				result->value.described_value.value = amqpvalue_create_list();
-				if (result->value.described_value.value == NULL)
-				{
-					free(result);
-					result = NULL;
-				}
 			}
 		}
 	}
@@ -5612,20 +5944,23 @@ int amqpvalue_set_composite_item(AMQP_VALUE value, uint32_t index, AMQP_VALUE it
 
 	if (value == NULL)
 	{
-		result = __FAILURE__;
+        LogError("NULL value");
+        result = __FAILURE__;
 	}
 	else
 	{
 		AMQP_VALUE_DATA* value_data = (AMQP_VALUE_DATA*)value;
 		if (value_data->type != AMQP_TYPE_COMPOSITE)
 		{
-			result = __FAILURE__;
+            LogError("Attempt to set composite item on a non-composite type");
+            result = __FAILURE__;
 		}
 		else
 		{
 			if (amqpvalue_set_list_item(value_data->value.described_value.value, index, item_value) != 0)
 			{
-				result = __FAILURE__;
+                LogError("amqpvalue_set_list_item failed for composite item");
+                result = __FAILURE__;
 			}
 			else
 			{
@@ -5643,7 +5978,8 @@ AMQP_VALUE amqpvalue_get_composite_item(AMQP_VALUE value, size_t index)
 
 	if (value == NULL)
 	{
-		result = NULL;
+        LogError("NULL value");
+        result = NULL;
 	}
 	else
 	{
@@ -5651,11 +5987,16 @@ AMQP_VALUE amqpvalue_get_composite_item(AMQP_VALUE value, size_t index)
 		if ((value_data->type != AMQP_TYPE_COMPOSITE) &&
 			(value_data->type != AMQP_TYPE_DESCRIBED))
 		{
-			result = NULL;
+            LogError("Attempt to get composite item on a non-composite type");
+            result = NULL;
 		}
 		else
 		{
 			result = amqpvalue_get_list_item(value_data->value.described_value.value, index);
+            if (result == NULL)
+            {
+                LogError("amqpvalue_get_list_item failed for composite item");
+            }
 		}
 	}
 
@@ -5668,7 +6009,8 @@ AMQP_VALUE amqpvalue_get_composite_item_in_place(AMQP_VALUE value, size_t index)
 
 	if (value == NULL)
 	{
-		result = NULL;
+        LogError("NULL value");
+        result = NULL;
 	}
 	else
 	{
@@ -5676,15 +6018,55 @@ AMQP_VALUE amqpvalue_get_composite_item_in_place(AMQP_VALUE value, size_t index)
 		if ((value_data->type != AMQP_TYPE_COMPOSITE) &&
 			(value_data->type != AMQP_TYPE_DESCRIBED))
 		{
-			result = NULL;
+            LogError("Attempt to get composite item in place on a non-composite type");
+            result = NULL;
 		}
 		else
 		{
 			result = amqpvalue_get_list_item_in_place(value_data->value.described_value.value, index);
+            if (result == NULL)
+            {
+                LogError("amqpvalue_get_list_item_in_place failed for composite item");
+            }
 		}
 	}
 
 	return result;
+}
+
+int amqpvalue_get_composite_item_count(AMQP_VALUE value, uint32_t* item_count)
+{
+    int result;
+
+    if (value == NULL)
+    {
+        LogError("NULL value");
+        result = __FAILURE__;
+    }
+    else
+    {
+        AMQP_VALUE_DATA* value_data = (AMQP_VALUE_DATA*)value;
+        if ((value_data->type != AMQP_TYPE_COMPOSITE) &&
+            (value_data->type != AMQP_TYPE_DESCRIBED))
+        {
+            LogError("Attempt to get composite item in place on a non-composite type");
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (amqpvalue_get_list_item_count(value_data->value.described_value.value, item_count) != 0)
+            {
+                LogError("amqpvalue_get_list_item_in_place failed for composite item");
+                result = __FAILURE__;
+            }
+            else
+            {
+                result = 0;
+            }
+        }
+    }
+
+    return result;
 }
 
 AMQP_VALUE amqpvalue_get_list_item_in_place(AMQP_VALUE value, size_t index)
@@ -5693,7 +6075,8 @@ AMQP_VALUE amqpvalue_get_list_item_in_place(AMQP_VALUE value, size_t index)
 
 	if (value == NULL)
 	{
-		result = NULL;
+        LogError("NULL value");
+        result = NULL;
 	}
 	else
 	{
@@ -5702,7 +6085,8 @@ AMQP_VALUE amqpvalue_get_list_item_in_place(AMQP_VALUE value, size_t index)
 		if ((value_data->type != AMQP_TYPE_LIST) ||
 			(value_data->value.list_value.count <= index))
 		{
-			result = NULL;
+            LogError("Attempt to get list item in place on a non-list type");
+            result = NULL;
 		}
 		else
 		{

--- a/src/link.c
+++ b/src/link.c
@@ -229,7 +229,10 @@ static int send_attach(LINK_INSTANCE* link, const char* name, handle handle, rol
         attach_set_role(attach, role);
         attach_set_source(attach, link->source);
         attach_set_target(attach, link->target);
-        attach_set_properties(attach, link->attach_properties);
+        if (link->attach_properties != NULL)
+        {
+            attach_set_properties(attach, link->attach_properties);
+        }
 
         if (role == role_sender)
         {

--- a/src/message_sender.c
+++ b/src/message_sender.c
@@ -99,7 +99,16 @@ static void on_delivery_settled(void* context, delivery_number delivery_no, AMQP
 
     if (message_with_callback->on_message_send_complete != NULL)
     {
-        AMQP_VALUE descriptor = amqpvalue_get_inplace_descriptor(delivery_state);
+        AMQP_VALUE descriptor;
+        if (delivery_state != NULL)
+        {
+            descriptor = amqpvalue_get_inplace_descriptor(delivery_state);
+        }
+        else
+        {
+            descriptor = NULL;
+        }
+
         if ((descriptor == NULL) && (delivery_state != NULL))
         {
             LogError("Error getting descriptor for delivery state");
@@ -207,11 +216,15 @@ static SEND_ONE_MESSAGE_RESULT send_one_message(MESSAGE_SENDER_INSTANCE* message
 
         // application properties
         message_get_application_properties(message, &application_properties);
-        application_properties_value = amqpvalue_create_application_properties(application_properties);
         if (application_properties != NULL)
         {
+            application_properties_value = amqpvalue_create_application_properties(application_properties);
             amqpvalue_get_encoded_size(application_properties_value, &encoded_size);
             total_encoded_size += encoded_size;
+        }
+        else
+        {
+            application_properties_value = NULL;
         }
 
         result = SEND_ONE_MESSAGE_OK;
@@ -427,10 +440,22 @@ static SEND_ONE_MESSAGE_RESULT send_one_message(MESSAGE_SENDER_INSTANCE* message
             }
         }
 
-        amqpvalue_destroy(application_properties);
-        amqpvalue_destroy(application_properties_value);
-        amqpvalue_destroy(properties_amqp_value);
-        properties_destroy(properties);
+        if (application_properties != NULL)
+        {
+            amqpvalue_destroy(application_properties);
+        }
+        if (application_properties_value != NULL)
+        {
+            amqpvalue_destroy(application_properties_value);
+        }
+        if (properties_amqp_value != NULL)
+        {
+            amqpvalue_destroy(properties_amqp_value);
+        }
+        if (properties != NULL)
+        {
+            properties_destroy(properties);
+        }
     }
 
     return result;

--- a/uamqp_generator/amqp_definitions_c.cs
+++ b/uamqp_generator/amqp_definitions_c.cs
@@ -19,7 +19,7 @@ namespace amqplib_generator
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+    #line 1 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "14.0.0.0")]
     public partial class amqp_definitions_c : amqp_definitions_cBase
     {
@@ -31,7 +31,7 @@ namespace amqplib_generator
         {
             this.Write("\r\n");
             
-            #line 8 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 8 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  amqp amqp = Program.LoadAMQPTypes(); 
             
             #line default
@@ -50,706 +50,706 @@ namespace amqplib_generator
 
 ");
             
-            #line 21 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 21 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 	foreach (section section in amqp.Items.Where(item => item is section)) 
             
             #line default
             #line hidden
             
-            #line 22 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 22 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 	{ 
             
             #line default
             #line hidden
             
-            #line 23 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 23 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 		List<type> types = new List<type>(); 
             
             #line default
             #line hidden
             
-            #line 24 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 24 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 		types.AddRange(section.Items.Where(item => item is type).Cast<type>()); 
             
             #line default
             #line hidden
             
-            #line 25 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 25 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 		foreach (type type in types) 
             
             #line default
             #line hidden
             
-            #line 26 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 26 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 		{ 
             
             #line default
             #line hidden
             
-            #line 27 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 27 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 			string type_name = type.name.ToLower().Replace('-', '_'); 
             
             #line default
             #line hidden
             
-            #line 28 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 28 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 			if (type.@class == typeClass.composite) 
             
             #line default
             #line hidden
             
-            #line 29 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 29 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 			{ 
             
             #line default
             #line hidden
             
-            #line 30 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 30 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				var descriptor = type.Items.Where(item => item is descriptor).First() as descriptor; 
             
             #line default
             #line hidden
             this.Write("/* ");
             
-            #line 31 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 31 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type.name));
             
             #line default
             #line hidden
             this.Write(" */\r\n\r\ntypedef struct ");
             
-            #line 33 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 33 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE_TAG\r\n{\r\n\tAMQP_VALUE composite_value;\r\n} ");
             
-            #line 36 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 36 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE;\r\n\r\n");
             
-            #line 38 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 38 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				string arg_list = Program.GetMandatoryArgList(type); 
             
             #line default
             #line hidden
             
-            #line 39 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 39 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				KeyValuePair<field, int>[] mandatory_args = Program.GetMandatoryArgs(type).ToArray(); 
             
             #line default
             #line hidden
             this.Write("static ");
             
-            #line 40 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 40 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 40 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 40 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_create_internal(void)\r\n{\r\n\t");
             
-            #line 42 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 42 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 42 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 42 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 42 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 42 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)malloc(sizeof(");
             
-            #line 42 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 42 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE));\r\n\tif (");
             
-            #line 43 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 43 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance != NULL)\r\n\t{\r\n\t\t");
             
-            #line 45 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 45 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value = NULL;\r\n\t}\r\n\r\n\treturn ");
             
-            #line 48 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 48 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance;\r\n}\r\n\r\n");
             
-            #line 51 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 51 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 51 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 51 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_create(");
             
-            #line 51 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 51 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(arg_list));
             
             #line default
             #line hidden
             this.Write(")\r\n{\r\n\t");
             
-            #line 53 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 53 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 53 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 53 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 53 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 53 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)malloc(sizeof(");
             
-            #line 53 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 53 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE));\r\n\tif (");
             
-            #line 54 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 54 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance != NULL)\r\n\t{\r\n\t\t");
             
-            #line 56 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 56 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value = amqpvalue_create_composite_with_ulong_descriptor(");
             
-            #line 56 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 56 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Program.GetDescriptorCode(Program.GetDescriptor(type))));
             
             #line default
             #line hidden
             this.Write(");\r\n\t\tif (");
             
-            #line 57 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 57 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value == NULL)\r\n\t\t{\r\n\t\t\tfree(");
             
-            #line 59 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 59 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance);\r\n\t\t\t");
             
-            #line 60 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 60 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = NULL;\r\n\t\t}\r\n");
             
-            #line 62 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 62 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				if (mandatory_args.Count() > 0) 
             
             #line default
             #line hidden
             
-            #line 63 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 63 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				{ 
             
             #line default
             #line hidden
             this.Write("\t\telse\r\n\t\t{\r\n");
             
-            #line 66 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 66 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					for (int i = 0; i < mandatory_args.Count(); i++) 
             
             #line default
             #line hidden
             
-            #line 67 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 67 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					{ 
             
             #line default
             #line hidden
             
-            #line 68 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 68 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 						string mandatory_arg_name = mandatory_args[i].Key.name.ToLower().Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             this.Write("\t\t\tAMQP_VALUE ");
             
-            #line 69 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 69 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_arg_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value;\r\n");
             
-            #line 70 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 70 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					} 
             
             #line default
             #line hidden
             this.Write("\t\t\tint result = 0;\r\n\r\n");
             
-            #line 73 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 73 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					for (int i = 0; i < mandatory_args.Count(); i++) 
             
             #line default
             #line hidden
             
-            #line 74 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 74 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					{ 
             
             #line default
             #line hidden
             
-            #line 75 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 75 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 						string mandatory_arg_type = Program.GetCType(mandatory_args[i].Key.type.ToLower(), mandatory_args[i].Key.multiple == "true").Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             
-            #line 76 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 76 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 						string mandatory_arg_name = mandatory_args[i].Key.name.ToLower().Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             
-            #line 77 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 77 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 						if (mandatory_args[i].Key.multiple != "true") 
             
             #line default
             #line hidden
             
-            #line 78 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 78 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 						{ 
             
             #line default
             #line hidden
             this.Write("\t\t\t");
             
-            #line 79 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 79 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_arg_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value = amqpvalue_create_");
             
-            #line 79 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 79 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_args[i].Key.type.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 79 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 79 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_args[i].Key.name.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("_value);\r\n");
             
-            #line 80 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 80 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 						} 
             
             #line default
             #line hidden
             
-            #line 81 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 81 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 						else 
             
             #line default
             #line hidden
             
-            #line 82 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 82 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 						{ 
             
             #line default
             #line hidden
             this.Write("\t\t\t");
             
-            #line 83 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 83 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_arg_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value = ");
             
-            #line 83 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 83 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_args[i].Key.name.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("_value;\r\n");
             
-            #line 84 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 84 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 						} 
             
             #line default
             #line hidden
             this.Write("\t\t\tif ((result == 0) && (amqpvalue_set_composite_item(");
             
-            #line 85 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 85 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value, ");
             
-            #line 85 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 85 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_args[i].Value));
             
             #line default
             #line hidden
             this.Write(", ");
             
-            #line 85 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 85 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_arg_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value) != 0))\r\n\t\t\t{\r\n\t\t\t\tresult = __FAILURE__;\r\n\t\t\t}\r\n");
             
-            #line 89 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 89 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					} 
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 91 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 91 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					for (int i = 0; i < mandatory_args.Count(); i++) 
             
             #line default
             #line hidden
             
-            #line 92 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 92 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					{ 
             
             #line default
             #line hidden
             
-            #line 93 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 93 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 						string mandatory_arg_name = mandatory_args[i].Key.name.ToLower().Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             this.Write("\t\t\tamqpvalue_destroy(");
             
-            #line 94 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 94 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_arg_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value);\r\n");
             
-            #line 95 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 95 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					} 
             
             #line default
             #line hidden
             this.Write("\t\t}\r\n");
             
-            #line 97 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 97 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				} 
             
             #line default
             #line hidden
             this.Write("\t}\r\n\r\n\treturn ");
             
-            #line 100 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 100 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance;\r\n}\r\n\r\n");
             
-            #line 103 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 103 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 103 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 103 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_clone(");
             
-            #line 103 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 103 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE value)\r\n{\r\n\t");
             
-            #line 105 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 105 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 105 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 105 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 105 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 105 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)malloc(sizeof(");
             
-            #line 105 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 105 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE));\r\n\tif (");
             
-            #line 106 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 106 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance != NULL)\r\n\t{\r\n\t\t");
             
-            #line 108 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 108 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value = amqpvalue_clone(((");
             
-            #line 108 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 108 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)value)->composite_value);\r\n\t\tif (");
             
-            #line 109 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 109 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value == NULL)\r\n\t\t{\r\n\t\t\tfree(");
             
-            #line 111 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 111 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance);\r\n\t\t\t");
             
-            #line 112 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 112 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = NULL;\r\n\t\t}\r\n\t}\r\n\r\n\treturn ");
             
-            #line 116 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 116 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance;\r\n}\r\n\r\nvoid ");
             
-            #line 119 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 119 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_destroy(");
             
-            #line 119 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 119 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 119 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 119 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(")\r\n{\r\n\tif (");
             
-            #line 121 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 121 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(" != NULL)\r\n\t{\r\n\t\t");
             
-            #line 123 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 123 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 123 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 123 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 123 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 123 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)");
             
-            #line 123 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 123 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(";\r\n\t\tamqpvalue_destroy(");
             
-            #line 124 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 124 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value);\r\n\t\tfree(");
             
-            #line 125 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 125 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance);\r\n\t}\r\n}\r\n\r\nAMQP_VALUE amqpvalue_create_");
             
-            #line 129 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 129 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 129 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 129 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 129 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 129 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(")\r\n{\r\n\tAMQP_VALUE result;\r\n\r\n\tif (");
             
-            #line 133 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 133 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(" == NULL)\r\n\t{\r\n\t\tresult = NULL;\r\n\t}\r\n\telse\r\n\t{\r\n\t\t");
             
-            #line 139 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 139 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 139 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 139 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 139 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 139 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)");
             
-            #line 139 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 139 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(";\r\n\t\tresult = amqpvalue_clone(");
             
-            #line 140 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 140 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value);\r\n\t}\r\n\r\n\treturn result;\r\n}\r\n\r\nbool is_");
             
-            #line 146 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 146 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
@@ -758,7 +758,7 @@ namespace amqplib_generator
                     "tor_ulong;\r\n\tif ((amqpvalue_get_ulong(descriptor, &descriptor_ulong) == 0) &&\r\n\t" +
                     "\t(descriptor_ulong == ");
             
-            #line 152 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 152 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Program.GetDescriptorCode(descriptor).ToString()));
             
             #line default
@@ -766,70 +766,70 @@ namespace amqplib_generator
             this.Write("))\r\n\t{\r\n\t\tresult = true;\r\n\t}\r\n\telse\r\n\t{\r\n\t\tresult = false;\r\n\t}\r\n\r\n\treturn result;" +
                     "\r\n}\r\n\r\n\r\nint amqpvalue_get_");
             
-            #line 165 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 165 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("(AMQP_VALUE value, ");
             
-            #line 165 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 165 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE* ");
             
-            #line 165 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 165 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("_handle)\r\n{\r\n\tint result;\r\n\t");
             
-            #line 168 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 168 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 168 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 168 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 168 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 168 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)");
             
-            #line 168 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 168 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_create_internal();\r\n\t*");
             
-            #line 169 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 169 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("_handle = ");
             
-            #line 169 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 169 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("_instance;\r\n\tif (*");
             
-            #line 170 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 170 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -838,1000 +838,1199 @@ namespace amqplib_generator
                     "alue = amqpvalue_get_inplace_described_value(value);\r\n\t\tif (list_value == NULL)\r" +
                     "\n\t\t{\r\n\t\t\t");
             
-            #line 179 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 179 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_destroy(*");
             
-            #line 179 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 179 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
-            this.Write("_handle);\r\n\t\t\tresult = __FAILURE__;\r\n\t\t}\r\n\t\telse\r\n\t\t{\r\n\t\t\tdo\r\n\t\t\t{\r\n");
+            this.Write(@"_handle);
+			result = __FAILURE__;
+		}
+		else
+		{
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
+");
             
-            #line 186 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 193 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				int k = 0; 
             
             #line default
             #line hidden
             
-            #line 187 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 194 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				bool first_one = true; 
             
             #line default
             #line hidden
             
-            #line 188 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 195 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				foreach (field field in type.Items.Where(item => item is field)) 
             
             #line default
             #line hidden
             
-            #line 189 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 196 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				{ 
             
             #line default
             #line hidden
             
-            #line 190 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 197 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					string field_name = field.name.ToLower().Replace('-', '_'); 
             
             #line default
             #line hidden
             
-            #line 191 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 198 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					string c_type = Program.GetCType(field.type, false).Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             
-            #line 192 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 199 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					type field_type = Program.GetTypeByName(types, field.type); 
             
             #line default
             #line hidden
             
-            #line 193 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 200 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					if ((field_type != null) && (field_type.@class == typeClass.composite)) c_type = field_type.name.ToUpper().Replace('-', '_').Replace(':', '_') + "_HANDLE"; 
             
             #line default
             #line hidden
             
-            #line 194 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 201 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					if (first_one) 
             
             #line default
             #line hidden
             
-            #line 195 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 202 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					{ 
             
             #line default
             #line hidden
             
-            #line 196 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 203 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 						first_one = false; 
             
             #line default
             #line hidden
-            this.Write("\t\t\t\tAMQP_VALUE item_value;\r\n");
+            this.Write("    \t\t\t\tAMQP_VALUE item_value;\r\n");
             
-            #line 198 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 205 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					} 
             
             #line default
             #line hidden
-            this.Write("\t\t\t\t/* ");
+            this.Write("\t\t\t\t    /* ");
             
-            #line 199 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 206 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.name));
             
             #line default
             #line hidden
-            this.Write(" */\r\n\t\t\t\titem_value = amqpvalue_get_list_item(list_value, ");
+            this.Write(" */\r\n\t\t\t\t    if (list_item_count > ");
             
-            #line 200 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 207 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(k));
             
             #line default
             #line hidden
-            this.Write(");\r\n\t\t\t\tif (item_value == NULL)\r\n\t\t\t\t{\r\n");
+            this.Write(")\r\n                    {\r\n                        item_value = amqpvalue_get_list" +
+                    "_item(list_value, ");
             
-            #line 203 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 209 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(k));
+            
+            #line default
+            #line hidden
+            this.Write(");\r\n\t\t\t\t        if (item_value == NULL)\r\n\t\t\t\t        {\r\n");
+            
+            #line 212 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  					if (field.mandatory == "true") 
             
             #line default
             #line hidden
             
-            #line 204 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 213 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  					{ 
             
             #line default
             #line hidden
-            this.Write("\t\t\t\t\t{\r\n\t\t\t\t\t\t");
+            this.Write("\t\t\t\t\t        {\r\n\t\t\t\t\t\t        ");
             
-            #line 206 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 215 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_destroy(*");
             
-            #line 206 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 215 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
-            this.Write("_handle);\r\n\t\t\t\t\t\tresult = __FAILURE__;\r\n\t\t\t\t\t\tbreak;\r\n\t\t\t\t\t}\r\n");
+            this.Write("_handle);\r\n\t\t\t\t\t\t        result = __FAILURE__;\r\n\t\t\t\t\t\t        break;\r\n\t\t\t\t\t      " +
+                    "  }\r\n");
             
-            #line 210 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 219 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  					} 
             
             #line default
             #line hidden
             
-            #line 211 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 220 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  					else 
             
             #line default
             #line hidden
             
-            #line 212 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 221 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  					{ 
             
             #line default
             #line hidden
-            this.Write("\t\t\t\t\t/* do nothing */\r\n");
+            this.Write("\t\t\t\t\t        /* do nothing */\r\n");
             
-            #line 214 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 223 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  					} 
             
             #line default
             #line hidden
-            this.Write("\t\t\t\t}\r\n\t\t\t\telse\r\n\t\t\t\t{\r\n");
+            this.Write("\t\t\t\t        }\r\n\t\t\t\t        else\r\n\t\t\t\t        {\r\n");
             
-            #line 218 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 227 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  if (field.type != "*") 
             
             #line default
             #line hidden
             
-            #line 219 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 228 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  { 
             
             #line default
             #line hidden
-            this.Write("\t\t\t\t\t");
+            this.Write("\t\t\t\t\t        ");
             
-            #line 220 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 229 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(c_type));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 220 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 229 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
-            this.Write(";\r\n");
+            this.Write(";\r\n\t\t\t\t\t\t    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)\r\n\t\t\t\t\t\t    {\r\n" +
+                    "");
             
-            #line 221 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 232 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+ 					if (field.mandatory == "true") 
+            
+            #line default
+            #line hidden
+            
+            #line 233 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+ 					{ 
+            
+            #line default
+            #line hidden
+            this.Write("\t\t\t\t\t\t        ");
+            
+            #line 234 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
+            
+            #line default
+            #line hidden
+            this.Write("_destroy(*");
+            
+            #line 234 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
+            
+            #line default
+            #line hidden
+            this.Write("_handle);\r\n\t\t\t\t\t\t        result = __FAILURE__;\r\n\t\t\t\t\t\t        break;\r\n");
+            
+            #line 237 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+ 					} 
+            
+            #line default
+            #line hidden
+            
+            #line 238 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+ 					else 
+            
+            #line default
+            #line hidden
+            
+            #line 239 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+ 					{ 
+            
+            #line default
+            #line hidden
+            this.Write("\t\t\t\t\t\t        /* no error, field is not mandatory */\r\n");
+            
+            #line 241 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+ 					} 
+            
+            #line default
+            #line hidden
+            this.Write("                            }\r\n                            else\r\n                " +
+                    "            {\r\n");
+            
+            #line 245 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 		if (field.multiple != "true") 
             
             #line default
             #line hidden
             
-            #line 222 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 246 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 		{ 
             
             #line default
             #line hidden
-            this.Write("\t\t\t\t\tif (amqpvalue_get_");
+            this.Write("\t\t\t\t\t            if (amqpvalue_get_");
             
-            #line 223 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 247 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.type.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(item_value, &");
             
-            #line 223 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 247 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write(") != 0)\r\n");
             
-            #line 224 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 248 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 		} 
             
             #line default
             #line hidden
             
-            #line 225 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 249 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 		else 
             
             #line default
             #line hidden
             
-            #line 226 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 250 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 		{ 
             
             #line default
             #line hidden
-            this.Write("\t\t\t\t\tAMQP_VALUE ");
+            this.Write("\t\t\t\t\t            AMQP_VALUE ");
             
-            #line 227 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 251 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
-            this.Write("_array;\r\n\t\t\t\t\tif ((amqpvalue_get_array(item_value, &");
+            this.Write("_array;\r\n\t\t\t\t\t            if ((amqpvalue_get_array(item_value, &");
             
-            #line 228 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 252 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
-            this.Write("_array) != 0) &&\r\n\t\t\t\t\t\t(amqpvalue_get_");
+            this.Write("_array) != 0) &&\r\n\t\t\t\t\t\t            (amqpvalue_get_");
             
-            #line 229 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 253 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.type.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(item_value, &");
             
-            #line 229 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 253 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write(") != 0))\r\n");
             
-            #line 230 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 254 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 		} 
             
             #line default
             #line hidden
-            this.Write("\t\t\t\t\t{\r\n");
+            this.Write("\t\t\t\t\t            {\r\n\t\t\t\t\t\t            ");
             
-            #line 232 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
- 					if (field.mandatory == "true") 
-            
-            #line default
-            #line hidden
-            
-            #line 233 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
- 					{ 
-            
-            #line default
-            #line hidden
-            this.Write("\t\t\t\t\t\t");
-            
-            #line 234 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 256 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_destroy(*");
             
-            #line 234 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 256 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
-            this.Write("_handle);\r\n\t\t\t\t\t\tresult = __FAILURE__;\r\n\t\t\t\t\t\tbreak;\r\n");
+            this.Write("_handle);\r\n\t\t\t\t\t\t            result = __FAILURE__;\r\n\t\t\t\t\t\t            break;\r\n\t\t\t" +
+                    "\t\t            }\r\n                            }\r\n\r\n");
             
-            #line 237 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
- 					} 
-            
-            #line default
-            #line hidden
-            
-            #line 238 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
- 					else 
-            
-            #line default
-            #line hidden
-            
-            #line 239 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
- 					{ 
-            
-            #line default
-            #line hidden
-            this.Write("\t\t\t\t\t\tif (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)\r\n\t\t\t\t\t\t{\r\n\t\t\t\t\t\t\t");
-            
-            #line 242 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
-            
-            #line default
-            #line hidden
-            this.Write("_destroy(*");
-            
-            #line 242 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
-            
-            #line default
-            #line hidden
-            this.Write("_handle);\r\n\t\t\t\t\t\t\tresult = __FAILURE__;\r\n\t\t\t\t\t\t\tbreak;\r\n\t\t\t\t\t\t}\r\n");
-            
-            #line 246 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
- 					} 
-            
-            #line default
-            #line hidden
-            this.Write("\t\t\t\t\t}\r\n\r\n");
-            
-            #line 249 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 262 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  } 
             
             #line default
             #line hidden
             
-            #line 250 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 263 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  else 
             
             #line default
             #line hidden
             
-            #line 251 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 264 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  { 
             
             #line default
             #line hidden
             
-            #line 252 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 265 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  } 
             
             #line default
             #line hidden
-            this.Write("\t\t\t\t\tamqpvalue_destroy(item_value);\r\n\t\t\t\t}\r\n");
+            this.Write("\t\t\t\t\t        amqpvalue_destroy(item_value);\r\n\t\t\t\t        }\r\n                    }" +
+                    "\r\n");
             
-            #line 255 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 269 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+ 					if (field.mandatory == "true") 
+            
+            #line default
+            #line hidden
+            
+            #line 270 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+ 					{ 
+            
+            #line default
+            #line hidden
+            this.Write("                    else\r\n                    {\r\n                        result =" +
+                    " __FAILURE__;\r\n                    }\r\n");
+            
+            #line 275 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+ 					} 
+            
+            #line default
+            #line hidden
+            
+            #line 276 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					k++; 
             
             #line default
             #line hidden
             
-            #line 256 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 277 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				} 
             
             #line default
             #line hidden
-            this.Write("\r\n\t\t\t\t");
+            this.Write("\r\n\t\t\t\t    ");
             
-            #line 258 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 279 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
-            this.Write("_instance->composite_value = amqpvalue_clone(value);\r\n\r\n\t\t\t\tresult = 0;\r\n\t\t\t} whi" +
-                    "le (0);\r\n\t\t}\r\n\t}\r\n\r\n\treturn result;\r\n}\r\n\r\n");
+            this.Write("_instance->composite_value = amqpvalue_clone(value);\r\n\r\n\t\t\t\t    result = 0;\r\n\t\t\t " +
+                    "   } while (0);\r\n            }\r\n\t\t}\r\n\t}\r\n\r\n\treturn result;\r\n}\r\n\r\n");
             
-            #line 268 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 290 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				int j = 0; 
             
             #line default
             #line hidden
             
-            #line 269 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 291 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				foreach (field field in type.Items.Where(item => item is field)) 
             
             #line default
             #line hidden
             
-            #line 270 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 292 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				{ 
             
             #line default
             #line hidden
             
-            #line 271 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 293 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					string field_name = field.name.ToLower().Replace('-', '_'); 
             
             #line default
             #line hidden
             
-            #line 272 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 294 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					string c_type = Program.GetCType(field.type, field.multiple == "true").Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             
-            #line 273 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 295 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					type field_type = Program.GetTypeByName(types, field.type); 
             
             #line default
             #line hidden
             
-            #line 274 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 296 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					if ((field_type != null) && (field_type.@class == typeClass.composite)) c_type = field_type.name.ToUpper().Replace('-', '_').Replace(':', '_') + "_HANDLE"; 
             
             #line default
             #line hidden
             this.Write("int ");
             
-            #line 275 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 297 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_get_");
             
-            #line 275 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 297 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 275 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 297 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 275 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 297 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(", ");
             
-            #line 275 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 297 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(c_type));
             
             #line default
             #line hidden
             this.Write("* ");
             
-            #line 275 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 297 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value)\r\n{\r\n\tint result;\r\n\r\n\tif (");
             
-            #line 279 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 301 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
-            this.Write(" == NULL)\r\n\t{\r\n\t\tresult = __FAILURE__;\r\n\t}\r\n\telse\r\n\t{\r\n\t\t");
+            this.Write(" == NULL)\r\n\t{\r\n\t\tresult = __FAILURE__;\r\n\t}\r\n\telse\r\n\t{\r\n        uint32_t item_coun" +
+                    "t;\r\n\t\t");
             
-            #line 285 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 308 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 285 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 308 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 285 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 308 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)");
             
-            #line 285 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 308 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
-            this.Write(";\r\n\t\tAMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(");
+            this.Write(";\r\n        if (amqpvalue_get_composite_item_count(");
             
-            #line 286 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 309 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
-            this.Write("_instance->composite_value, ");
+            this.Write("_instance->composite_value, &item_count) != 0)\r\n        {\r\n            result = _" +
+                    "_FAILURE__;\r\n        }\r\n        else\r\n        {\r\n            if (item_count <= ");
             
-            #line 286 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 315 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(j));
             
             #line default
             #line hidden
-            this.Write(");\r\n\t\tif (item_value == NULL)\r\n\t\t{\r\n");
+            this.Write(")\r\n            {\r\n");
             
-            #line 289 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 317 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					    if (field.@default != null) 
             
             #line default
             #line hidden
             
-            #line 290 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 318 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					    { 
             
             #line default
             #line hidden
             
-            #line 291 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 319 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 			                if ((field_type != null) && (field_type.@class == typeClass.restricted) && (field_type.Items != null)) 
             
             #line default
             #line hidden
             
-            #line 292 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 320 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					        { 
             
             #line default
             #line hidden
-            this.Write("            *");
+            this.Write("                *");
             
-            #line 293 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 321 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value = ");
             
-            #line 293 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 321 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_type.@name.Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("_");
             
-            #line 293 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 321 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.@default.Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 294 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 322 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					        } 
             
             #line default
             #line hidden
             
-            #line 295 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 323 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					        else 
             
             #line default
             #line hidden
             
-            #line 296 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 324 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					        { 
             
             #line default
             #line hidden
-            this.Write("\t\t\t*");
+            this.Write("\t\t\t    *");
             
-            #line 297 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 325 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value = ");
             
-            #line 297 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 325 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.@default));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 298 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 326 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					        } 
             
             #line default
             #line hidden
-            this.Write("            result = 0;\r\n");
+            this.Write("                result = 0;\r\n");
             
-            #line 300 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 328 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					    } 
             
             #line default
             #line hidden
             
-            #line 301 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 329 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					    else 
             
             #line default
             #line hidden
             
-            #line 302 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-					    { 
-            
-            #line default
-            #line hidden
-            this.Write("\t\t\tresult = __FAILURE__;\r\n");
-            
-            #line 304 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-					    } 
-            
-            #line default
-            #line hidden
-            this.Write("\t\t}\r\n\t\telse\r\n\t\t{\r\n");
-            
-            #line 308 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-						if (field.type.Replace('-', '_').Replace(':', '_') == "*") 
-            
-            #line default
-            #line hidden
-            
-            #line 309 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-						{ 
-            
-            #line default
-            #line hidden
-            this.Write("\t\t\t*");
-            
-            #line 310 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
-            
-            #line default
-            #line hidden
-            this.Write("_value = item_value;\r\n\t\t\tresult = 0;\r\n");
-            
-            #line 312 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-						} 
-            
-            #line default
-            #line hidden
-            
-            #line 313 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-						else 
-            
-            #line default
-            #line hidden
-            
-            #line 314 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-						{ 
-            
-            #line default
-            #line hidden
-            
-            #line 315 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-							if (field.multiple != "true") 
-            
-            #line default
-            #line hidden
-            
-            #line 316 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-							{ 
-            
-            #line default
-            #line hidden
-            this.Write("\t\t\tif (amqpvalue_get_");
-            
-            #line 317 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(field.type.Replace('-', '_').Replace(':', '_')));
-            
-            #line default
-            #line hidden
-            this.Write("(item_value, ");
-            
-            #line 317 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
-            
-            #line default
-            #line hidden
-            this.Write("_value) != 0)\r\n");
-            
-            #line 318 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-							} 
-            
-            #line default
-            #line hidden
-            
-            #line 319 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-							else 
-            
-            #line default
-            #line hidden
-            
-            #line 320 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-							{ 
-            
-            #line default
-            #line hidden
-            this.Write("\t\t\tif (amqpvalue_get_array(item_value, ");
-            
-            #line 321 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
-            
-            #line default
-            #line hidden
-            this.Write("_value) != 0)\r\n");
-            
-            #line 322 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-							} 
-            
-            #line default
-            #line hidden
-            this.Write("\t\t\t{\r\n");
-            
-            #line 324 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-					    if (field.@default != null) 
-            
-            #line default
-            #line hidden
-            
-            #line 325 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-					    { 
-            
-            #line default
-            #line hidden
-            this.Write("                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)\r\n          " +
-                    "      {\r\n    \t\t\t    result = __FAILURE__;\r\n                }\r\n                el" +
-                    "se\r\n                {\r\n");
-            
-            #line 332 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-			                if ((field_type != null) && (field_type.@class == typeClass.restricted) && (field_type.Items != null)) 
-            
-            #line default
-            #line hidden
-            
-            #line 333 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-					        { 
-            
-            #line default
-            #line hidden
-            this.Write("                    *");
-            
-            #line 334 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
-            
-            #line default
-            #line hidden
-            this.Write("_value = ");
-            
-            #line 334 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(field_type.@name.Replace('-', '_').Replace(':', '_')));
-            
-            #line default
-            #line hidden
-            this.Write("_");
-            
-            #line 334 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(field.@default.Replace('-', '_').Replace(':', '_')));
-            
-            #line default
-            #line hidden
-            this.Write(";\r\n");
-            
-            #line 335 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-					        } 
-            
-            #line default
-            #line hidden
-            
-            #line 336 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-					        else 
-            
-            #line default
-            #line hidden
-            
-            #line 337 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-					        { 
-            
-            #line default
-            #line hidden
-            this.Write("\t\t\t        *");
-            
-            #line 338 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
-            
-            #line default
-            #line hidden
-            this.Write("_value = ");
-            
-            #line 338 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(field.@default));
-            
-            #line default
-            #line hidden
-            this.Write(";\r\n");
-            
-            #line 339 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-					        } 
-            
-            #line default
-            #line hidden
-            this.Write("                    result = 0;\r\n                }\r\n");
-            
-            #line 342 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-					    } 
-            
-            #line default
-            #line hidden
-            
-            #line 343 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
-					    else 
-            
-            #line default
-            #line hidden
-            
-            #line 344 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 330 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					    { 
             
             #line default
             #line hidden
             this.Write("\t\t\t    result = __FAILURE__;\r\n");
             
-            #line 346 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 332 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					    } 
             
             #line default
             #line hidden
-            this.Write("\t\t\t}\r\n\t\t\telse\r\n\t\t\t{\r\n\t\t\t\tresult = 0;\r\n\t\t\t}\r\n");
+            this.Write("            }\r\n            else\r\n            {\r\n\t\t        AMQP_VALUE item_value =" +
+                    " amqpvalue_get_composite_item_in_place(");
             
-            #line 352 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 336 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
+            
+            #line default
+            #line hidden
+            this.Write("_instance->composite_value, ");
+            
+            #line 336 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(j));
+            
+            #line default
+            #line hidden
+            this.Write(");\r\n\t\t        if ((item_value == NULL) ||\r\n                    (amqpvalue_get_typ" +
+                    "e(item_value) == AMQP_TYPE_NULL))\r\n\t\t        {\r\n");
+            
+            #line 340 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					    if (field.@default != null) 
+            
+            #line default
+            #line hidden
+            
+            #line 341 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					    { 
+            
+            #line default
+            #line hidden
+            
+            #line 342 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+			                if ((field_type != null) && (field_type.@class == typeClass.restricted) && (field_type.Items != null)) 
+            
+            #line default
+            #line hidden
+            
+            #line 343 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					        { 
+            
+            #line default
+            #line hidden
+            this.Write("                    *");
+            
+            #line 344 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
+            
+            #line default
+            #line hidden
+            this.Write("_value = ");
+            
+            #line 344 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field_type.@name.Replace('-', '_').Replace(':', '_')));
+            
+            #line default
+            #line hidden
+            this.Write("_");
+            
+            #line 344 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field.@default.Replace('-', '_').Replace(':', '_')));
+            
+            #line default
+            #line hidden
+            this.Write(";\r\n");
+            
+            #line 345 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					        } 
+            
+            #line default
+            #line hidden
+            
+            #line 346 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					        else 
+            
+            #line default
+            #line hidden
+            
+            #line 347 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					        { 
+            
+            #line default
+            #line hidden
+            this.Write("\t\t\t        *");
+            
+            #line 348 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
+            
+            #line default
+            #line hidden
+            this.Write("_value = ");
+            
+            #line 348 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field.@default));
+            
+            #line default
+            #line hidden
+            this.Write(";\r\n");
+            
+            #line 349 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					        } 
+            
+            #line default
+            #line hidden
+            this.Write("                    result = 0;\r\n");
+            
+            #line 351 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					    } 
+            
+            #line default
+            #line hidden
+            
+            #line 352 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					    else 
+            
+            #line default
+            #line hidden
+            
+            #line 353 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					    { 
+            
+            #line default
+            #line hidden
+            this.Write("\t\t\t        result = __FAILURE__;\r\n");
+            
+            #line 355 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					    } 
+            
+            #line default
+            #line hidden
+            this.Write("\t\t        }\r\n\t\t        else\r\n\t\t        {\r\n");
+            
+            #line 359 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+						if (field.type.Replace('-', '_').Replace(':', '_') == "*") 
+            
+            #line default
+            #line hidden
+            
+            #line 360 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+						{ 
+            
+            #line default
+            #line hidden
+            this.Write("\t\t\t        *");
+            
+            #line 361 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
+            
+            #line default
+            #line hidden
+            this.Write("_value = item_value;\r\n\t\t\t        result = 0;\r\n");
+            
+            #line 363 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 						} 
             
             #line default
             #line hidden
-            this.Write("\t\t}\r\n\t}\r\n\r\n\treturn result;\r\n}\r\n\r\nint ");
             
-            #line 359 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 364 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+						else 
+            
+            #line default
+            #line hidden
+            
+            #line 365 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+						{ 
+            
+            #line default
+            #line hidden
+            
+            #line 366 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+							if (field.multiple != "true") 
+            
+            #line default
+            #line hidden
+            
+            #line 367 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+							{ 
+            
+            #line default
+            #line hidden
+            this.Write("\t\t\t        if (amqpvalue_get_");
+            
+            #line 368 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field.type.Replace('-', '_').Replace(':', '_')));
+            
+            #line default
+            #line hidden
+            this.Write("(item_value, ");
+            
+            #line 368 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
+            
+            #line default
+            #line hidden
+            this.Write("_value) != 0)\r\n");
+            
+            #line 369 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+							} 
+            
+            #line default
+            #line hidden
+            
+            #line 370 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+							else 
+            
+            #line default
+            #line hidden
+            
+            #line 371 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+							{ 
+            
+            #line default
+            #line hidden
+            this.Write("\t\t\t        if (amqpvalue_get_array(item_value, ");
+            
+            #line 372 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
+            
+            #line default
+            #line hidden
+            this.Write("_value) != 0)\r\n");
+            
+            #line 373 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+							} 
+            
+            #line default
+            #line hidden
+            this.Write("\t\t\t        {\r\n");
+            
+            #line 375 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					    if (field.@default != null) 
+            
+            #line default
+            #line hidden
+            
+            #line 376 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					    { 
+            
+            #line default
+            #line hidden
+            this.Write("                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)\r\n  " +
+                    "                      {\r\n    \t\t\t            result = __FAILURE__;\r\n             " +
+                    "           }\r\n                        else\r\n                        {\r\n");
+            
+            #line 383 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+			                if ((field_type != null) && (field_type.@class == typeClass.restricted) && (field_type.Items != null)) 
+            
+            #line default
+            #line hidden
+            
+            #line 384 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					        { 
+            
+            #line default
+            #line hidden
+            this.Write("                            *");
+            
+            #line 385 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
+            
+            #line default
+            #line hidden
+            this.Write("_value = ");
+            
+            #line 385 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field_type.@name.Replace('-', '_').Replace(':', '_')));
+            
+            #line default
+            #line hidden
+            this.Write("_");
+            
+            #line 385 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field.@default.Replace('-', '_').Replace(':', '_')));
+            
+            #line default
+            #line hidden
+            this.Write(";\r\n");
+            
+            #line 386 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					        } 
+            
+            #line default
+            #line hidden
+            
+            #line 387 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					        else 
+            
+            #line default
+            #line hidden
+            
+            #line 388 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					        { 
+            
+            #line default
+            #line hidden
+            this.Write("\t\t\t                *");
+            
+            #line 389 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
+            
+            #line default
+            #line hidden
+            this.Write("_value = ");
+            
+            #line 389 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field.@default));
+            
+            #line default
+            #line hidden
+            this.Write(";\r\n");
+            
+            #line 390 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					        } 
+            
+            #line default
+            #line hidden
+            this.Write("                            result = 0;\r\n                        }\r\n");
+            
+            #line 393 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					    } 
+            
+            #line default
+            #line hidden
+            
+            #line 394 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					    else 
+            
+            #line default
+            #line hidden
+            
+            #line 395 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					    { 
+            
+            #line default
+            #line hidden
+            this.Write("\t\t\t            result = __FAILURE__;\r\n");
+            
+            #line 397 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+					    } 
+            
+            #line default
+            #line hidden
+            this.Write("\t\t\t        }\r\n\t\t\t        else\r\n\t\t\t        {\r\n\t\t\t\t        result = 0;\r\n\t\t\t        " +
+                    "}\r\n");
+            
+            #line 403 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+						} 
+            
+            #line default
+            #line hidden
+            this.Write("                }\r\n            }\r\n\t\t}\r\n\t}\r\n\r\n\treturn result;\r\n}\r\n\r\nint ");
+            
+            #line 412 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_set_");
             
-            #line 359 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 412 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 359 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 412 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 359 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 412 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(", ");
             
-            #line 359 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 412 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(c_type));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 359 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 412 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value)\r\n{\r\n\tint result;\r\n\r\n\tif (");
             
-            #line 363 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 416 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(" == NULL)\r\n\t{\r\n\t\tresult = __FAILURE__;\r\n\t}\r\n\telse\r\n\t{\r\n\t\t");
             
-            #line 369 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 422 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 369 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 422 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 369 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 422 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)");
             
-            #line 369 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 422 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 370 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 423 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  if (c_type != "AMQP_VALUE") 
             
             #line default
             #line hidden
             
-            #line 371 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 424 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  { 
             
             #line default
             #line hidden
             this.Write("\t\tAMQP_VALUE ");
             
-            #line 372 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 425 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value = amqpvalue_create_");
             
-            #line 372 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 425 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.type.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 372 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 425 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value);\r\n");
             
-            #line 373 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 426 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  } 
             
             #line default
             #line hidden
             
-            #line 374 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 427 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  else 
             
             #line default
             #line hidden
             
-            #line 375 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 428 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  { 
             
             #line default
             #line hidden
             this.Write("\t\tAMQP_VALUE ");
             
-            #line 376 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 429 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
+            
+            #line default
+            #line hidden
+            this.Write("_amqp_value;\r\n        if (");
+            
+            #line 430 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
+            
+            #line default
+            #line hidden
+            this.Write("_value == NULL)\r\n        {\r\n            ");
+            
+            #line 432 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
+            
+            #line default
+            #line hidden
+            this.Write("_amqp_value = NULL;\r\n        }\r\n        else\r\n        {\r\n            ");
+            
+            #line 436 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value = amqpvalue_clone(");
             
-            #line 376 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 436 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
-            this.Write("_value);\r\n");
+            this.Write("_value);\r\n        }\r\n");
             
-            #line 377 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 438 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  } 
             
             #line default
             #line hidden
             this.Write("\t\tif (");
             
-            #line 378 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 439 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -1839,21 +2038,21 @@ namespace amqplib_generator
             this.Write("_amqp_value == NULL)\r\n\t\t{\r\n\t\t\tresult = __FAILURE__;\r\n\t\t}\r\n\t\telse\r\n\t\t{\r\n\t\t\tif (amq" +
                     "pvalue_set_composite_item(");
             
-            #line 384 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 445 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value, ");
             
-            #line 384 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 445 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(j));
             
             #line default
             #line hidden
             this.Write(", ");
             
-            #line 384 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 445 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -1861,144 +2060,144 @@ namespace amqplib_generator
             this.Write("_amqp_value) != 0)\r\n\t\t\t{\r\n\t\t\t\tresult = __FAILURE__;\r\n\t\t\t}\r\n\t\t\telse\r\n\t\t\t{\r\n\t\t\t\tres" +
                     "ult = 0;\r\n\t\t\t}\r\n\r\n\t\t\tamqpvalue_destroy(");
             
-            #line 393 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 454 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value);\r\n\t\t}\r\n\t}\r\n\r\n\treturn result;\r\n}\r\n\r\n");
             
-            #line 400 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 461 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					j++; 
             
             #line default
             #line hidden
             
-            #line 401 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 462 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				} 
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 403 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 464 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 			} 
             
             #line default
             #line hidden
             
-            #line 404 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 465 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 			else if (type.@class == typeClass.restricted) 
             
             #line default
             #line hidden
             
-            #line 405 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 466 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 			{ 
             
             #line default
             #line hidden
             
-            #line 406 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 467 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				string c_type = Program.GetCType(type.source, false).Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             
-            #line 407 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 468 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				bool hasDescriptor = (type.Items != null) && (type.Items.Where(item => item is descriptor).Count() > 0); 
             
             #line default
             #line hidden
             this.Write("/* ");
             
-            #line 408 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 469 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type.name));
             
             #line default
             #line hidden
             this.Write(" */\r\n\r\n");
             
-            #line 410 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 471 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				if (c_type != "AMQP_VALUE") 
             
             #line default
             #line hidden
             
-            #line 411 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 472 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				{ 
             
             #line default
             #line hidden
             
-            #line 412 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 473 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					if (!hasDescriptor) 
             
             #line default
             #line hidden
             
-            #line 413 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 474 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					{ 
             
             #line default
             #line hidden
             this.Write("AMQP_VALUE amqpvalue_create_");
             
-            #line 414 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 475 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 414 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 475 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write(" value)\r\n{\r\n\treturn amqpvalue_create_");
             
-            #line 416 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 477 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type.source.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(value);\r\n}\r\n");
             
-            #line 418 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 479 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					} 
             
             #line default
             #line hidden
             
-            #line 419 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 480 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					else 
             
             #line default
             #line hidden
             
-            #line 420 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 481 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					{ 
             
             #line default
             #line hidden
             this.Write("AMQP_VALUE amqpvalue_create_");
             
-            #line 421 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 482 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 421 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 482 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write(" value)\r\n{\r\n\tAMQP_VALUE result;\r\n\tAMQP_VALUE described_value = amqpvalue_create_");
             
-            #line 424 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 485 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type.source.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
@@ -2006,7 +2205,7 @@ namespace amqplib_generator
             this.Write("(value);\r\n\tif (described_value == NULL)\r\n\t{\r\n\t\tresult = NULL;\r\n\t}\r\n\telse\r\n\t{\r\n\t\tA" +
                     "MQP_VALUE descriptor = amqpvalue_create_ulong(");
             
-            #line 431 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 492 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Program.GetDescriptorCode(Program.GetDescriptor(type))));
             
             #line default
@@ -2031,7 +2230,7 @@ namespace amqplib_generator
 
 bool is_");
             
-            #line 449 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 510 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -2040,7 +2239,7 @@ bool is_");
                     "tor_ulong;\r\n\tif ((amqpvalue_get_ulong(descriptor, &descriptor_ulong) == 0) &&\r\n\t" +
                     "\t(descriptor_ulong == ");
             
-            #line 455 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 516 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Program.GetDescriptorCode(Program.GetDescriptor(type)).ToString()));
             
             #line default
@@ -2048,70 +2247,70 @@ bool is_");
             this.Write("))\r\n\t{\r\n\t\tresult = true;\r\n\t}\r\n\telse\r\n\t{\r\n\t\tresult = false;\r\n\t}\r\n\r\n\treturn result;" +
                     "\r\n}\r\n");
             
-            #line 466 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 527 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					} 
             
             #line default
             #line hidden
             
-            #line 467 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 528 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				} 
             
             #line default
             #line hidden
             
-            #line 468 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 529 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				else 
             
             #line default
             #line hidden
             
-            #line 469 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 530 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				{ 
             
             #line default
             #line hidden
             
-            #line 470 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 531 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					if (!hasDescriptor) 
             
             #line default
             #line hidden
             
-            #line 471 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 532 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					{ 
             
             #line default
             #line hidden
             this.Write("AMQP_VALUE amqpvalue_create_");
             
-            #line 472 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 533 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("(AMQP_VALUE value)\r\n{\r\n\treturn amqpvalue_clone(value);\r\n}\r\n");
             
-            #line 476 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 537 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					} 
             
             #line default
             #line hidden
             
-            #line 477 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 538 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					else 
             
             #line default
             #line hidden
             
-            #line 478 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 539 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					{ 
             
             #line default
             #line hidden
             this.Write("AMQP_VALUE amqpvalue_create_");
             
-            #line 479 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 540 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -2120,7 +2319,7 @@ bool is_");
                     "ue_clone(value);\r\n\tif (described_value == NULL)\r\n\t{\r\n\t\tresult = NULL;\r\n\t}\r\n\telse" +
                     "\r\n\t{\r\n\t\tAMQP_VALUE descriptor = amqpvalue_create_ulong(");
             
-            #line 489 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 550 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Program.GetDescriptorCode(Program.GetDescriptor(type))));
             
             #line default
@@ -2145,7 +2344,7 @@ bool is_");
 
 bool is_");
             
-            #line 507 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 568 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -2154,7 +2353,7 @@ bool is_");
                     "tor_ulong;\r\n\tif ((amqpvalue_get_ulong(descriptor, &descriptor_ulong) == 0) &&\r\n\t" +
                     "\t(descriptor_ulong == ");
             
-            #line 513 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 574 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Program.GetDescriptorCode(Program.GetDescriptor(type)).ToString()));
             
             #line default
@@ -2162,32 +2361,32 @@ bool is_");
             this.Write("))\r\n\t{\r\n\t\tresult = true;\r\n\t}\r\n\telse\r\n\t{\r\n\t\tresult = false;\r\n\t}\r\n\r\n\treturn result;" +
                     "\r\n}\r\n");
             
-            #line 524 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 585 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 					} 
             
             #line default
             #line hidden
             
-            #line 525 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 586 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 				} 
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 527 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 588 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 			} 
             
             #line default
             #line hidden
             
-            #line 528 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 589 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 		} 
             
             #line default
             #line hidden
             
-            #line 529 "D:\repos\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
+            #line 590 "D:\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
 	} 
             
             #line default

--- a/uamqp_generator/amqp_definitions_c.tt
+++ b/uamqp_generator/amqp_definitions_c.tt
@@ -181,8 +181,15 @@ int amqpvalue_get_<#= type_name #>(AMQP_VALUE value, <#= type_name.ToUpper() #>_
 		}
 		else
 		{
-			do
-			{
+            uint32_t list_item_count;
+            if (amqpvalue_get_list_item_count(list_value, &list_item_count) != 0)
+            {
+                result = __FAILURE__;
+            }
+            else
+            {
+			    do
+			    {
 <#				int k = 0; #>
 <#				bool first_one = true; #>
 <#				foreach (field field in type.Items.Where(item => item is field)) #>
@@ -194,71 +201,86 @@ int amqpvalue_get_<#= type_name #>(AMQP_VALUE value, <#= type_name.ToUpper() #>_
 <#					if (first_one) #>
 <#					{ #>
 <#						first_one = false; #>
-				AMQP_VALUE item_value;
+    				AMQP_VALUE item_value;
 <#					} #>
-				/* <#= field.name #> */
-				item_value = amqpvalue_get_list_item(list_value, <#= k #>);
-				if (item_value == NULL)
-				{
+				    /* <#= field.name #> */
+				    if (list_item_count > <#= k #>)
+                    {
+                        item_value = amqpvalue_get_list_item(list_value, <#= k #>);
+				        if (item_value == NULL)
+				        {
 <# 					if (field.mandatory == "true") #>
 <# 					{ #>
-					{
-						<#= type_name #>_destroy(*<#= type_name.ToLower() #>_handle);
-						result = __FAILURE__;
-						break;
-					}
+					        {
+						        <#= type_name #>_destroy(*<#= type_name.ToLower() #>_handle);
+						        result = __FAILURE__;
+						        break;
+					        }
 <# 					} #>
 <# 					else #>
 <# 					{ #>
-					/* do nothing */
+					        /* do nothing */
 <# 					} #>
-				}
-				else
-				{
+				        }
+				        else
+				        {
 <# if (field.type != "*") #>
 <# { #>
-					<#= c_type #> <#= field_name #>;
+					        <#= c_type #> <#= field_name #>;
+						    if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)
+						    {
+<# 					if (field.mandatory == "true") #>
+<# 					{ #>
+						        <#= type_name #>_destroy(*<#= type_name.ToLower() #>_handle);
+						        result = __FAILURE__;
+						        break;
+<# 					} #>
+<# 					else #>
+<# 					{ #>
+						        /* no error, field is not mandatory */
+<# 					} #>
+                            }
+                            else
+                            {
 <#		if (field.multiple != "true") #>
 <#		{ #>
-					if (amqpvalue_get_<#= field.type.ToLower().Replace('-', '_').Replace(':', '_') #>(item_value, &<#= field_name #>) != 0)
+					            if (amqpvalue_get_<#= field.type.ToLower().Replace('-', '_').Replace(':', '_') #>(item_value, &<#= field_name #>) != 0)
 <#		} #>
 <#		else #>
 <#		{ #>
-					AMQP_VALUE <#= field_name #>_array;
-					if ((amqpvalue_get_array(item_value, &<#= field_name #>_array) != 0) &&
-						(amqpvalue_get_<#= field.type.ToLower().Replace('-', '_').Replace(':', '_') #>(item_value, &<#= field_name #>) != 0))
+					            AMQP_VALUE <#= field_name #>_array;
+					            if ((amqpvalue_get_array(item_value, &<#= field_name #>_array) != 0) &&
+						            (amqpvalue_get_<#= field.type.ToLower().Replace('-', '_').Replace(':', '_') #>(item_value, &<#= field_name #>) != 0))
 <#		} #>
-					{
-<# 					if (field.mandatory == "true") #>
-<# 					{ #>
-						<#= type_name #>_destroy(*<#= type_name.ToLower() #>_handle);
-						result = __FAILURE__;
-						break;
-<# 					} #>
-<# 					else #>
-<# 					{ #>
-						if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-						{
-							<#= type_name #>_destroy(*<#= type_name.ToLower() #>_handle);
-							result = __FAILURE__;
-							break;
-						}
-<# 					} #>
-					}
+					            {
+						            <#= type_name #>_destroy(*<#= type_name.ToLower() #>_handle);
+						            result = __FAILURE__;
+						            break;
+					            }
+                            }
 
 <# } #>
 <# else #>
 <# { #>
 <# } #>
-					amqpvalue_destroy(item_value);
-				}
+					        amqpvalue_destroy(item_value);
+				        }
+                    }
+<# 					if (field.mandatory == "true") #>
+<# 					{ #>
+                    else
+                    {
+                        result = __FAILURE__;
+                    }
+<# 					} #>
 <#					k++; #>
 <#				} #>
 
-				<#= type_name.ToLower() #>_instance->composite_value = amqpvalue_clone(value);
+				    <#= type_name.ToLower() #>_instance->composite_value = amqpvalue_clone(value);
 
-				result = 0;
-			} while (0);
+				    result = 0;
+			    } while (0);
+            }
 		}
 	}
 
@@ -282,53 +304,41 @@ int <#= type_name #>_get_<#= field_name #>(<#= type_name.ToUpper() #>_HANDLE <#=
 	}
 	else
 	{
+        uint32_t item_count;
 		<#= type_name.ToUpper() #>_INSTANCE* <#= type_name #>_instance = (<#= type_name.ToUpper() #>_INSTANCE*)<#= type_name #>;
-		AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(<#= type_name #>_instance->composite_value, <#= j #>);
-		if (item_value == NULL)
-		{
+        if (amqpvalue_get_composite_item_count(<#= type_name #>_instance->composite_value, &item_count) != 0)
+        {
+            result = __FAILURE__;
+        }
+        else
+        {
+            if (item_count <= <#= j #>)
+            {
 <#					    if (field.@default != null) #>
 <#					    { #>
 <#			                if ((field_type != null) && (field_type.@class == typeClass.restricted) && (field_type.Items != null)) #>
 <#					        { #>
-            *<#= field_name #>_value = <#= field_type.@name.Replace('-', '_').Replace(':', '_') #>_<#= field.@default.Replace('-', '_').Replace(':', '_') #>;
+                *<#= field_name #>_value = <#= field_type.@name.Replace('-', '_').Replace(':', '_') #>_<#= field.@default.Replace('-', '_').Replace(':', '_') #>;
 <#					        } #>
 <#					        else #>
 <#					        { #>
-			*<#= field_name #>_value = <#= field.@default #>;
+			    *<#= field_name #>_value = <#= field.@default #>;
 <#					        } #>
-            result = 0;
+                result = 0;
 <#					    } #>
 <#					    else #>
 <#					    { #>
-			result = __FAILURE__;
+			    result = __FAILURE__;
 <#					    } #>
-		}
-		else
-		{
-<#						if (field.type.Replace('-', '_').Replace(':', '_') == "*") #>
-<#						{ #>
-			*<#= field_name #>_value = item_value;
-			result = 0;
-<#						} #>
-<#						else #>
-<#						{ #>
-<#							if (field.multiple != "true") #>
-<#							{ #>
-			if (amqpvalue_get_<#= field.type.Replace('-', '_').Replace(':', '_') #>(item_value, <#= field_name #>_value) != 0)
-<#							} #>
-<#							else #>
-<#							{ #>
-			if (amqpvalue_get_array(item_value, <#= field_name #>_value) != 0)
-<#							} #>
-			{
+            }
+            else
+            {
+		        AMQP_VALUE item_value = amqpvalue_get_composite_item_in_place(<#= type_name #>_instance->composite_value, <#= j #>);
+		        if ((item_value == NULL) ||
+                    (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL))
+		        {
 <#					    if (field.@default != null) #>
 <#					    { #>
-                if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
-                {
-    			    result = __FAILURE__;
-                }
-                else
-                {
 <#			                if ((field_type != null) && (field_type.@class == typeClass.restricted) && (field_type.Items != null)) #>
 <#					        { #>
                     *<#= field_name #>_value = <#= field_type.@name.Replace('-', '_').Replace(':', '_') #>_<#= field.@default.Replace('-', '_').Replace(':', '_') #>;
@@ -338,18 +348,61 @@ int <#= type_name #>_get_<#= field_name #>(<#= type_name.ToUpper() #>_HANDLE <#=
 			        *<#= field_name #>_value = <#= field.@default #>;
 <#					        } #>
                     result = 0;
-                }
 <#					    } #>
 <#					    else #>
 <#					    { #>
-			    result = __FAILURE__;
+			        result = __FAILURE__;
 <#					    } #>
-			}
-			else
-			{
-				result = 0;
-			}
+		        }
+		        else
+		        {
+<#						if (field.type.Replace('-', '_').Replace(':', '_') == "*") #>
+<#						{ #>
+			        *<#= field_name #>_value = item_value;
+			        result = 0;
 <#						} #>
+<#						else #>
+<#						{ #>
+<#							if (field.multiple != "true") #>
+<#							{ #>
+			        if (amqpvalue_get_<#= field.type.Replace('-', '_').Replace(':', '_') #>(item_value, <#= field_name #>_value) != 0)
+<#							} #>
+<#							else #>
+<#							{ #>
+			        if (amqpvalue_get_array(item_value, <#= field_name #>_value) != 0)
+<#							} #>
+			        {
+<#					    if (field.@default != null) #>
+<#					    { #>
+                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
+                        {
+    			            result = __FAILURE__;
+                        }
+                        else
+                        {
+<#			                if ((field_type != null) && (field_type.@class == typeClass.restricted) && (field_type.Items != null)) #>
+<#					        { #>
+                            *<#= field_name #>_value = <#= field_type.@name.Replace('-', '_').Replace(':', '_') #>_<#= field.@default.Replace('-', '_').Replace(':', '_') #>;
+<#					        } #>
+<#					        else #>
+<#					        { #>
+			                *<#= field_name #>_value = <#= field.@default #>;
+<#					        } #>
+                            result = 0;
+                        }
+<#					    } #>
+<#					    else #>
+<#					    { #>
+			            result = __FAILURE__;
+<#					    } #>
+			        }
+			        else
+			        {
+				        result = 0;
+			        }
+<#						} #>
+                }
+            }
 		}
 	}
 
@@ -373,7 +426,15 @@ int <#= type_name #>_set_<#= field_name #>(<#= type_name.ToUpper() #>_HANDLE <#=
 <# } #>
 <# else #>
 <# { #>
-		AMQP_VALUE <#= field_name #>_amqp_value = amqpvalue_clone(<#= field_name #>_value);
+		AMQP_VALUE <#= field_name #>_amqp_value;
+        if (<#= field_name #>_value == NULL)
+        {
+            <#= field_name #>_amqp_value = NULL;
+        }
+        else
+        {
+            <#= field_name #>_amqp_value = amqpvalue_clone(<#= field_name #>_value);
+        }
 <# } #>
 		if (<#= field_name #>_amqp_value == NULL)
 		{


### PR DESCRIPTION
Add LogError to amqpvalue. While adding LogError some cases where the calling code did not check whether it should call the amqpvalue code (for example the definitions.c file did not check for the number of items in a composite type, but relied on the fact that the amqpvalue_get_list_item would fail.

These cases should also be corrected now.
This required adding a amqpvalue_get_composite_item_count function in amqpvalue, which did not yet receive unit tests, but it will soon.