### PR TITLE
Fixing on_delivery_settled to result in correct MESSAGE_SEND_RESULT value

### DIFF
--- a/inc/azure_uamqp_c/link.h
+++ b/inc/azure_uamqp_c/link.h
@@ -19,20 +19,27 @@ typedef struct LINK_INSTANCE_TAG* LINK_HANDLE;
 
 typedef enum LINK_STATE_TAG
 {
-	LINK_STATE_DETACHED,
-	LINK_STATE_HALF_ATTACHED,
-	LINK_STATE_ATTACHED,
-	LINK_STATE_ERROR
+    LINK_STATE_DETACHED,
+    LINK_STATE_HALF_ATTACHED,
+    LINK_STATE_ATTACHED,
+    LINK_STATE_ERROR
 } LINK_STATE;
 
 typedef enum LINK_TRANSFER_RESULT_TAG
 {
-	LINK_TRANSFER_OK,
-	LINK_TRANSFER_ERROR,
-	LINK_TRANSFER_BUSY
+    LINK_TRANSFER_OK,
+    LINK_TRANSFER_ERROR,
+    LINK_TRANSFER_BUSY
 } LINK_TRANSFER_RESULT;
 
-typedef void(*ON_DELIVERY_SETTLED)(void* context, delivery_number delivery_no, AMQP_VALUE delivery_state);
+typedef enum LINK_DELIVERY_SETTLE_REASON_TAG
+{
+    LINK_DELIVERY_SETTLE_REASON_DISPOSITION_RECEIVED,
+    LINK_DELIVERY_SETTLE_REASON_SETTLED,
+    LINK_DELIVERY_SETTLE_REASON_NOT_DELIVERED
+} LINK_DELIVERY_SETTLE_REASON;
+
+typedef void(*ON_DELIVERY_SETTLED)(void* context, delivery_number delivery_no, LINK_DELIVERY_SETTLE_REASON reason, AMQP_VALUE delivery_state);
 typedef AMQP_VALUE(*ON_TRANSFER_RECEIVED)(void* context, TRANSFER_HANDLE transfer, uint32_t payload_size, const unsigned char* payload_bytes);
 typedef void(*ON_LINK_STATE_CHANGED)(void* context, LINK_STATE new_link_state, LINK_STATE previous_link_state);
 typedef void(*ON_LINK_FLOW_ON)(void* context);

--- a/src/link.c
+++ b/src/link.c
@@ -80,7 +80,7 @@ static void remove_all_pending_deliveries(LINK_INSTANCE* link, bool indicate_set
             {
                 if (indicate_settled && (delivery_instance->on_delivery_settled != NULL))
                 {
-                    delivery_instance->on_delivery_settled(delivery_instance->callback_context, delivery_instance->delivery_id, NULL);
+                    delivery_instance->on_delivery_settled(delivery_instance->callback_context, delivery_instance->delivery_id, LINK_DELIVERY_SETTLE_REASON_NOT_DELIVERED, NULL);
                 }
                 free(delivery_instance);
             }
@@ -474,7 +474,7 @@ static void link_frame_received(void* context, AMQP_VALUE performative, uint32_t
                                 }
                                 else
                                 {
-                                    delivery_instance->on_delivery_settled(delivery_instance->callback_context, delivery_instance->delivery_id, delivery_state);
+                                    delivery_instance->on_delivery_settled(delivery_instance->callback_context, delivery_instance->delivery_id, LINK_DELIVERY_SETTLE_REASON_DISPOSITION_RECEIVED, delivery_state);
                                     free(delivery_instance);
                                     if (singlylinkedlist_remove(link_instance->pending_deliveries, pending_delivery) != 0)
                                     {
@@ -589,7 +589,7 @@ static void on_send_complete(void* context, IO_SEND_RESULT send_result)
     (void)send_result;
 	if (link_instance->snd_settle_mode == sender_settle_mode_settled)
 	{
-		delivery_instance->on_delivery_settled(delivery_instance->callback_context, delivery_instance->delivery_id, NULL);
+		delivery_instance->on_delivery_settled(delivery_instance->callback_context, delivery_instance->delivery_id, LINK_DELIVERY_SETTLE_REASON_SETTLED, NULL);
 		free(delivery_instance);
 		(void)singlylinkedlist_remove(link_instance->pending_deliveries, delivery_instance_list_item);
 	}

--- a/src/message_sender.c
+++ b/src/message_sender.c
@@ -91,7 +91,7 @@ static void remove_pending_message(MESSAGE_SENDER_INSTANCE* message_sender_insta
     }
 }
 
-static void on_delivery_settled(void* context, delivery_number delivery_no, AMQP_VALUE delivery_state)
+static void on_delivery_settled(void* context, delivery_number delivery_no, LINK_DELIVERY_SETTLE_REASON reason, AMQP_VALUE delivery_state)
 {
     MESSAGE_WITH_CALLBACK* message_with_callback = (MESSAGE_WITH_CALLBACK*)context;
     MESSAGE_SENDER_INSTANCE* message_sender_instance = (MESSAGE_SENDER_INSTANCE*)message_with_callback->message_sender;
@@ -99,35 +99,39 @@ static void on_delivery_settled(void* context, delivery_number delivery_no, AMQP
 
     if (message_with_callback->on_message_send_complete != NULL)
     {
-        AMQP_VALUE descriptor;
-        if (delivery_state != NULL)
+        switch (reason)
         {
-            descriptor = amqpvalue_get_inplace_descriptor(delivery_state);
-        }
-        else
-        {
-            descriptor = NULL;
-        }
-
-        if ((descriptor == NULL) && (delivery_state != NULL))
-        {
-            LogError("Error getting descriptor for delivery state");
-        }
-        else
-        {
-            MESSAGE_SEND_RESULT message_send_result;
-
-            if ((delivery_state == NULL) ||
-                (is_accepted_type_by_descriptor(descriptor)))
+        case LINK_DELIVERY_SETTLE_REASON_DISPOSITION_RECEIVED:
+            if (delivery_state == NULL)
             {
-                message_send_result = MESSAGE_SEND_OK;
+                LogError("delivery state not provided");
             }
             else
             {
-                message_send_result = MESSAGE_SEND_ERROR;
+                AMQP_VALUE descriptor = amqpvalue_get_inplace_descriptor(delivery_state);
+
+                if (descriptor == NULL)
+                {
+                    LogError("Error getting descriptor for delivery state");
+                }
+                else if (is_accepted_type_by_descriptor(descriptor))
+                {
+                    message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_OK);
+                }
+                else
+                {
+                    message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_ERROR);
+                }
             }
 
-            message_with_callback->on_message_send_complete(message_with_callback->context, message_send_result);
+            break;
+        case LINK_DELIVERY_SETTLE_REASON_SETTLED:
+            message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_OK);
+            break;
+        case LINK_DELIVERY_SETTLE_REASON_NOT_DELIVERED:
+        default:
+            message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_ERROR);
+            break;
         }
     }
 
@@ -478,10 +482,10 @@ static void send_all_pending_messages(MESSAGE_SENDER_INSTANCE* message_sender_in
                 void* context = message_sender_instance->messages[i]->context;
                 remove_pending_message_by_index(message_sender_instance, i);
 
-				if (on_message_send_complete != NULL)
-				{
-					on_message_send_complete(context, MESSAGE_SEND_ERROR);
-				}
+                if (on_message_send_complete != NULL)
+                {
+                    on_message_send_complete(context, MESSAGE_SEND_ERROR);
+                }
 
                 i = message_sender_instance->message_count;
                 break;
@@ -747,7 +751,7 @@ int messagesender_send(MESSAGE_SENDER_HANDLE message_sender, MESSAGE_HANDLE mess
                             {
                             default:
                             case SEND_ONE_MESSAGE_ERROR:
-							
+                            
                                 remove_pending_message_by_index(message_sender_instance, message_sender_instance->message_count - 1);
                                 result = __FAILURE__;
                                 break;


### PR DESCRIPTION
Sorry, since unit tests are not present for message_sender and link it would be a big item to add for the fix I need.
I started the test suite for link.h though.