### PR TITLE
Add a getter for peer max message size

### DIFF
--- a/inc/azure_uamqp_c/link.h
+++ b/inc/azure_uamqp_c/link.h
@@ -20,7 +20,8 @@ typedef struct LINK_INSTANCE_TAG* LINK_HANDLE;
 typedef enum LINK_STATE_TAG
 {
     LINK_STATE_DETACHED,
-    LINK_STATE_HALF_ATTACHED,
+    LINK_STATE_HALF_ATTACHED_ATTACH_SENT,
+	LINK_STATE_HALF_ATTACHED_ATTACH_RECEIVED,
     LINK_STATE_ATTACHED,
     LINK_STATE_ERROR
 } LINK_STATE;
@@ -47,20 +48,21 @@ typedef void(*ON_LINK_FLOW_ON)(void* context);
 MOCKABLE_FUNCTION(, LINK_HANDLE, link_create, SESSION_HANDLE, session, const char*, name, role, role, AMQP_VALUE, source, AMQP_VALUE, target);
 MOCKABLE_FUNCTION(, LINK_HANDLE, link_create_from_endpoint, SESSION_HANDLE, session, LINK_ENDPOINT_HANDLE, link_endpoint, const char*, name, role, role, AMQP_VALUE, source, AMQP_VALUE, target);
 MOCKABLE_FUNCTION(, void, link_destroy, LINK_HANDLE, handle);
-MOCKABLE_FUNCTION(, int,  link_set_snd_settle_mode, LINK_HANDLE, link, sender_settle_mode, snd_settle_mode);
-MOCKABLE_FUNCTION(, int,  link_get_snd_settle_mode, LINK_HANDLE, link, sender_settle_mode*, snd_settle_mode);
-MOCKABLE_FUNCTION(, int,  link_set_rcv_settle_mode, LINK_HANDLE, link, receiver_settle_mode, rcv_settle_mode);
-MOCKABLE_FUNCTION(, int,  link_get_rcv_settle_mode, LINK_HANDLE, link, receiver_settle_mode*, rcv_settle_mode);
-MOCKABLE_FUNCTION(, int,  link_set_initial_delivery_count, LINK_HANDLE, link, sequence_no, initial_delivery_count);
-MOCKABLE_FUNCTION(, int,  link_get_initial_delivery_count, LINK_HANDLE, link, sequence_no*, initial_delivery_count);
-MOCKABLE_FUNCTION(, int,  link_set_max_message_size, LINK_HANDLE, link, uint64_t, max_message_size);
-MOCKABLE_FUNCTION(, int,  link_get_max_message_size, LINK_HANDLE, link, uint64_t*, max_message_size);
-MOCKABLE_FUNCTION(, int,  link_set_attach_properties, LINK_HANDLE, link, fields, attach_properties);
-MOCKABLE_FUNCTION(, int,  link_get_name, LINK_HANDLE, link, const char**, link_name);
-MOCKABLE_FUNCTION(, int,  link_get_received_message_id, LINK_HANDLE, link, delivery_number*, message_id);
-MOCKABLE_FUNCTION(, int,  link_send_disposition, LINK_HANDLE, link, delivery_number, message_number, AMQP_VALUE, delivery_state);
-MOCKABLE_FUNCTION(, int,  link_attach, LINK_HANDLE, link, ON_TRANSFER_RECEIVED, on_transfer_received, ON_LINK_STATE_CHANGED, on_link_state_changed, ON_LINK_FLOW_ON, on_link_flow_on, void*, callback_context);
-MOCKABLE_FUNCTION(, int,  link_detach, LINK_HANDLE, link, bool, close);
+MOCKABLE_FUNCTION(, int, link_set_snd_settle_mode, LINK_HANDLE, link, sender_settle_mode, snd_settle_mode);
+MOCKABLE_FUNCTION(, int, link_get_snd_settle_mode, LINK_HANDLE, link, sender_settle_mode*, snd_settle_mode);
+MOCKABLE_FUNCTION(, int, link_set_rcv_settle_mode, LINK_HANDLE, link, receiver_settle_mode, rcv_settle_mode);
+MOCKABLE_FUNCTION(, int, link_get_rcv_settle_mode, LINK_HANDLE, link, receiver_settle_mode*, rcv_settle_mode);
+MOCKABLE_FUNCTION(, int, link_set_initial_delivery_count, LINK_HANDLE, link, sequence_no, initial_delivery_count);
+MOCKABLE_FUNCTION(, int, link_get_initial_delivery_count, LINK_HANDLE, link, sequence_no*, initial_delivery_count);
+MOCKABLE_FUNCTION(, int, link_set_max_message_size, LINK_HANDLE, link, uint64_t, max_message_size);
+MOCKABLE_FUNCTION(, int, link_get_max_message_size, LINK_HANDLE, link, uint64_t*, max_message_size);
+MOCKABLE_FUNCTION(, int, link_get_peer_max_message_size, LINK_HANDLE, link, uint64_t*, peer_max_message_size);
+MOCKABLE_FUNCTION(, int, link_set_attach_properties, LINK_HANDLE, link, fields, attach_properties);
+MOCKABLE_FUNCTION(, int, link_get_name, LINK_HANDLE, link, const char**, link_name);
+MOCKABLE_FUNCTION(, int, link_get_received_message_id, LINK_HANDLE, link, delivery_number*, message_id);
+MOCKABLE_FUNCTION(, int, link_send_disposition, LINK_HANDLE, link, delivery_number, message_number, AMQP_VALUE, delivery_state);
+MOCKABLE_FUNCTION(, int, link_attach, LINK_HANDLE, link, ON_TRANSFER_RECEIVED, on_transfer_received, ON_LINK_STATE_CHANGED, on_link_state_changed, ON_LINK_FLOW_ON, on_link_flow_on, void*, callback_context);
+MOCKABLE_FUNCTION(, int, link_detach, LINK_HANDLE, link, bool, close);
 MOCKABLE_FUNCTION(, LINK_TRANSFER_RESULT, link_transfer, LINK_HANDLE, handle, message_format, message_format, PAYLOAD*, payloads, size_t, payload_count, ON_DELIVERY_SETTLED, on_delivery_settled, void*, callback_context);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add a getter for peer max message size. This prompted splitting the half attached state into half_attached_attach_send and half attached_attach_received.