### PR TITLE
Fix double-free crash if send_one_message fails with SEND_ONE_MESSAGE_ERROR (github issue #188)

### DIFF
--- a/src/message_sender.c
+++ b/src/message_sender.c
@@ -897,7 +897,6 @@ ASYNC_OPERATION_HANDLE messagesender_send_async(MESSAGE_SENDER_HANDLE message_se
                             case SEND_ONE_MESSAGE_ERROR:
                                 LogError("Error sending message");
                                 remove_pending_message_by_index(message_sender, message_sender->message_count - 1);
-                                async_operation_destroy(result);
                                 result = NULL;
                                 break;
 


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-uamqp-c/issues/188

Fix has been verified with real reconnection scenario on a Linux device.

This module doesn't have unit tests (correct me if I'm wrong), so no other changes were added to this PR.