### PR TITLE
Add option to specify ratio at which an empty frame should be sent in order to satisfy the remote idle timeout

### DIFF
--- a/inc/azure_uamqp_c/connection.h
+++ b/inc/azure_uamqp_c/connection.h
@@ -84,6 +84,7 @@ extern "C" {
     MOCKABLE_FUNCTION(, int, connection_set_idle_timeout, CONNECTION_HANDLE, connection, milliseconds, idle_timeout);
     MOCKABLE_FUNCTION(, int, connection_get_idle_timeout, CONNECTION_HANDLE, connection, milliseconds*, idle_timeout);
     MOCKABLE_FUNCTION(, int, connection_get_remote_max_frame_size, CONNECTION_HANDLE, connection, uint32_t*, remote_max_frame_size);
+    MOCKABLE_FUNCTION(, int, connection_set_remote_idle_timeout_empty_frame_send_ratio, CONNECTION_HANDLE, connection, double, idle_timeout_empty_frame_send_ratio);
     MOCKABLE_FUNCTION(, uint64_t, connection_handle_deadlines, CONNECTION_HANDLE, connection);
     MOCKABLE_FUNCTION(, void, connection_dowork, CONNECTION_HANDLE, connection);
     MOCKABLE_FUNCTION(, ENDPOINT_HANDLE, connection_create_endpoint, CONNECTION_HANDLE, connection);


### PR DESCRIPTION
Add option to specify ratio at which an empty frame should be sent in order to satisfy the remote idle timeout

This addresses #190 