### PR TITLE
Mrzeropayload

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -1023,6 +1023,14 @@ int message_add_body_amqp_data(MESSAGE_HANDLE message, BINARY_DATA amqp_data)
                 LogError("Cannot allocate memory for body AMQP data items");
                 result = __FAILURE__;
             }
+            else if (amqp_data.length == 0)
+            {
+                message->body_amqp_data_items = new_body_amqp_data_items;
+                message->body_amqp_data_items[message->body_amqp_data_count].body_data_section_bytes = NULL;
+                message->body_amqp_data_items[message->body_amqp_data_count].body_data_section_length = 0;
+                message->body_amqp_data_count++;
+                result = 0;
+            }
             else
             {
                 message->body_amqp_data_items = new_body_amqp_data_items;

--- a/tests/message_ut/message_ut.c
+++ b/tests/message_ut/message_ut.c
@@ -2709,7 +2709,6 @@ TEST_FUNCTION(message_add_body_amqp_data_with_NULL_buffer_and_zero_size_succeeds
     amqp_data.length = 0;
 
     STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
-    //STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
     // act
     result = message_add_body_amqp_data(message, amqp_data);
@@ -2736,7 +2735,6 @@ TEST_FUNCTION(message_add_body_amqp_data_with_non_NULL_buffer_and_zero_size_succ
     amqp_data.length = 0;
 
     STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
-    //STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
     // act
     result = message_add_body_amqp_data(message, amqp_data);

--- a/tests/message_ut/message_ut.c
+++ b/tests/message_ut/message_ut.c
@@ -2709,7 +2709,7 @@ TEST_FUNCTION(message_add_body_amqp_data_with_NULL_buffer_and_zero_size_succeeds
     amqp_data.length = 0;
 
     STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    //STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
     // act
     result = message_add_body_amqp_data(message, amqp_data);
@@ -2736,7 +2736,7 @@ TEST_FUNCTION(message_add_body_amqp_data_with_non_NULL_buffer_and_zero_size_succ
     amqp_data.length = 0;
 
     STRICT_EXPECTED_CALL(gballoc_realloc(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    //STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
 
     // act
     result = message_add_body_amqp_data(message, amqp_data);


### PR DESCRIPTION
Thought the unit tests actually test the scenario when the payload is zero length they rely upon the fact that some implementations of malloc will return a valid pointer when a request for zero bytes is made. Unfortunately this is implementation specific and it is also valid to return a null pointer. On platforms that do that the AMQP message cannot be created with a zero length payload. This fix addresses that. No additional unit tests were added since this is already covered.