### PR TITLE
Use strict XCode warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ add_library(uamqp
     ${uamqp_h_files}
     ${socketlistener_c_files}
     )
+setTargetBuildProperties(uamqp)
 
 target_link_libraries(uamqp aziotsharedutil)
 


### PR DESCRIPTION
Our compilers are letting several code issues through with no warning, including mismatched enum assignments. This change forces XCode to apply the stricter rules to CMake generated projects that it always applies to its wizard-generated iOS projects.