### PR TITLE
Silence Warnings

### DIFF
--- a/inc/azure_uamqp_c/header_detect_io.h
+++ b/inc/azure_uamqp_c/header_detect_io.h
@@ -34,9 +34,9 @@ extern "C" {
 		HEADER_DETECT_ENTRY* header_detect_entries;
 		size_t header_detect_entry_count;
 	} HEADER_DETECT_IO_CONFIG;
-    
-	MOCKABLE_FUNCTION(, const AMQP_HEADER, header_detect_io_get_amqp_header);
-	MOCKABLE_FUNCTION(, const AMQP_HEADER, header_detect_io_get_sasl_amqp_header);
+
+	MOCKABLE_FUNCTION(, AMQP_HEADER, header_detect_io_get_amqp_header);
+	MOCKABLE_FUNCTION(, AMQP_HEADER, header_detect_io_get_sasl_amqp_header);
 	MOCKABLE_FUNCTION(, const IO_INTERFACE_DESCRIPTION*, header_detect_io_get_interface_description);
 
 #ifdef __cplusplus

--- a/src/amqp_definitions.c
+++ b/src/amqp_definitions.c
@@ -382,8 +382,8 @@ int error_get_condition(ERROR_HANDLE error, const char** condition_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_symbol(item_value, condition_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_symbol(item_value, condition_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -465,8 +465,8 @@ int error_get_description(ERROR_HANDLE error, const char** description_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_string(item_value, description_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_string(item_value, description_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -548,8 +548,8 @@ int error_get_info(ERROR_HANDLE error, fields* info_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_fields(item_value, info_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_fields(item_value, info_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -1119,8 +1119,8 @@ int open_get_container_id(OPEN_HANDLE open, const char** container_id_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_string(item_value, container_id_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_string(item_value, container_id_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -1202,8 +1202,8 @@ int open_get_hostname(OPEN_HANDLE open, const char** hostname_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_string(item_value, hostname_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_string(item_value, hostname_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -1287,8 +1287,8 @@ int open_get_max_frame_size(OPEN_HANDLE open, uint32_t* max_frame_size_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_uint(item_value, max_frame_size_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_uint(item_value, max_frame_size_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -1380,8 +1380,8 @@ int open_get_channel_max(OPEN_HANDLE open, uint16_t* channel_max_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_ushort(item_value, channel_max_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_ushort(item_value, channel_max_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -1471,8 +1471,8 @@ int open_get_idle_time_out(OPEN_HANDLE open, milliseconds* idle_time_out_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_milliseconds(item_value, idle_time_out_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_milliseconds(item_value, idle_time_out_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -2142,8 +2142,8 @@ int open_get_properties(OPEN_HANDLE open, fields* properties_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_fields(item_value, properties_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_fields(item_value, properties_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -2659,8 +2659,8 @@ int begin_get_remote_channel(BEGIN_HANDLE begin, uint16_t* remote_channel_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_ushort(item_value, remote_channel_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_ushort(item_value, remote_channel_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -2742,8 +2742,8 @@ int begin_get_next_outgoing_id(BEGIN_HANDLE begin, transfer_number* next_outgoin
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_transfer_number(item_value, next_outgoing_id_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_transfer_number(item_value, next_outgoing_id_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -2825,8 +2825,8 @@ int begin_get_incoming_window(BEGIN_HANDLE begin, uint32_t* incoming_window_valu
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_uint(item_value, incoming_window_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_uint(item_value, incoming_window_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -2908,8 +2908,8 @@ int begin_get_outgoing_window(BEGIN_HANDLE begin, uint32_t* outgoing_window_valu
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_uint(item_value, outgoing_window_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_uint(item_value, outgoing_window_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -2993,8 +2993,8 @@ int begin_get_handle_max(BEGIN_HANDLE begin, handle* handle_max_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_handle(item_value, handle_max_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_handle(item_value, handle_max_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -3378,8 +3378,8 @@ int begin_get_properties(BEGIN_HANDLE begin, fields* properties_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_fields(item_value, properties_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_fields(item_value, properties_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -4037,8 +4037,8 @@ int attach_get_name(ATTACH_HANDLE attach, const char** name_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_string(item_value, name_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_string(item_value, name_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -4120,8 +4120,8 @@ int attach_get_handle(ATTACH_HANDLE attach, handle* handle_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_handle(item_value, handle_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_handle(item_value, handle_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -4203,8 +4203,8 @@ int attach_get_role(ATTACH_HANDLE attach, role* role_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_role(item_value, role_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_role(item_value, role_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -4288,8 +4288,8 @@ int attach_get_snd_settle_mode(ATTACH_HANDLE attach, sender_settle_mode* snd_set
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_sender_settle_mode(item_value, snd_settle_mode_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_sender_settle_mode(item_value, snd_settle_mode_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -4381,8 +4381,8 @@ int attach_get_rcv_settle_mode(ATTACH_HANDLE attach, receiver_settle_mode* rcv_s
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_receiver_settle_mode(item_value, rcv_settle_mode_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_receiver_settle_mode(item_value, rcv_settle_mode_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -4640,8 +4640,8 @@ int attach_get_unsettled(ATTACH_HANDLE attach, AMQP_VALUE* unsettled_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_map(item_value, unsettled_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_map(item_value, unsettled_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -4733,8 +4733,8 @@ int attach_get_incomplete_unsettled(ATTACH_HANDLE attach, bool* incomplete_unset
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, incomplete_unsettled_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, incomplete_unsettled_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -4824,8 +4824,8 @@ int attach_get_initial_delivery_count(ATTACH_HANDLE attach, sequence_no* initial
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_sequence_no(item_value, initial_delivery_count_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_sequence_no(item_value, initial_delivery_count_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -4907,8 +4907,8 @@ int attach_get_max_message_size(ATTACH_HANDLE attach, uint64_t* max_message_size
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_ulong(item_value, max_message_size_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_ulong(item_value, max_message_size_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -5284,8 +5284,8 @@ int attach_get_properties(ATTACH_HANDLE attach, fields* properties_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_fields(item_value, properties_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_fields(item_value, properties_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -5884,8 +5884,8 @@ int flow_get_next_incoming_id(FLOW_HANDLE flow, transfer_number* next_incoming_i
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_transfer_number(item_value, next_incoming_id_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_transfer_number(item_value, next_incoming_id_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -5967,8 +5967,8 @@ int flow_get_incoming_window(FLOW_HANDLE flow, uint32_t* incoming_window_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_uint(item_value, incoming_window_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_uint(item_value, incoming_window_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -6050,8 +6050,8 @@ int flow_get_next_outgoing_id(FLOW_HANDLE flow, transfer_number* next_outgoing_i
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_transfer_number(item_value, next_outgoing_id_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_transfer_number(item_value, next_outgoing_id_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -6133,8 +6133,8 @@ int flow_get_outgoing_window(FLOW_HANDLE flow, uint32_t* outgoing_window_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_uint(item_value, outgoing_window_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_uint(item_value, outgoing_window_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -6216,8 +6216,8 @@ int flow_get_handle(FLOW_HANDLE flow, handle* handle_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_handle(item_value, handle_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_handle(item_value, handle_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -6299,8 +6299,8 @@ int flow_get_delivery_count(FLOW_HANDLE flow, sequence_no* delivery_count_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_sequence_no(item_value, delivery_count_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_sequence_no(item_value, delivery_count_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -6382,8 +6382,8 @@ int flow_get_link_credit(FLOW_HANDLE flow, uint32_t* link_credit_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_uint(item_value, link_credit_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_uint(item_value, link_credit_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -6465,8 +6465,8 @@ int flow_get_available(FLOW_HANDLE flow, uint32_t* available_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_uint(item_value, available_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_uint(item_value, available_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -6550,8 +6550,8 @@ int flow_get_drain(FLOW_HANDLE flow, bool* drain_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, drain_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, drain_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -6643,8 +6643,8 @@ int flow_get_echo(FLOW_HANDLE flow, bool* echo_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, echo_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, echo_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -6734,8 +6734,8 @@ int flow_get_properties(FLOW_HANDLE flow, fields* properties_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_fields(item_value, properties_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_fields(item_value, properties_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -7282,8 +7282,8 @@ int transfer_get_handle(TRANSFER_HANDLE transfer, handle* handle_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_handle(item_value, handle_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_handle(item_value, handle_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -7365,8 +7365,8 @@ int transfer_get_delivery_id(TRANSFER_HANDLE transfer, delivery_number* delivery
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_delivery_number(item_value, delivery_id_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_delivery_number(item_value, delivery_id_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -7448,8 +7448,8 @@ int transfer_get_delivery_tag(TRANSFER_HANDLE transfer, delivery_tag* delivery_t
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_delivery_tag(item_value, delivery_tag_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_delivery_tag(item_value, delivery_tag_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -7531,8 +7531,8 @@ int transfer_get_message_format(TRANSFER_HANDLE transfer, message_format* messag
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_message_format(item_value, message_format_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_message_format(item_value, message_format_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -7614,8 +7614,8 @@ int transfer_get_settled(TRANSFER_HANDLE transfer, bool* settled_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, settled_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, settled_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -7699,8 +7699,8 @@ int transfer_get_more(TRANSFER_HANDLE transfer, bool* more_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, more_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, more_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -7790,8 +7790,8 @@ int transfer_get_rcv_settle_mode(TRANSFER_HANDLE transfer, receiver_settle_mode*
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_receiver_settle_mode(item_value, rcv_settle_mode_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_receiver_settle_mode(item_value, rcv_settle_mode_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -7959,8 +7959,8 @@ int transfer_get_resume(TRANSFER_HANDLE transfer, bool* resume_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, resume_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, resume_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -8052,8 +8052,8 @@ int transfer_get_aborted(TRANSFER_HANDLE transfer, bool* aborted_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, aborted_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, aborted_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -8145,8 +8145,8 @@ int transfer_get_batchable(TRANSFER_HANDLE transfer, bool* batchable_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, batchable_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, batchable_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -8574,8 +8574,8 @@ int disposition_get_role(DISPOSITION_HANDLE disposition, role* role_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_role(item_value, role_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_role(item_value, role_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -8657,8 +8657,8 @@ int disposition_get_first(DISPOSITION_HANDLE disposition, delivery_number* first
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_delivery_number(item_value, first_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_delivery_number(item_value, first_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -8740,8 +8740,8 @@ int disposition_get_last(DISPOSITION_HANDLE disposition, delivery_number* last_v
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_delivery_number(item_value, last_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_delivery_number(item_value, last_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -8825,8 +8825,8 @@ int disposition_get_settled(DISPOSITION_HANDLE disposition, bool* settled_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, settled_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, settled_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -9002,8 +9002,8 @@ int disposition_get_batchable(DISPOSITION_HANDLE disposition, bool* batchable_va
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, batchable_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, batchable_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -9346,8 +9346,8 @@ int detach_get_handle(DETACH_HANDLE detach, handle* handle_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_handle(item_value, handle_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_handle(item_value, handle_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -9431,8 +9431,8 @@ int detach_get_closed(DETACH_HANDLE detach, bool* closed_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, closed_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, closed_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -9522,8 +9522,8 @@ int detach_get_error(DETACH_HANDLE detach, ERROR_HANDLE* error_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_error(item_value, error_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_error(item_value, error_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -9776,8 +9776,8 @@ int end_get_error(END_HANDLE end, ERROR_HANDLE* error_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_error(item_value, error_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_error(item_value, error_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -10030,8 +10030,8 @@ int close_get_error(CLOSE_HANDLE close, ERROR_HANDLE* error_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_error(item_value, error_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_error(item_value, error_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -10709,8 +10709,8 @@ int sasl_init_get_mechanism(SASL_INIT_HANDLE sasl_init, const char** mechanism_v
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_symbol(item_value, mechanism_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_symbol(item_value, mechanism_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -10792,8 +10792,8 @@ int sasl_init_get_initial_response(SASL_INIT_HANDLE sasl_init, amqp_binary* init
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_binary(item_value, initial_response_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_binary(item_value, initial_response_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -10875,8 +10875,8 @@ int sasl_init_get_hostname(SASL_INIT_HANDLE sasl_init, const char** hostname_val
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_string(item_value, hostname_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_string(item_value, hostname_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -11149,8 +11149,8 @@ int sasl_challenge_get_challenge(SASL_CHALLENGE_HANDLE sasl_challenge, amqp_bina
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_binary(item_value, challenge_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_binary(item_value, challenge_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -11423,8 +11423,8 @@ int sasl_response_get_response(SASL_RESPONSE_HANDLE sasl_response, amqp_binary* 
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_binary(item_value, response_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_binary(item_value, response_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -11726,8 +11726,8 @@ int sasl_outcome_get_code(SASL_OUTCOME_HANDLE sasl_outcome, sasl_code* code_valu
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_sasl_code(item_value, code_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_sasl_code(item_value, code_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -11809,8 +11809,8 @@ int sasl_outcome_get_additional_data(SASL_OUTCOME_HANDLE sasl_outcome, amqp_bina
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_binary(item_value, additional_data_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_binary(item_value, additional_data_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -12435,8 +12435,8 @@ int source_get_durable(SOURCE_HANDLE source, terminus_durability* durable_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_terminus_durability(item_value, durable_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_terminus_durability(item_value, durable_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -12528,8 +12528,8 @@ int source_get_expiry_policy(SOURCE_HANDLE source, terminus_expiry_policy* expir
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_terminus_expiry_policy(item_value, expiry_policy_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_terminus_expiry_policy(item_value, expiry_policy_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -12621,8 +12621,8 @@ int source_get_timeout(SOURCE_HANDLE source, seconds* timeout_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_seconds(item_value, timeout_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_seconds(item_value, timeout_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -12714,8 +12714,8 @@ int source_get_dynamic(SOURCE_HANDLE source, bool* dynamic_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, dynamic_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, dynamic_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -12805,8 +12805,8 @@ int source_get_dynamic_node_properties(SOURCE_HANDLE source, node_properties* dy
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_node_properties(item_value, dynamic_node_properties_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_node_properties(item_value, dynamic_node_properties_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -12888,8 +12888,8 @@ int source_get_distribution_mode(SOURCE_HANDLE source, const char** distribution
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_symbol(item_value, distribution_mode_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_symbol(item_value, distribution_mode_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -12971,8 +12971,8 @@ int source_get_filter(SOURCE_HANDLE source, filter_set* filter_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_filter_set(item_value, filter_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_filter_set(item_value, filter_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -13845,8 +13845,8 @@ int target_get_durable(TARGET_HANDLE target, terminus_durability* durable_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_terminus_durability(item_value, durable_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_terminus_durability(item_value, durable_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -13938,8 +13938,8 @@ int target_get_expiry_policy(TARGET_HANDLE target, terminus_expiry_policy* expir
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_terminus_expiry_policy(item_value, expiry_policy_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_terminus_expiry_policy(item_value, expiry_policy_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -14031,8 +14031,8 @@ int target_get_timeout(TARGET_HANDLE target, seconds* timeout_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_seconds(item_value, timeout_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_seconds(item_value, timeout_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -14124,8 +14124,8 @@ int target_get_dynamic(TARGET_HANDLE target, bool* dynamic_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, dynamic_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, dynamic_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -14215,8 +14215,8 @@ int target_get_dynamic_node_properties(TARGET_HANDLE target, node_properties* dy
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_node_properties(item_value, dynamic_node_properties_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_node_properties(item_value, dynamic_node_properties_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -14772,8 +14772,8 @@ int header_get_durable(HEADER_HANDLE header, bool* durable_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, durable_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, durable_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -14865,8 +14865,8 @@ int header_get_priority(HEADER_HANDLE header, uint8_t* priority_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_ubyte(item_value, priority_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_ubyte(item_value, priority_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -14956,8 +14956,8 @@ int header_get_ttl(HEADER_HANDLE header, milliseconds* ttl_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_milliseconds(item_value, ttl_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_milliseconds(item_value, ttl_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -15041,8 +15041,8 @@ int header_get_first_acquirer(HEADER_HANDLE header, bool* first_acquirer_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, first_acquirer_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, first_acquirer_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -15134,8 +15134,8 @@ int header_get_delivery_count(HEADER_HANDLE header, uint32_t* delivery_count_val
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_uint(item_value, delivery_count_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_uint(item_value, delivery_count_value);
+                    if (get_single_value_result != 0)
                     {
                         if (amqpvalue_get_type(item_value) != AMQP_TYPE_NULL)
                         {
@@ -16096,8 +16096,8 @@ int properties_get_user_id(PROPERTIES_HANDLE properties, amqp_binary* user_id_va
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_binary(item_value, user_id_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_binary(item_value, user_id_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -16263,8 +16263,8 @@ int properties_get_subject(PROPERTIES_HANDLE properties, const char** subject_va
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_string(item_value, subject_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_string(item_value, subject_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -16514,8 +16514,8 @@ int properties_get_content_type(PROPERTIES_HANDLE properties, const char** conte
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_symbol(item_value, content_type_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_symbol(item_value, content_type_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -16597,8 +16597,8 @@ int properties_get_content_encoding(PROPERTIES_HANDLE properties, const char** c
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_symbol(item_value, content_encoding_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_symbol(item_value, content_encoding_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -16680,8 +16680,8 @@ int properties_get_absolute_expiry_time(PROPERTIES_HANDLE properties, timestamp*
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_timestamp(item_value, absolute_expiry_time_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_timestamp(item_value, absolute_expiry_time_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -16763,8 +16763,8 @@ int properties_get_creation_time(PROPERTIES_HANDLE properties, timestamp* creati
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_timestamp(item_value, creation_time_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_timestamp(item_value, creation_time_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -16846,8 +16846,8 @@ int properties_get_group_id(PROPERTIES_HANDLE properties, const char** group_id_
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_string(item_value, group_id_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_string(item_value, group_id_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -16929,8 +16929,8 @@ int properties_get_group_sequence(PROPERTIES_HANDLE properties, sequence_no* gro
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_sequence_no(item_value, group_sequence_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_sequence_no(item_value, group_sequence_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -17012,8 +17012,8 @@ int properties_get_reply_to_group_id(PROPERTIES_HANDLE properties, const char** 
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_string(item_value, reply_to_group_id_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_string(item_value, reply_to_group_id_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -17333,8 +17333,8 @@ int received_get_section_number(RECEIVED_HANDLE received, uint32_t* section_numb
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_uint(item_value, section_number_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_uint(item_value, section_number_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -17416,8 +17416,8 @@ int received_get_section_offset(RECEIVED_HANDLE received, uint64_t* section_offs
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_ulong(item_value, section_offset_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_ulong(item_value, section_offset_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -17807,8 +17807,8 @@ int rejected_get_error(REJECTED_HANDLE rejected, ERROR_HANDLE* error_value)
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_error(item_value, error_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_error(item_value, error_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -18252,8 +18252,8 @@ int modified_get_delivery_failed(MODIFIED_HANDLE modified, bool* delivery_failed
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, delivery_failed_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, delivery_failed_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -18335,8 +18335,8 @@ int modified_get_undeliverable_here(MODIFIED_HANDLE modified, bool* undeliverabl
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_boolean(item_value, undeliverable_here_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_boolean(item_value, undeliverable_here_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -18418,8 +18418,8 @@ int modified_get_message_annotations(MODIFIED_HANDLE modified, fields* message_a
                 }
                 else
                 {
-                    int get_single_value_result;
-                    if ((get_single_value_result = amqpvalue_get_fields(item_value, message_annotations_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_fields(item_value, message_annotations_value);
+                    if (get_single_value_result != 0)
                     {
                         result = __FAILURE__;
                     }
@@ -18468,5 +18468,3 @@ int modified_set_message_annotations(MODIFIED_HANDLE modified, fields message_an
 
     return result;
 }
-
-

--- a/src/amqp_definitions.c
+++ b/src/amqp_definitions.c
@@ -18468,3 +18468,5 @@ int modified_set_message_annotations(MODIFIED_HANDLE modified, fields message_an
 
     return result;
 }
+
+

--- a/src/amqp_management.c
+++ b/src/amqp_management.c
@@ -54,8 +54,8 @@ typedef struct AMQP_MANAGEMENT_INSTANCE_TAG
     AMQP_MANAGEMENT_STATE amqp_management_state;
     char* status_code_key_name;
     char* status_description_key_name;
-    int sender_connected : 1;
-    int receiver_connected : 1;
+    uint8_t sender_connected : 1;
+    uint8_t receiver_connected : 1;
 } AMQP_MANAGEMENT_INSTANCE;
 
 static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE message)
@@ -410,7 +410,7 @@ static void on_message_sender_state_changed(void* context, MESSAGE_SENDER_STATE 
                     break;
 
                 case MESSAGE_SENDER_STATE_OPEN:
-                    amqp_management_instance->sender_connected = -1;
+                    amqp_management_instance->sender_connected = 1;
                     /* Codes_SRS_AMQP_MANAGEMENT_01_142: [ - If `new_state` is `MESSAGE_SENDER_STATE_OPEN` and the message receiver did not yet indicate its state as `MESSAGE_RECEIVER_STATE_OPEN`, the `on_amqp_management_open_complete` callback shall not be called.]*/
                     if (amqp_management_instance->receiver_connected != 0)
                     {
@@ -509,7 +509,7 @@ static void on_message_receiver_state_changed(const void* context, MESSAGE_RECEI
                     break;
 
                 case MESSAGE_RECEIVER_STATE_OPEN:
-                    amqp_management_instance->receiver_connected = -1;
+                    amqp_management_instance->receiver_connected = 1;
                     /* Codes_SRS_AMQP_MANAGEMENT_01_154: [ - If `new_state` is `MESSAGE_RECEIVER_STATE_OPEN` and the message sender did not yet indicate its state as `MESSAGE_RECEIVER_STATE_OPEN`, the `on_amqp_management_open_complete` callback shall not be called. ]*/
                     if (amqp_management_instance->sender_connected != 0)
                     {
@@ -1062,7 +1062,7 @@ int amqp_management_close(AMQP_MANAGEMENT_HANDLE amqp_management)
                     operation_message->on_execute_operation_complete(operation_message->callback_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_INSTANCE_CLOSED, 0, NULL, NULL);
                     free(operation_message);
                 }
-                
+
                 if (singlylinkedlist_remove(amqp_management->pending_operations, list_item_handle) != 0)
                 {
                     LogError("Cannot remove item");

--- a/src/connection.c
+++ b/src/connection.c
@@ -104,7 +104,7 @@ static void connection_set_state(CONNECTION_HANDLE connection, CONNECTION_STATE 
     }
 }
 
-// This callback usage needs to be either verified and commented or integrated into 
+// This callback usage needs to be either verified and commented or integrated into
 // the state machine.
 static void unchecked_on_send_complete(void* context, IO_SEND_RESULT send_result)
 {
@@ -147,6 +147,7 @@ static int send_header(CONNECTION_HANDLE connection)
     return result;
 }
 
+#ifndef NO_LOGGING
 static const char* get_frame_type_as_string(AMQP_VALUE descriptor)
 {
     const char* result;
@@ -194,6 +195,7 @@ static const char* get_frame_type_as_string(AMQP_VALUE descriptor)
 
     return result;
 }
+#endif // NO_LOGGING
 
 static void log_incoming_frame(AMQP_VALUE performative)
 {
@@ -248,7 +250,7 @@ static void log_outgoing_frame(AMQP_VALUE performative)
 static void on_bytes_encoded(void* context, const unsigned char* bytes, size_t length, bool encode_complete)
 {
     CONNECTION_HANDLE connection = (CONNECTION_HANDLE)context;
-    if (xio_send(connection->io, bytes, length, 
+    if (xio_send(connection->io, bytes, length,
         (encode_complete && connection->on_send_complete != NULL) ? connection->on_send_complete : unchecked_on_send_complete,
         connection->on_send_complete_callback_context) != 0)
     {
@@ -288,7 +290,7 @@ static int send_open_frame(CONNECTION_HANDLE connection)
         if (open_performative == NULL)
         {
             LogError("Cannot create OPEN performative");
-            
+
             /* Codes_SRS_CONNECTION_01_208: [If the open frame cannot be constructed, the connection shall be closed and set to the END state.] */
             if (xio_close(connection->io, NULL, NULL) != 0)
             {
@@ -1062,7 +1064,7 @@ static void on_amqp_frame_received(void* context, uint16_t channel, AMQP_VALUE p
 
 static void frame_codec_error(void* context)
 {
-    /* Bug: some error handling should happen here 
+    /* Bug: some error handling should happen here
     Filed: uAMQP: frame_codec error and amqp_frame_codec_error should handle the errors */
     LogError("A frame_codec_error occured");
     (void)context;

--- a/src/header_detect_io.c
+++ b/src/header_detect_io.c
@@ -132,7 +132,7 @@ static void on_send_complete(void* context, IO_SEND_RESULT send_result)
     }
 }
 
-// This callback usage needs to be either verified and commented or integrated into 
+// This callback usage needs to be either verified and commented or integrated into
 // the state machine.
 static void unchecked_on_send_complete(void* context, IO_SEND_RESULT send_result)
 {
@@ -942,13 +942,13 @@ static const AMQP_HEADER sasl_amqp_header =
     sizeof(sasl_amqp_header_bytes)
 };
 
-const AMQP_HEADER header_detect_io_get_amqp_header(void)
+AMQP_HEADER header_detect_io_get_amqp_header(void)
 {
     /* Codes_SRS_HEADER_DETECT_IO_01_091: [ `header_detect_io_get_amqp_header` shall return a structure that should point to a buffer that contains the bytes { 'A', 'M', 'Q', 'P', 0, 1, 0, 0 }. ]*/
     return amqp_header;
 }
 
-const AMQP_HEADER header_detect_io_get_sasl_amqp_header(void)
+AMQP_HEADER header_detect_io_get_sasl_amqp_header(void)
 {
     /* Codes_SRS_HEADER_DETECT_IO_01_091: [ `header_detect_io_get_sasl_amqp_header` shall return a structure that should point to a buffer that contains the bytes { 'A', 'M', 'Q', 'P', 3, 1, 0, 0 }. ]*/
     return sasl_amqp_header;

--- a/src/saslclientio.c
+++ b/src/saslclientio.c
@@ -33,6 +33,12 @@ typedef enum IO_STATE_TAG
     SASL_HEADER_EXCHANGE_HEADER_RCVD, \
     SASL_HEADER_EXCHANGE_HEADER_EXCH
 
+// Suppress unused function warning for SASL_HEADER_EXCHANGE_STATEstrings
+#ifdef NO_LOGGING
+#define ENUM_TO_STRING_UNUSED
+#include "azure_c_shared_utility/macro_utils.h"
+#endif
+
 DEFINE_LOCAL_ENUM(SASL_HEADER_EXCHANGE_STATE, SASL_HEADER_EXCHANGE_STATE_VALUES)
 
 #define SASL_CLIENT_NEGOTIATION_STATE_VALUES \
@@ -144,7 +150,7 @@ static void handle_error(SASL_CLIENT_IO_INSTANCE* sasl_client_io_instance)
     }
 }
 
-// This callback usage needs to be either verified and commented or integrated into 
+// This callback usage needs to be either verified and commented or integrated into
 // the state machine.
 static void unchecked_on_send_complete(void* context, IO_SEND_RESULT send_result)
 {
@@ -255,6 +261,7 @@ static void on_underlying_io_error(void* context)
     }
 }
 
+#ifndef NO_LOGGING
 static const char* get_frame_type_as_string(AMQP_VALUE descriptor)
 {
     const char* result;
@@ -286,6 +293,7 @@ static const char* get_frame_type_as_string(AMQP_VALUE descriptor)
 
     return result;
 }
+#endif // NO_LOGGING
 
 static void log_incoming_frame(AMQP_VALUE performative)
 {
@@ -400,7 +408,7 @@ static int saslclientio_receive_byte(SASL_CLIENT_IO_INSTANCE* sasl_client_io_ins
                     LogError("Invalid SASL header exchange state: %s", ENUM_TO_STRING(SASL_HEADER_EXCHANGE_STATE, sasl_client_io_instance->sasl_header_exchange_state));
                     result = __FAILURE__;
                     break;
-                
+
                 case SASL_HEADER_EXCHANGE_HEADER_SENT:
                     /* from this point on we need to decode SASL frames */
                     sasl_client_io_instance->sasl_header_exchange_state = SASL_HEADER_EXCHANGE_HEADER_EXCH;
@@ -1096,7 +1104,7 @@ int saslclientio_open_async(CONCRETE_IO_HANDLE sasl_client_io, ON_IO_OPEN_COMPLE
             }
         }
     }
-    
+
     return result;
 }
 

--- a/src/session.c
+++ b/src/session.c
@@ -45,11 +45,11 @@ typedef struct SESSION_INSTANCE_TAG
     handle handle_max;
     uint32_t remote_incoming_window;
     uint32_t remote_outgoing_window;
-    int is_underlying_connection_open : 1;
+    uint8_t is_underlying_connection_open : 1;
 } SESSION_INSTANCE;
 
 #define UNDERLYING_CONNECTION_NOT_OPEN 0
-#define UNDERLYING_CONNECTION_OPEN -1
+#define UNDERLYING_CONNECTION_OPEN 1
 
 static void session_set_state(SESSION_INSTANCE* session_instance, SESSION_STATE session_state)
 {
@@ -492,8 +492,8 @@ static void on_frame_received(void* context, AMQP_VALUE performative, uint32_t p
             if (flow_get_next_incoming_id(flow_handle, &flow_next_incoming_id) != 0)
             {
                 /*
-                If the next-incoming-id field of the flow frame is not set, 
-                then remote-incomingwindow is computed as follows: 
+                If the next-incoming-id field of the flow frame is not set,
+                then remote-incomingwindow is computed as follows:
                 initial-outgoing-id(endpoint) + incoming-window(flow) - next-outgoing-id(endpoint)
                 */
                 flow_next_incoming_id = session_instance->next_outgoing_id;

--- a/uamqp_generator/amqp_definitions_c.cs
+++ b/uamqp_generator/amqp_definitions_c.cs
@@ -19,7 +19,7 @@ namespace amqplib_generator
     /// Class to produce the template output
     /// </summary>
     
-    #line 1 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+    #line 1 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.TextTemplating", "15.0.0.0")]
     public partial class amqp_definitions_c : amqp_definitions_cBase
     {
@@ -31,7 +31,7 @@ namespace amqplib_generator
         {
             this.Write("\r\n");
             
-            #line 8 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 8 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  amqp amqp = Program.LoadAMQPTypes(); 
             
             #line default
@@ -50,414 +50,414 @@ namespace amqplib_generator
 
 ");
             
-            #line 21 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 21 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
   foreach (section section in amqp.Items.Where(item => item is section)) 
             
             #line default
             #line hidden
             
-            #line 22 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 22 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
   { 
             
             #line default
             #line hidden
             
-            #line 23 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 23 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       List<type> types = new List<type>(); 
             
             #line default
             #line hidden
             
-            #line 24 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 24 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       types.AddRange(section.Items.Where(item => item is type).Cast<type>()); 
             
             #line default
             #line hidden
             
-            #line 25 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 25 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       foreach (type type in types) 
             
             #line default
             #line hidden
             
-            #line 26 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 26 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       { 
             
             #line default
             #line hidden
             
-            #line 27 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 27 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
           string type_name = type.name.ToLower().Replace('-', '_'); 
             
             #line default
             #line hidden
             
-            #line 28 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 28 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
           if (type.@class == typeClass.composite) 
             
             #line default
             #line hidden
             
-            #line 29 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 29 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
           { 
             
             #line default
             #line hidden
             
-            #line 30 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 30 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               var descriptor = type.Items.Where(item => item is descriptor).First() as descriptor; 
             
             #line default
             #line hidden
             this.Write("/* ");
             
-            #line 31 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 31 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type.name));
             
             #line default
             #line hidden
             this.Write(" */\r\n\r\ntypedef struct ");
             
-            #line 33 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 33 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE_TAG\r\n{\r\n    AMQP_VALUE composite_value;\r\n} ");
             
-            #line 36 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 36 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE;\r\n\r\n");
             
-            #line 38 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 38 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               string arg_list = Program.GetMandatoryArgList(type); 
             
             #line default
             #line hidden
             
-            #line 39 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 39 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               KeyValuePair<field, int>[] mandatory_args = Program.GetMandatoryArgs(type).ToArray(); 
             
             #line default
             #line hidden
             this.Write("static ");
             
-            #line 40 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 40 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 40 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 40 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_create_internal(void)\r\n{\r\n    ");
             
-            #line 42 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 42 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 42 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 42 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 42 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 42 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)malloc(sizeof(");
             
-            #line 42 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 42 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE));\r\n    if (");
             
-            #line 43 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 43 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance != NULL)\r\n    {\r\n        ");
             
-            #line 45 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 45 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value = NULL;\r\n    }\r\n\r\n    return ");
             
-            #line 48 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 48 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance;\r\n}\r\n\r\n");
             
-            #line 51 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 51 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 51 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 51 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_create(");
             
-            #line 51 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 51 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(arg_list));
             
             #line default
             #line hidden
             this.Write(")\r\n{\r\n    ");
             
-            #line 53 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 53 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 53 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 53 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 53 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 53 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)malloc(sizeof(");
             
-            #line 53 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 53 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE));\r\n    if (");
             
-            #line 54 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 54 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance != NULL)\r\n    {\r\n        ");
             
-            #line 56 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 56 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value = amqpvalue_create_composite_with_ulong_descriptor(");
             
-            #line 56 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 56 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Program.GetDescriptorCode(Program.GetDescriptor(type))));
             
             #line default
             #line hidden
             this.Write(");\r\n        if (");
             
-            #line 57 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 57 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value == NULL)\r\n        {\r\n            free(");
             
-            #line 59 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 59 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance);\r\n            ");
             
-            #line 60 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 60 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = NULL;\r\n        }\r\n");
             
-            #line 62 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 62 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               if (mandatory_args.Count() > 0) 
             
             #line default
             #line hidden
             
-            #line 63 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 63 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               { 
             
             #line default
             #line hidden
             this.Write("        else\r\n        {\r\n");
             
-            #line 66 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 66 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   for (int i = 0; i < mandatory_args.Count(); i++) 
             
             #line default
             #line hidden
             
-            #line 67 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 67 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   { 
             
             #line default
             #line hidden
             
-            #line 68 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 68 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       string mandatory_arg_name = mandatory_args[i].Key.name.ToLower().Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             this.Write("            AMQP_VALUE ");
             
-            #line 69 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 69 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_arg_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value;\r\n");
             
-            #line 70 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 70 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   } 
             
             #line default
             #line hidden
             this.Write("            int result = 0;\r\n\r\n");
             
-            #line 73 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 73 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   for (int i = 0; i < mandatory_args.Count(); i++) 
             
             #line default
             #line hidden
             
-            #line 74 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 74 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   { 
             
             #line default
             #line hidden
             
-            #line 75 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 75 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       string mandatory_arg_type = Program.GetCType(mandatory_args[i].Key.type.ToLower(), mandatory_args[i].Key.multiple == "true").Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             
-            #line 76 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 76 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       string mandatory_arg_name = mandatory_args[i].Key.name.ToLower().Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             
-            #line 77 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 77 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       if (mandatory_args[i].Key.multiple != "true") 
             
             #line default
             #line hidden
             
-            #line 78 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 78 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       { 
             
             #line default
             #line hidden
             this.Write("            ");
             
-            #line 79 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 79 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_arg_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value = amqpvalue_create_");
             
-            #line 79 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 79 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_args[i].Key.type.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 79 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 79 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_args[i].Key.name.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("_value);\r\n");
             
-            #line 80 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 80 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       } 
             
             #line default
             #line hidden
             
-            #line 81 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 81 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       else 
             
             #line default
             #line hidden
             
-            #line 82 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 82 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       { 
             
             #line default
             #line hidden
             this.Write("            ");
             
-            #line 83 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 83 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_arg_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value = ");
             
-            #line 83 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 83 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_args[i].Key.name.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("_value;\r\n");
             
-            #line 84 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 84 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       } 
             
             #line default
             #line hidden
             this.Write("            if ((result == 0) && (amqpvalue_set_composite_item(");
             
-            #line 85 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 85 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value, ");
             
-            #line 85 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 85 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_args[i].Value));
             
             #line default
             #line hidden
             this.Write(", ");
             
-            #line 85 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 85 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_arg_name));
             
             #line default
@@ -465,292 +465,292 @@ namespace amqplib_generator
             this.Write("_amqp_value) != 0))\r\n            {\r\n                result = __FAILURE__;\r\n      " +
                     "      }\r\n");
             
-            #line 89 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 89 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   } 
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 91 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 91 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   for (int i = 0; i < mandatory_args.Count(); i++) 
             
             #line default
             #line hidden
             
-            #line 92 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 92 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   { 
             
             #line default
             #line hidden
             
-            #line 93 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 93 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       string mandatory_arg_name = mandatory_args[i].Key.name.ToLower().Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             this.Write("            amqpvalue_destroy(");
             
-            #line 94 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 94 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(mandatory_arg_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value);\r\n");
             
-            #line 95 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 95 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   } 
             
             #line default
             #line hidden
             this.Write("        }\r\n");
             
-            #line 97 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 97 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               } 
             
             #line default
             #line hidden
             this.Write("    }\r\n\r\n    return ");
             
-            #line 100 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 100 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance;\r\n}\r\n\r\n");
             
-            #line 103 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 103 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 103 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 103 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_clone(");
             
-            #line 103 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 103 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE value)\r\n{\r\n    ");
             
-            #line 105 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 105 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 105 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 105 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 105 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 105 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)malloc(sizeof(");
             
-            #line 105 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 105 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE));\r\n    if (");
             
-            #line 106 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 106 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance != NULL)\r\n    {\r\n        ");
             
-            #line 108 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 108 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value = amqpvalue_clone(((");
             
-            #line 108 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 108 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)value)->composite_value);\r\n        if (");
             
-            #line 109 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 109 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value == NULL)\r\n        {\r\n            free(");
             
-            #line 111 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 111 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance);\r\n            ");
             
-            #line 112 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 112 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = NULL;\r\n        }\r\n    }\r\n\r\n    return ");
             
-            #line 116 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 116 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance;\r\n}\r\n\r\nvoid ");
             
-            #line 119 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 119 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_destroy(");
             
-            #line 119 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 119 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 119 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 119 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(")\r\n{\r\n    if (");
             
-            #line 121 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 121 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(" != NULL)\r\n    {\r\n        ");
             
-            #line 123 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 123 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 123 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 123 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 123 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 123 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)");
             
-            #line 123 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 123 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(";\r\n        amqpvalue_destroy(");
             
-            #line 124 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 124 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value);\r\n        free(");
             
-            #line 125 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 125 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance);\r\n    }\r\n}\r\n\r\nAMQP_VALUE amqpvalue_create_");
             
-            #line 129 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 129 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 129 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 129 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 129 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 129 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(")\r\n{\r\n    AMQP_VALUE result;\r\n\r\n    if (");
             
-            #line 133 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 133 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(" == NULL)\r\n    {\r\n        result = NULL;\r\n    }\r\n    else\r\n    {\r\n        ");
             
-            #line 139 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 139 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 139 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 139 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 139 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 139 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)");
             
-            #line 139 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 139 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(";\r\n        result = amqpvalue_clone(");
             
-            #line 140 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 140 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value);\r\n    }\r\n\r\n    return result;\r\n}\r\n\r\nbool is_");
             
-            #line 146 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 146 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
@@ -759,7 +759,7 @@ namespace amqplib_generator
                     "escriptor_ulong;\r\n    if ((amqpvalue_get_ulong(descriptor, &descriptor_ulong) ==" +
                     " 0) &&\r\n        (descriptor_ulong == ");
             
-            #line 152 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 152 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Program.GetDescriptorCode(descriptor).ToString()));
             
             #line default
@@ -767,70 +767,70 @@ namespace amqplib_generator
             this.Write("))\r\n    {\r\n        result = true;\r\n    }\r\n    else\r\n    {\r\n        result = false" +
                     ";\r\n    }\r\n\r\n    return result;\r\n}\r\n\r\n\r\nint amqpvalue_get_");
             
-            #line 165 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 165 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("(AMQP_VALUE value, ");
             
-            #line 165 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 165 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE* ");
             
-            #line 165 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 165 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("_handle)\r\n{\r\n    int result;\r\n    ");
             
-            #line 168 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 168 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 168 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 168 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 168 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 168 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)");
             
-            #line 168 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 168 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_create_internal();\r\n    *");
             
-            #line 169 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 169 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("_handle = ");
             
-            #line 169 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 169 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("_instance;\r\n    if (*");
             
-            #line 170 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 170 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -839,14 +839,14 @@ namespace amqplib_generator
                     "       AMQP_VALUE list_value = amqpvalue_get_inplace_described_value(value);\r\n  " +
                     "      if (list_value == NULL)\r\n        {\r\n            ");
             
-            #line 179 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 179 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_destroy(*");
             
-            #line 179 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 179 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -867,88 +867,88 @@ namespace amqplib_generator
                 {
 ");
             
-            #line 193 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 193 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               int k = 0; 
             
             #line default
             #line hidden
             
-            #line 194 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 194 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               bool first_one = true; 
             
             #line default
             #line hidden
             
-            #line 195 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 195 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               foreach (field field in type.Items.Where(item => item is field)) 
             
             #line default
             #line hidden
             
-            #line 196 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 196 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               { 
             
             #line default
             #line hidden
             
-            #line 197 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 197 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   string field_name = field.name.ToLower().Replace('-', '_'); 
             
             #line default
             #line hidden
             
-            #line 198 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 198 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   string c_type = Program.GetCType(field.type, false).Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             
-            #line 199 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 199 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   type field_type = Program.GetTypeByName(field.type); 
             
             #line default
             #line hidden
             
-            #line 200 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 200 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   if ((field_type != null) && (field_type.@class == typeClass.composite)) c_type = field_type.name.ToUpper().Replace('-', '_').Replace(':', '_') + "_HANDLE"; 
             
             #line default
             #line hidden
             
-            #line 201 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 201 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   if (first_one) 
             
             #line default
             #line hidden
             
-            #line 202 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 202 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   { 
             
             #line default
             #line hidden
             
-            #line 203 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 203 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       first_one = false; 
             
             #line default
             #line hidden
             this.Write("                    AMQP_VALUE item_value;\r\n");
             
-            #line 205 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 205 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   } 
             
             #line default
             #line hidden
             this.Write("                    /* ");
             
-            #line 206 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 206 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.name));
             
             #line default
             #line hidden
             this.Write(" */\r\n                    if (list_item_count > ");
             
-            #line 207 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 207 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(k));
             
             #line default
@@ -956,34 +956,34 @@ namespace amqplib_generator
             this.Write(")\r\n                    {\r\n                        item_value = amqpvalue_get_list" +
                     "_item(list_value, ");
             
-            #line 209 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 209 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(k));
             
             #line default
             #line hidden
             this.Write(");\r\n                        if (item_value == NULL)\r\n                        {\r\n");
             
-            #line 212 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 212 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      if (field.mandatory == "true") 
             
             #line default
             #line hidden
             
-            #line 213 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 213 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      { 
             
             #line default
             #line hidden
             this.Write("                            {\r\n                                ");
             
-            #line 215 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 215 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_destroy(*");
             
-            #line 215 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 215 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -991,26 +991,26 @@ namespace amqplib_generator
             this.Write("_handle);\r\n                                result = __FAILURE__;\r\n               " +
                     "                 break;\r\n                            }\r\n");
             
-            #line 219 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 219 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      } 
             
             #line default
             #line hidden
             
-            #line 220 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 220 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      else 
             
             #line default
             #line hidden
             
-            #line 221 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 221 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      { 
             
             #line default
             #line hidden
             this.Write("                            /* do nothing */\r\n");
             
-            #line 223 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 223 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      } 
             
             #line default
@@ -1018,13 +1018,13 @@ namespace amqplib_generator
             this.Write("                        }\r\n                        else\r\n                        " +
                     "{\r\n");
             
-            #line 227 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 227 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  if (field.type != "*") 
             
             #line default
             #line hidden
             
-            #line 228 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 228 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  { 
             
             #line default
@@ -1032,13 +1032,13 @@ namespace amqplib_generator
             this.Write("                            if (amqpvalue_get_type(item_value) == AMQP_TYPE_NULL)" +
                     "\r\n                            {\r\n");
             
-            #line 231 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 231 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      if (field.mandatory == "true") 
             
             #line default
             #line hidden
             
-            #line 232 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 232 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      { 
             
             #line default
@@ -1046,14 +1046,14 @@ namespace amqplib_generator
             this.Write("                                amqpvalue_destroy(item_value);\r\n                 " +
                     "               ");
             
-            #line 234 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 234 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_destroy(*");
             
-            #line 234 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 234 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -1061,26 +1061,26 @@ namespace amqplib_generator
             this.Write("_handle);\r\n                                result = __FAILURE__;\r\n               " +
                     "                 break;\r\n");
             
-            #line 237 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 237 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      } 
             
             #line default
             #line hidden
             
-            #line 238 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 238 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      else 
             
             #line default
             #line hidden
             
-            #line 239 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 239 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      { 
             
             #line default
             #line hidden
             this.Write("                                /* no error, field is not mandatory */\r\n");
             
-            #line 241 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 241 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      } 
             
             #line default
@@ -1088,81 +1088,81 @@ namespace amqplib_generator
             this.Write("                            }\r\n                            else\r\n                " +
                     "            {\r\n");
             
-            #line 245 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 245 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       if (field.multiple != "true") 
             
             #line default
             #line hidden
             
-            #line 246 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 246 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       { 
             
             #line default
             #line hidden
             this.Write("                                ");
             
-            #line 247 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 247 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(c_type));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 247 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 247 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write(";\r\n                                if (amqpvalue_get_");
             
-            #line 248 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 248 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.type.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(item_value, &");
             
-            #line 248 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 248 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write(") != 0)\r\n");
             
-            #line 249 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 249 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       } 
             
             #line default
             #line hidden
             
-            #line 250 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 250 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       else 
             
             #line default
             #line hidden
             
-            #line 251 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 251 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       { 
             
             #line default
             #line hidden
             this.Write("                                ");
             
-            #line 252 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 252 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(c_type));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 252 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 252 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write(" = NULL;\r\n                                AMQP_VALUE ");
             
-            #line 253 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 253 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -1170,28 +1170,28 @@ namespace amqplib_generator
             this.Write("_array;\r\n                                if (((amqpvalue_get_type(item_value) != " +
                     "AMQP_TYPE_ARRAY) || (amqpvalue_get_array(item_value, &");
             
-            #line 254 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 254 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_array) != 0)) &&\r\n                                    (amqpvalue_get_");
             
-            #line 255 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 255 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.type.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(item_value, &");
             
-            #line 255 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 255 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write(") != 0))\r\n");
             
-            #line 256 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 256 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       } 
             
             #line default
@@ -1199,14 +1199,14 @@ namespace amqplib_generator
             this.Write("                                {\r\n                                    amqpvalue_" +
                     "destroy(item_value);\r\n                                    ");
             
-            #line 259 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 259 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_destroy(*");
             
-            #line 259 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 259 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -1214,13 +1214,13 @@ namespace amqplib_generator
             this.Write("_handle);\r\n                                    result = __FAILURE__;\r\n           " +
                     "                         break;\r\n                                }\r\n");
             
-            #line 263 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 263 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       if (c_type == "ERROR_HANDLE") 
             
             #line default
             #line hidden
             
-            #line 264 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 264 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       { 
             
             #line default
@@ -1228,39 +1228,39 @@ namespace amqplib_generator
             this.Write("                                else\r\n                                {\r\n        " +
                     "                            error_destroy(");
             
-            #line 267 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 267 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name.ToLower()));
             
             #line default
             #line hidden
             this.Write(");\r\n                                }\r\n");
             
-            #line 269 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 269 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       } 
             
             #line default
             #line hidden
             this.Write("                            }\r\n\r\n");
             
-            #line 272 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 272 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  } 
             
             #line default
             #line hidden
             
-            #line 273 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 273 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  else 
             
             #line default
             #line hidden
             
-            #line 274 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 274 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  { 
             
             #line default
             #line hidden
             
-            #line 275 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 275 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  } 
             
             #line default
@@ -1268,13 +1268,13 @@ namespace amqplib_generator
             this.Write("                            amqpvalue_destroy(item_value);\r\n                     " +
                     "   }\r\n                    }\r\n");
             
-            #line 279 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 279 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      if (field.mandatory == "true") 
             
             #line default
             #line hidden
             
-            #line 280 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 280 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      { 
             
             #line default
@@ -1282,26 +1282,26 @@ namespace amqplib_generator
             this.Write("                    else\r\n                    {\r\n                        result =" +
                     " __FAILURE__;\r\n                    }\r\n");
             
-            #line 285 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 285 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                      } 
             
             #line default
             #line hidden
             
-            #line 286 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 286 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   k++; 
             
             #line default
             #line hidden
             
-            #line 287 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 287 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               } 
             
             #line default
             #line hidden
             this.Write("\r\n                    ");
             
-            #line 289 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 289 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -1310,98 +1310,98 @@ namespace amqplib_generator
                     "t = 0;\r\n                } while((void)0,0);\r\n            }\r\n        }\r\n    }\r\n\r\n" +
                     "    return result;\r\n}\r\n\r\n");
             
-            #line 300 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 300 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               int j = 0; 
             
             #line default
             #line hidden
             
-            #line 301 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 301 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               foreach (field field in type.Items.Where(item => item is field)) 
             
             #line default
             #line hidden
             
-            #line 302 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 302 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               { 
             
             #line default
             #line hidden
             
-            #line 303 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 303 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   string field_name = field.name.ToLower().Replace('-', '_'); 
             
             #line default
             #line hidden
             
-            #line 304 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 304 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   string c_type = Program.GetCType(field.type, field.multiple == "true").Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             
-            #line 305 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 305 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   string single_value_c_type = Program.GetCType(field.type, false).Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             
-            #line 306 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 306 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   type field_type = Program.GetTypeByName(field.type); 
             
             #line default
             #line hidden
             
-            #line 307 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 307 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   if ((field_type != null) && (field_type.@class == typeClass.composite)) c_type = field_type.name.ToUpper().Replace('-', '_').Replace(':', '_') + "_HANDLE"; 
             
             #line default
             #line hidden
             this.Write("int ");
             
-            #line 308 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 308 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_get_");
             
-            #line 308 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 308 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 308 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 308 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 308 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 308 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(", ");
             
-            #line 308 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 308 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(c_type));
             
             #line default
             #line hidden
             this.Write("* ");
             
-            #line 308 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 308 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value)\r\n{\r\n    int result;\r\n\r\n    if (");
             
-            #line 312 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 312 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
@@ -1409,35 +1409,35 @@ namespace amqplib_generator
             this.Write(" == NULL)\r\n    {\r\n        result = __FAILURE__;\r\n    }\r\n    else\r\n    {\r\n        " +
                     "uint32_t item_count;\r\n        ");
             
-            #line 319 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 319 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 319 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 319 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 319 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 319 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)");
             
-            #line 319 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 319 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(";\r\n        if (amqpvalue_get_composite_item_count(");
             
-            #line 320 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 320 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
@@ -1445,119 +1445,119 @@ namespace amqplib_generator
             this.Write("_instance->composite_value, &item_count) != 0)\r\n        {\r\n            result = _" +
                     "_FAILURE__;\r\n        }\r\n        else\r\n        {\r\n            if (item_count <= ");
             
-            #line 326 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 326 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(j));
             
             #line default
             #line hidden
             this.Write(")\r\n            {\r\n");
             
-            #line 328 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 328 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       if (field.@default != null) 
             
             #line default
             #line hidden
             
-            #line 329 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 329 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       { 
             
             #line default
             #line hidden
             
-            #line 330 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 330 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           if ((field_type != null) && (field_type.@class == typeClass.restricted) && (field_type.Items != null)) 
             
             #line default
             #line hidden
             
-            #line 331 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 331 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           { 
             
             #line default
             #line hidden
             this.Write("                *");
             
-            #line 332 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 332 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value = ");
             
-            #line 332 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 332 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_type.@name.Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("_");
             
-            #line 332 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 332 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.@default.Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 333 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 333 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           } 
             
             #line default
             #line hidden
             
-            #line 334 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 334 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           else 
             
             #line default
             #line hidden
             
-            #line 335 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 335 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           { 
             
             #line default
             #line hidden
             this.Write("                *");
             
-            #line 336 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 336 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value = ");
             
-            #line 336 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 336 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.@default));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 337 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 337 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           } 
             
             #line default
             #line hidden
             this.Write("                result = 0;\r\n");
             
-            #line 339 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 339 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       } 
             
             #line default
             #line hidden
             
-            #line 340 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 340 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       else 
             
             #line default
             #line hidden
             
-            #line 341 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 341 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       { 
             
             #line default
             #line hidden
             this.Write("                result = __FAILURE__;\r\n");
             
-            #line 343 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 343 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       } 
             
             #line default
@@ -1565,14 +1565,14 @@ namespace amqplib_generator
             this.Write("            }\r\n            else\r\n            {\r\n                AMQP_VALUE item_v" +
                     "alue = amqpvalue_get_composite_item_in_place(");
             
-            #line 347 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 347 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value, ");
             
-            #line 347 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 347 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(j));
             
             #line default
@@ -1580,246 +1580,245 @@ namespace amqplib_generator
             this.Write(");\r\n                if ((item_value == NULL) ||\r\n                    (amqpvalue_g" +
                     "et_type(item_value) == AMQP_TYPE_NULL))\r\n                {\r\n");
             
-            #line 351 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 351 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       if (field.@default != null) 
             
             #line default
             #line hidden
             
-            #line 352 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 352 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       { 
             
             #line default
             #line hidden
             
-            #line 353 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 353 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           if ((field_type != null) && (field_type.@class == typeClass.restricted) && (field_type.Items != null)) 
             
             #line default
             #line hidden
             
-            #line 354 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 354 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           { 
             
             #line default
             #line hidden
             this.Write("                    *");
             
-            #line 355 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 355 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value = ");
             
-            #line 355 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 355 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_type.@name.Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("_");
             
-            #line 355 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 355 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.@default.Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 356 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 356 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           } 
             
             #line default
             #line hidden
             
-            #line 357 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 357 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           else 
             
             #line default
             #line hidden
             
-            #line 358 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 358 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           { 
             
             #line default
             #line hidden
             this.Write("                    *");
             
-            #line 359 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 359 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value = ");
             
-            #line 359 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 359 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.@default));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 360 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 360 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           } 
             
             #line default
             #line hidden
             this.Write("                    result = 0;\r\n");
             
-            #line 362 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 362 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       } 
             
             #line default
             #line hidden
             
-            #line 363 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 363 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       else 
             
             #line default
             #line hidden
             
-            #line 364 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 364 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       { 
             
             #line default
             #line hidden
             this.Write("                    result = __FAILURE__;\r\n");
             
-            #line 366 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 366 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       } 
             
             #line default
             #line hidden
             this.Write("                }\r\n                else\r\n                {\r\n");
             
-            #line 370 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 370 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       if (field.multiple == "true") 
             
             #line default
             #line hidden
             
-            #line 371 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 371 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       { 
             
             #line default
             #line hidden
             this.Write("                    ");
             
-            #line 372 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 372 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(single_value_c_type));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 372 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 372 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_single_value;\r\n");
             
-            #line 373 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 373 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       } 
             
             #line default
             #line hidden
             
-            #line 374 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 374 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       if (field.type.Replace('-', '_').Replace(':', '_') == "*") 
             
             #line default
             #line hidden
             
-            #line 375 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 375 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       { 
             
             #line default
             #line hidden
             this.Write("                    *");
             
-            #line 376 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 376 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value = item_value;\r\n                    result = 0;\r\n");
             
-            #line 378 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 378 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       } 
             
             #line default
             #line hidden
             
-            #line 379 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 379 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       else 
             
             #line default
             #line hidden
             
-            #line 380 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 380 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       { 
             
             #line default
             #line hidden
-            this.Write("                    int get_single_value_result;\r\n");
             
-            #line 382 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 381 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           if (field.multiple != "true") 
             
             #line default
             #line hidden
             
-            #line 383 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 382 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           { 
             
             #line default
             #line hidden
-            this.Write("                    if ((get_single_value_result = amqpvalue_get_");
+            this.Write("                    int get_single_value_result = amqpvalue_get_");
             
-            #line 384 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 383 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.type.Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(item_value, ");
             
-            #line 384 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 383 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
-            this.Write("_value)) != 0)\r\n");
+            this.Write("_value);\r\n                    if (get_single_value_result != 0)\r\n");
             
-            #line 385 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 385 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           } 
             
             #line default
             #line hidden
             
-            #line 386 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 386 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           else 
             
             #line default
             #line hidden
             
-            #line 387 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 387 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           { 
             
             #line default
             #line hidden
-            this.Write("                    if (amqpvalue_get_type(item_value) != AMQP_TYPE_ARRAY)\r\n     " +
-                    "               {\r\n                        get_single_value_result = amqpvalue_ge" +
-                    "t_");
+            this.Write("                    int get_single_value_result;\r\n                    if (amqpval" +
+                    "ue_get_type(item_value) != AMQP_TYPE_ARRAY)\r\n                    {\r\n            " +
+                    "            get_single_value_result = amqpvalue_get_");
             
-            #line 390 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 391 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.type.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(item_value, &");
             
-            #line 390 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 391 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -1827,14 +1826,14 @@ namespace amqplib_generator
             this.Write("_single_value);\r\n                    }\r\n                    else\r\n               " +
                     "     {\r\n                        (void)memset((void*)&");
             
-            #line 394 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 395 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_single_value, 0, sizeof(");
             
-            #line 394 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 395 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -1843,27 +1842,27 @@ namespace amqplib_generator
                     "           }\r\n\r\n                    if (((amqpvalue_get_type(item_value) != AMQP" +
                     "_TYPE_ARRAY) || (amqpvalue_get_array(item_value, ");
             
-            #line 398 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 399 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value) != 0)) &&\r\n                        (get_single_value_result != 0))\r\n");
             
-            #line 400 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 401 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           } 
             
             #line default
             #line hidden
             this.Write("                    {\r\n");
             
-            #line 402 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 403 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       if (field.@default != null) 
             
             #line default
             #line hidden
             
-            #line 403 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 404 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       { 
             
             #line default
@@ -1873,113 +1872,113 @@ namespace amqplib_generator
                     "                    }\r\n                        else\r\n                        {\r\n" +
                     "");
             
-            #line 410 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 411 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           if ((field_type != null) && (field_type.@class == typeClass.restricted) && (field_type.Items != null)) 
             
             #line default
             #line hidden
             
-            #line 411 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 412 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           { 
             
             #line default
             #line hidden
             this.Write("                            *");
             
-            #line 412 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 413 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value = ");
             
-            #line 412 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 413 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_type.@name.Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("_");
             
-            #line 412 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 413 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.@default.Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 413 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 414 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           } 
             
             #line default
             #line hidden
             
-            #line 414 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 415 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           else 
             
             #line default
             #line hidden
             
-            #line 415 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 416 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           { 
             
             #line default
             #line hidden
             this.Write("                            *");
             
-            #line 416 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 417 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value = ");
             
-            #line 416 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 417 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.@default));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 417 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 418 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           } 
             
             #line default
             #line hidden
             this.Write("                            result = 0;\r\n                        }\r\n");
             
-            #line 420 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 421 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       } 
             
             #line default
             #line hidden
             
-            #line 421 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 422 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       else 
             
             #line default
             #line hidden
             
-            #line 422 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 423 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       { 
             
             #line default
             #line hidden
             this.Write("                        result = __FAILURE__;\r\n");
             
-            #line 424 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 425 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       } 
             
             #line default
             #line hidden
             this.Write("                    }\r\n                    else\r\n                    {\r\n");
             
-            #line 428 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 429 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           if (field.multiple == "true") 
             
             #line default
             #line hidden
             
-            #line 429 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 430 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           { 
             
             #line default
@@ -1987,14 +1986,14 @@ namespace amqplib_generator
             this.Write("                        if (amqpvalue_get_type(item_value) != AMQP_TYPE_ARRAY)\r\n " +
                     "                       {\r\n                            *");
             
-            #line 432 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 433 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value = amqpvalue_create_array();\r\n                            if (*");
             
-            #line 433 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 434 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -2007,14 +2006,14 @@ namespace amqplib_generator
                             {
                                 AMQP_VALUE single_amqp_value = amqpvalue_create_");
             
-            #line 439 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 440 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.type.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 439 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 440 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -2023,7 +2022,7 @@ namespace amqplib_generator
                     "                                {\r\n                                    amqpvalue" +
                     "_destroy(*");
             
-            #line 442 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 443 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -2033,7 +2032,7 @@ namespace amqplib_generator
                     "             {\r\n                                    if (amqpvalue_add_array_item" +
                     "(*");
             
-            #line 447 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 448 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -2041,7 +2040,7 @@ namespace amqplib_generator
             this.Write("_value, single_amqp_value) != 0)\r\n                                    {\r\n        " +
                     "                                amqpvalue_destroy(*");
             
-            #line 449 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 450 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -2054,21 +2053,21 @@ namespace amqplib_generator
                                     {
                                         if (amqpvalue_set_composite_item(");
             
-            #line 455 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 456 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value, ");
             
-            #line 455 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 456 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(j));
             
             #line default
             #line hidden
             this.Write(", *");
             
-            #line 455 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 456 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -2076,7 +2075,7 @@ namespace amqplib_generator
             this.Write("_value) != 0)\r\n                                        {\r\n                       " +
                     "                     amqpvalue_destroy(*");
             
-            #line 457 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 458 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -2094,7 +2093,7 @@ namespace amqplib_generator
                                 }
                                 amqpvalue_destroy(*");
             
-            #line 468 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 469 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -2103,33 +2102,33 @@ namespace amqplib_generator
                     "           else\r\n                        {\r\n                            result =" +
                     " 0;\r\n                        }\r\n");
             
-            #line 475 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 476 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           } 
             
             #line default
             #line hidden
             
-            #line 476 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 477 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           else 
             
             #line default
             #line hidden
             
-            #line 477 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 478 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           { 
             
             #line default
             #line hidden
             this.Write("                        result = 0;\r\n");
             
-            #line 479 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 480 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                           } 
             
             #line default
             #line hidden
             this.Write("                    }\r\n");
             
-            #line 481 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 482 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                       } 
             
             #line default
@@ -2137,49 +2136,49 @@ namespace amqplib_generator
             this.Write("                }\r\n            }\r\n        }\r\n    }\r\n\r\n    return result;\r\n}\r\n\r\nin" +
                     "t ");
             
-            #line 490 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 491 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_set_");
             
-            #line 490 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 491 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 490 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 491 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_HANDLE ");
             
-            #line 490 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 491 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(", ");
             
-            #line 490 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 491 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(c_type));
             
             #line default
             #line hidden
             this.Write(" ");
             
-            #line 490 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 491 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value)\r\n{\r\n    int result;\r\n\r\n    if (");
             
-            #line 494 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 495 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
@@ -2187,130 +2186,130 @@ namespace amqplib_generator
             this.Write(" == NULL)\r\n    {\r\n        result = __FAILURE__;\r\n    }\r\n    else\r\n    {\r\n        " +
                     "");
             
-            #line 500 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 501 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE* ");
             
-            #line 500 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 501 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance = (");
             
-            #line 500 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 501 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToUpper()));
             
             #line default
             #line hidden
             this.Write("_INSTANCE*)");
             
-            #line 500 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 501 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 501 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 502 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  if (c_type != "AMQP_VALUE") 
             
             #line default
             #line hidden
             
-            #line 502 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 503 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  { 
             
             #line default
             #line hidden
             this.Write("        AMQP_VALUE ");
             
-            #line 503 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 504 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value = amqpvalue_create_");
             
-            #line 503 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 504 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field.type.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 503 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 504 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value);\r\n");
             
-            #line 504 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 505 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  } 
             
             #line default
             #line hidden
             
-            #line 505 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 506 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  else 
             
             #line default
             #line hidden
             
-            #line 506 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 507 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  { 
             
             #line default
             #line hidden
             this.Write("        AMQP_VALUE ");
             
-            #line 507 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 508 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value;\r\n        if (");
             
-            #line 508 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 509 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value == NULL)\r\n        {\r\n            ");
             
-            #line 510 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 511 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value = NULL;\r\n        }\r\n        else\r\n        {\r\n            ");
             
-            #line 514 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 515 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value = amqpvalue_clone(");
             
-            #line 514 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 515 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_value);\r\n        }\r\n");
             
-            #line 516 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 517 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
  } 
             
             #line default
             #line hidden
             this.Write("        if (");
             
-            #line 517 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 518 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -2318,21 +2317,21 @@ namespace amqplib_generator
             this.Write("_amqp_value == NULL)\r\n        {\r\n            result = __FAILURE__;\r\n        }\r\n  " +
                     "      else\r\n        {\r\n            if (amqpvalue_set_composite_item(");
             
-            #line 523 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 524 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name));
             
             #line default
             #line hidden
             this.Write("_instance->composite_value, ");
             
-            #line 523 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 524 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(j));
             
             #line default
             #line hidden
             this.Write(", ");
             
-            #line 523 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 524 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
@@ -2341,137 +2340,137 @@ namespace amqplib_generator
                     "     }\r\n            else\r\n            {\r\n                result = 0;\r\n          " +
                     "  }\r\n\r\n            amqpvalue_destroy(");
             
-            #line 532 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 533 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(field_name));
             
             #line default
             #line hidden
             this.Write("_amqp_value);\r\n        }\r\n    }\r\n\r\n    return result;\r\n}\r\n\r\n");
             
-            #line 539 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 540 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   j++; 
             
             #line default
             #line hidden
             
-            #line 540 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 541 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               } 
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 542 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 543 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
           } 
             
             #line default
             #line hidden
             
-            #line 543 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 544 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
           else if (type.@class == typeClass.restricted) 
             
             #line default
             #line hidden
             
-            #line 544 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 545 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
           { 
             
             #line default
             #line hidden
             
-            #line 545 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 546 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               string c_type = Program.GetCType(type.source, false).Replace('-', '_').Replace(':', '_'); 
             
             #line default
             #line hidden
             
-            #line 546 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 547 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               bool hasDescriptor = (type.Items != null) && (type.Items.Where(item => item is descriptor).Count() > 0); 
             
             #line default
             #line hidden
             this.Write("/* ");
             
-            #line 547 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 548 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type.name));
             
             #line default
             #line hidden
             this.Write(" */\r\n\r\n");
             
-            #line 549 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 550 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               if (c_type != "AMQP_VALUE") 
             
             #line default
             #line hidden
             
-            #line 550 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 551 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               { 
             
             #line default
             #line hidden
             
-            #line 551 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 552 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   if (!hasDescriptor) 
             
             #line default
             #line hidden
             
-            #line 552 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 553 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   { 
             
             #line default
             #line hidden
             this.Write("AMQP_VALUE amqpvalue_create_");
             
-            #line 553 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 554 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 553 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 554 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write(" value)\r\n{\r\n    return amqpvalue_create_");
             
-            #line 555 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 556 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type.source.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
             #line hidden
             this.Write("(value);\r\n}\r\n");
             
-            #line 557 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 558 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   } 
             
             #line default
             #line hidden
             
-            #line 558 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 559 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   else 
             
             #line default
             #line hidden
             
-            #line 559 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 560 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   { 
             
             #line default
             #line hidden
             this.Write("AMQP_VALUE amqpvalue_create_");
             
-            #line 560 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 561 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("(");
             
-            #line 560 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 561 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -2479,7 +2478,7 @@ namespace amqplib_generator
             this.Write(" value)\r\n{\r\n    AMQP_VALUE result;\r\n    AMQP_VALUE described_value = amqpvalue_cr" +
                     "eate_");
             
-            #line 563 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 564 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type.source.ToLower().Replace('-', '_').Replace(':', '_')));
             
             #line default
@@ -2487,7 +2486,7 @@ namespace amqplib_generator
             this.Write("(value);\r\n    if (described_value == NULL)\r\n    {\r\n        result = NULL;\r\n    }\r" +
                     "\n    else\r\n    {\r\n        AMQP_VALUE descriptor = amqpvalue_create_ulong(");
             
-            #line 570 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 571 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Program.GetDescriptorCode(Program.GetDescriptor(type))));
             
             #line default
@@ -2512,7 +2511,7 @@ namespace amqplib_generator
 
 bool is_");
             
-            #line 588 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 589 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -2521,7 +2520,7 @@ bool is_");
                     "escriptor_ulong;\r\n    if ((amqpvalue_get_ulong(descriptor, &descriptor_ulong) ==" +
                     " 0) &&\r\n        (descriptor_ulong == ");
             
-            #line 594 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 595 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Program.GetDescriptorCode(Program.GetDescriptor(type)).ToString()));
             
             #line default
@@ -2529,70 +2528,70 @@ bool is_");
             this.Write("))\r\n    {\r\n        result = true;\r\n    }\r\n    else\r\n    {\r\n        result = false" +
                     ";\r\n    }\r\n\r\n    return result;\r\n}\r\n");
             
-            #line 605 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 606 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   } 
             
             #line default
             #line hidden
             
-            #line 606 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 607 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               } 
             
             #line default
             #line hidden
             
-            #line 607 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 608 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               else 
             
             #line default
             #line hidden
             
-            #line 608 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 609 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               { 
             
             #line default
             #line hidden
             
-            #line 609 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 610 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   if (!hasDescriptor) 
             
             #line default
             #line hidden
             
-            #line 610 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 611 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   { 
             
             #line default
             #line hidden
             this.Write("AMQP_VALUE amqpvalue_create_");
             
-            #line 611 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 612 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
             #line hidden
             this.Write("(AMQP_VALUE value)\r\n{\r\n    return amqpvalue_clone(value);\r\n}\r\n");
             
-            #line 615 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 616 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   } 
             
             #line default
             #line hidden
             
-            #line 616 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 617 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   else 
             
             #line default
             #line hidden
             
-            #line 617 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 618 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   { 
             
             #line default
             #line hidden
             this.Write("AMQP_VALUE amqpvalue_create_");
             
-            #line 618 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 619 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -2602,7 +2601,7 @@ bool is_");
                     "= NULL;\r\n    }\r\n    else\r\n    {\r\n        AMQP_VALUE descriptor = amqpvalue_creat" +
                     "e_ulong(");
             
-            #line 628 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 629 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Program.GetDescriptorCode(Program.GetDescriptor(type))));
             
             #line default
@@ -2627,7 +2626,7 @@ bool is_");
 
 bool is_");
             
-            #line 646 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 647 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(type_name.ToLower()));
             
             #line default
@@ -2636,7 +2635,7 @@ bool is_");
                     "escriptor_ulong;\r\n    if ((amqpvalue_get_ulong(descriptor, &descriptor_ulong) ==" +
                     " 0) &&\r\n        (descriptor_ulong == ");
             
-            #line 652 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 653 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Program.GetDescriptorCode(Program.GetDescriptor(type)).ToString()));
             
             #line default
@@ -2644,32 +2643,32 @@ bool is_");
             this.Write("))\r\n    {\r\n        result = true;\r\n    }\r\n    else\r\n    {\r\n        result = false" +
                     ";\r\n    }\r\n\r\n    return result;\r\n}\r\n");
             
-            #line 663 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 664 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
                   } 
             
             #line default
             #line hidden
             
-            #line 664 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 665 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
               } 
             
             #line default
             #line hidden
             this.Write("\r\n");
             
-            #line 666 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 667 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
           } 
             
             #line default
             #line hidden
             
-            #line 667 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 668 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
       } 
             
             #line default
             #line hidden
             
-            #line 668 "E:\iot\azure-iot-sdk-c\uamqp\uamqp_generator\amqp_definitions_c.tt"
+            #line 669 "C:\iot\azure-uamqp-c\uamqp_generator\amqp_definitions_c.tt"
   } 
             
             #line default

--- a/uamqp_generator/amqp_definitions_c.tt
+++ b/uamqp_generator/amqp_definitions_c.tt
@@ -378,13 +378,14 @@ int <#= type_name #>_get_<#= field_name #>(<#= type_name.ToUpper() #>_HANDLE <#=
 <#                      } #>
 <#                      else #>
 <#                      { #>
-                    int get_single_value_result;
 <#                          if (field.multiple != "true") #>
 <#                          { #>
-                    if ((get_single_value_result = amqpvalue_get_<#= field.type.Replace('-', '_').Replace(':', '_') #>(item_value, <#= field_name #>_value)) != 0)
+                    int get_single_value_result = amqpvalue_get_<#= field.type.Replace('-', '_').Replace(':', '_') #>(item_value, <#= field_name #>_value);
+                    if (get_single_value_result != 0)
 <#                          } #>
 <#                          else #>
 <#                          { #>
+                    int get_single_value_result;
                     if (amqpvalue_get_type(item_value) != AMQP_TYPE_ARRAY)
                     {
                         get_single_value_result = amqpvalue_get_<#= field.type.ToLower().Replace('-', '_').Replace(':', '_') #>(item_value, &<#= field_name #>_single_value);


### PR DESCRIPTION
Found while trying to port 2018-03-02 on master to the [TI CC3220SF](http://www.ti.com/product/CC3220) at the #IoTInsiderLab

Silences the following warnings:

```
"../../src/amqp_definitions.c", line 385: warning: variable "get_single_value_result" was set but never used
     ... the above warning occurs many times in amqp_definitions.c, removed for brevity...
"../../src/amqp_management.c", line 55: warning: signed bit field of length 1
"../../src/amqp_management.c", line 56: warning: signed bit field of length 1
"../../src/connection.c", line 149: warning: function "get_frame_type_as_string" was declared but never referenced
"../../inc/azure_uamqp_c/header_detect_io.h", line 38: warning: type qualifier on return type is meaningless
"../../inc/azure_uamqp_c/header_detect_io.h", line 39: warning: type qualifier on return type is meaningless
"../../src/header_detect_io.c", line 945: warning: type qualifier on return type is meaningless
"../../src/header_detect_io.c", line 951: warning: type qualifier on return type is meaningless
"../../src/saslclientio.c", line 42: warning: function "SASL_HEADER_EXCHANGE_STATEStrings" was declared but never referenced
"../../src/saslclientio.c", line 53: warning: function "SASL_CLIENT_NEGOTIATION_STATEStrings" was declared but never referenced
"../../src/saslclientio.c", line 265: warning: function "get_frame_type_as_string" was declared but never referenced
"../../src/session.c", line 48: warning: signed bit field of length 1
```

**Note: The code change to silence 2 of the warnings in saslclientio.c requires the [pull request](https://github.com/Azure/azure-c-shared-utility/pull/149) I submitted to azure-c-shared-utility. Without the dependent pull request, everything will continue the work, the warning just won't be silenced.**

All unittests pass for both logging and no_logging

```
$ docker run -it --rm --mount type=bind,src=/Users/seank/Development/azure-uamqp-c,dst=/src/azure-uamqp-c azure-build
# cd azure-uamqp-c/
# mkdir cmake
# cd cmake/
# cmake .. -Drun_unittests:bool=ON
-- The C compiler identification is GNU 5.4.0
...clipped for brevity...
-- Build files have been written to: /src/azure-uamqp-c/cmake
# cmake --build .
Scanning dependencies of target aziotsharedutil
[  0%] Building C object deps/azure-c-shared-utility/CMakeFiles/aziotsharedutil.dir/src/base32.c.o
...clipped for brevity...
[100%] Built target local_client_server_tcp_perf
# ./tests/amqp_frame_codec_ut/amqp_frame_codec_ut_exe
 === Executing test suite amqp_frame_codec_ut ===
...clipped for brevity...
47 tests ran, 0 failed, 47 succeeded.
# ./tests/amqp_management_ut/amqp_management_ut_exe
 === Executing test suite amqp_management_ut ===
...clipped for brevity...
116 tests ran, 0 failed, 116 succeeded.
# ./tests/amqpvalue_ut/amqpvalue_ut_exe
 === Executing test suite amqpvalue_ut ===
...clipped for brevity...
693 tests ran, 0 failed, 693 succeeded.
# ./tests/async_operation_ut/async_operation_ut_exe
 === Executing test suite async_operation_ut ===
...clipped for brevity...
8 tests ran, 0 failed, 8 succeeded.
# ./tests/cbs_ut/cbs_ut_exe
 === Executing test suite cbs_ut ===
...clipped for brevity...
67 tests ran, 0 failed, 67 succeeded.
# ./tests/connection_ut/connection_ut_exe
 === Executing test suite connection_ut ===
...clipped for brevity...
9 tests ran, 0 failed, 9 succeeded.
# ./tests/frame_codec_ut/frame_codec_ut_exe
 === Executing test suite frame_codec_ut ===
...clipped for brevity...
82 tests ran, 0 failed, 82 succeeded.
# ./tests/header_detect_io_ut/header_detect_io_ut_exe
 === Executing test suite header_detect_io_ut ===
...clipped for brevity...
97 tests ran, 0 failed, 97 succeeded.
# ./tests/message_ut/message_ut_exe
 === Executing test suite message_ut ===
...clipped for brevity...
167 tests ran, 0 failed, 167 succeeded.
# ./tests/sasl_anonymous_ut/sasl_anonymous_ut_exe
 === Executing test suite sasl_anonymous_ut ===
...clipped for brevity...
15 tests ran, 0 failed, 15 succeeded.
# ./tests/sasl_frame_codec_ut/sasl_frame_codec_ut_exe
 === Executing test suite sasl_frame_codec_ut ===
...clipped for brevity...
42 tests ran, 0 failed, 42 succeeded.
# ./tests/sasl_mechanism_ut/sasl_mechanism_ut_exe
 === Executing test suite sasl_mechanism_ut ===
...clipped for brevity...
21 tests ran, 0 failed, 21 succeeded.
# ./tests/sasl_plain_ut/sasl_plain_ut_exe
 === Executing test suite sasl_plain_ut ===
 ...clipped for brevity...
28 tests ran, 0 failed, 28 succeeded.
# ./tests/sasl_server_mechanism_ut/sasl_server_mechanism_ut_exe
 === Executing test suite sasl_server_mechanism_ut ===
...clipped for brevity...
22 tests ran, 0 failed, 22 succeeded.
# ./tests/saslclientio_ut/saslclientio_ut_exe
 === Executing test suite saslclientio_ut ===
...clipped for brevity...
115 tests ran, 0 failed, 115 succeeded.
# ./tests/session_ut/session_ut_exe
 === Executing test suite session_ut ===
...clipped for brevity...
19 tests ran, 0 failed, 19 succeeded.
# cd ..
# rm -rf cmake/
# mkdir cmake
# cd cmake
# cmake .. -Drun_unittests:bool=ON -Dno_logging:bool=ON
-- The C compiler identification is GNU 5.4.0
...clipped for brevity...
-- Build files have been written to: /src/azure-uamqp-c/cmake
# cmake --build .
Scanning dependencies of target aziotsharedutil
[  0%] Building C object deps/azure-c-shared-utility/CMakeFiles/aziotsharedutil.dir/src/base32.c.o
...clipped for brevity...
[100%] Built target local_client_server_tcp_perf
# ./tests/amqp_frame_codec_ut/amqp_frame_codec_ut_exe
 === Executing test suite amqp_frame_codec_ut ===
...clipped for brevity...
47 tests ran, 0 failed, 47 succeeded.
# ./tests/amqp_management_ut/amqp_management_ut_exe
 === Executing test suite amqp_management_ut ===
...clipped for brevity...
116 tests ran, 0 failed, 116 succeeded.
# ./tests/amqpvalue_ut/amqpvalue_ut_exe
 === Executing test suite amqpvalue_ut ===
...clipped for brevity...
693 tests ran, 0 failed, 693 succeeded.
# ./tests/async_operation_ut/async_operation_ut_exe
 === Executing test suite async_operation_ut ===
...clipped for brevity...
8 tests ran, 0 failed, 8 succeeded.
# ./tests/cbs_ut/cbs_ut_exe
 === Executing test suite cbs_ut ===
...clipped for brevity...
67 tests ran, 0 failed, 67 succeeded.
# ./tests/connection_ut/connection_ut_exe
 === Executing test suite connection_ut ===
...clipped for brevity...
9 tests ran, 0 failed, 9 succeeded.
# ./tests/frame_codec_ut/frame_codec_ut_exe
 === Executing test suite frame_codec_ut ===
...clipped for brevity...
82 tests ran, 0 failed, 82 succeeded.
# ./tests/header_detect_io_ut/header_detect_io_ut_exe
 === Executing test suite header_detect_io_ut ===
...clipped for brevity...
97 tests ran, 0 failed, 97 succeeded.
# ./tests/message_ut/message_ut_exe
 === Executing test suite message_ut ===
...clipped for brevity...
167 tests ran, 0 failed, 167 succeeded.
# ./tests/sasl_anonymous_ut/sasl_anonymous_ut_exe
 === Executing test suite sasl_anonymous_ut ===
...clipped for brevity...
15 tests ran, 0 failed, 15 succeeded.
# ./tests/sasl_frame_codec_ut/sasl_frame_codec_ut_exe
 === Executing test suite sasl_frame_codec_ut ===
...clipped for brevity...
42 tests ran, 0 failed, 42 succeeded.
# ./tests/sasl_mechanism_ut/sasl_mechanism_ut_exe
 === Executing test suite sasl_mechanism_ut ===
...clipped for brevity...
21 tests ran, 0 failed, 21 succeeded.
# ./tests/sasl_plain_ut/sasl_plain_ut_exe
 === Executing test suite sasl_plain_ut ===
...clipped for brevity...
28 tests ran, 0 failed, 28 succeeded.
# ./tests/sasl_server_mechanism_ut/sasl_server_mechanism_ut_exe
 === Executing test suite sasl_server_mechanism_ut ===
...clipped for brevity...
22 tests ran, 0 failed, 22 succeeded.
# ./tests/saslclientio_ut/saslclientio_ut_exe
 === Executing test suite saslclientio_ut ===
...clipped for brevity...
115 tests ran, 0 failed, 115 succeeded.
# ./tests/session_ut/session_ut_exe
 === Executing test suite session_ut ===
...clipped for brevity...
19 tests ran, 0 failed, 19 succeeded.
#
```

