### PR TITLE
Add support for extracting redirect information

### DIFF
--- a/inc/azure_uamqp_c/connection.h
+++ b/inc/azure_uamqp_c/connection.h
@@ -12,6 +12,8 @@
 #include "azure_uamqp_c/amqp_frame_codec.h"
 #include "azure_uamqp_c/amqp_definitions_fields.h"
 #include "azure_uamqp_c/amqp_definitions_milliseconds.h"
+#include "azure_uamqp_c/amqp_definitions_error.h"
+#include "azure_uamqp_c/amqpvalue.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,6 +21,7 @@ extern "C" {
 
     typedef struct CONNECTION_INSTANCE_TAG* CONNECTION_HANDLE;
     typedef struct ENDPOINT_INSTANCE_TAG* ENDPOINT_HANDLE;
+    typedef struct ON_CONNECTION_CLOSED_EVENT_SUBSCRIPTION_TAG* ON_CONNECTION_CLOSED_EVENT_SUBSCRIPTION_HANDLE;
 
     typedef enum CONNECTION_STATE_TAG
     {
@@ -70,6 +73,7 @@ extern "C" {
 
     typedef void(*ON_ENDPOINT_FRAME_RECEIVED)(void* context, AMQP_VALUE performative, uint32_t frame_payload_size, const unsigned char* payload_bytes);
     typedef void(*ON_CONNECTION_STATE_CHANGED)(void* context, CONNECTION_STATE new_connection_state, CONNECTION_STATE previous_connection_state);
+    typedef void(*ON_CONNECTION_CLOSE_RECEIVED)(void* context, ERROR_HANDLE error);
     typedef bool(*ON_NEW_ENDPOINT)(void* context, ENDPOINT_HANDLE new_endpoint);
 
     MOCKABLE_FUNCTION(, CONNECTION_HANDLE, connection_create, XIO_HANDLE, io, const char*, hostname, const char*, container_id, ON_NEW_ENDPOINT, on_new_endpoint, void*, callback_context);
@@ -77,7 +81,7 @@ extern "C" {
     MOCKABLE_FUNCTION(, void, connection_destroy, CONNECTION_HANDLE, connection);
     MOCKABLE_FUNCTION(, int, connection_open, CONNECTION_HANDLE, connection);
     MOCKABLE_FUNCTION(, int, connection_listen, CONNECTION_HANDLE, connection);
-    MOCKABLE_FUNCTION(, int, connection_close, CONNECTION_HANDLE, connection, const char*, condition_value, const char*, description);
+    MOCKABLE_FUNCTION(, int, connection_close, CONNECTION_HANDLE, connection, const char*, condition_value, const char*, description, AMQP_VALUE, info);
     MOCKABLE_FUNCTION(, int, connection_set_max_frame_size, CONNECTION_HANDLE, connection, uint32_t, max_frame_size);
     MOCKABLE_FUNCTION(, int, connection_get_max_frame_size, CONNECTION_HANDLE, connection, uint32_t*, max_frame_size);
     MOCKABLE_FUNCTION(, int, connection_set_channel_max, CONNECTION_HANDLE, connection, uint16_t, channel_max);
@@ -96,6 +100,9 @@ extern "C" {
     MOCKABLE_FUNCTION(, void, connection_destroy_endpoint, ENDPOINT_HANDLE, endpoint);
     MOCKABLE_FUNCTION(, int, connection_encode_frame, ENDPOINT_HANDLE, endpoint, AMQP_VALUE, performative, PAYLOAD*, payloads, size_t, payload_count, ON_SEND_COMPLETE, on_send_complete, void*, callback_context);
     MOCKABLE_FUNCTION(, void, connection_set_trace, CONNECTION_HANDLE, connection, bool, trace_on);
+
+    MOCKABLE_FUNCTION(, ON_CONNECTION_CLOSED_EVENT_SUBSCRIPTION_HANDLE, connection_subscribe_on_connection_close_received, CONNECTION_HANDLE, connection, ON_CONNECTION_CLOSE_RECEIVED, on_connection_close_received, void*, context);
+    MOCKABLE_FUNCTION(, void, connection_unsubscribe_on_connection_close_received, ON_CONNECTION_CLOSED_EVENT_SUBSCRIPTION_HANDLE, event_subscription);
 
 #ifdef __cplusplus
 }

--- a/src/session.c
+++ b/src/session.c
@@ -183,7 +183,7 @@ static void end_session_with_error(SESSION_INSTANCE* session_instance, const cha
     {
         /* fatal error */
         session_set_state(session_instance, SESSION_STATE_DISCARDING);
-        (void)connection_close(session_instance->connection, "amqp:internal-error", "Cannot allocate error handle to end session");
+        (void)connection_close(session_instance->connection, "amqp:internal-error", "Cannot allocate error handle to end session", NULL);
     }
     else
     {
@@ -192,7 +192,7 @@ static void end_session_with_error(SESSION_INSTANCE* session_instance, const cha
         {
             /* fatal error */
             session_set_state(session_instance, SESSION_STATE_DISCARDING);
-            (void)connection_close(session_instance->connection, "amqp:internal-error", "Cannot allocate error handle to end session");
+            (void)connection_close(session_instance->connection, "amqp:internal-error", "Cannot allocate error handle to end session", NULL);
         }
         else
         {
@@ -388,7 +388,7 @@ static void on_frame_received(void* context, AMQP_VALUE performative, uint32_t p
 
         if (amqpvalue_get_begin(performative, &begin_handle) != 0)
         {
-            connection_close(session_instance->connection, "amqp:decode-error", "Cannot decode BEGIN frame");
+            connection_close(session_instance->connection, "amqp:decode-error", "Cannot decode BEGIN frame", NULL);
         }
         else
         {
@@ -398,7 +398,7 @@ static void on_frame_received(void* context, AMQP_VALUE performative, uint32_t p
                 /* error */
                 begin_destroy(begin_handle);
                 session_set_state(session_instance, SESSION_STATE_DISCARDING);
-                connection_close(session_instance->connection, "amqp:decode-error", "Cannot get incoming windows and next outgoing id");
+                connection_close(session_instance->connection, "amqp:decode-error", "Cannot get incoming windows and next outgoing id", NULL);
             }
             else
             {
@@ -413,7 +413,7 @@ static void on_frame_received(void* context, AMQP_VALUE performative, uint32_t p
                     session_set_state(session_instance, SESSION_STATE_BEGIN_RCVD);
                     if (send_begin(session_instance) != 0)
                     {
-                        connection_close(session_instance->connection, "amqp:internal-error", "Failed sending BEGIN frame");
+                        connection_close(session_instance->connection, "amqp:internal-error", "Failed sending BEGIN frame", NULL);
                         session_set_state(session_instance, SESSION_STATE_DISCARDING);
                     }
                     else
@@ -700,7 +700,7 @@ static void on_frame_received(void* context, AMQP_VALUE performative, uint32_t p
                 if (send_end_frame(session_instance, NULL) != 0)
                 {
                     /* fatal error */
-                    (void)connection_close(session_instance->connection, "amqp:internal-error", "Cannot send END frame.");
+                    (void)connection_close(session_instance->connection, "amqp:internal-error", "Cannot send END frame.", NULL);
                 }
 
                 session_set_state(session_instance, SESSION_STATE_DISCARDING);

--- a/tests/local_client_server_tcp_e2e/local_client_server_tcp_e2e.c
+++ b/tests/local_client_server_tcp_e2e/local_client_server_tcp_e2e.c
@@ -17,6 +17,10 @@
 static TEST_MUTEX_HANDLE g_testByTest;
 static TEST_MUTEX_HANDLE g_dllByDll;
 
+static const char* test_redirect_hostname = "blahblah";
+static const char* test_redirect_network_host = "1.2.3.4";
+static uint16_t test_redirect_port = 4242;
+
 #define TEST_TIMEOUT 30 // seconds
 
 static int generate_port_number(void)
@@ -526,7 +530,6 @@ TEST_FUNCTION(cancelling_a_send_works)
     socketlistener_destroy(socket_listener);
 }
 
-/* TODO: This test fails at the moment. Changes are needed to the way the link endpoints are tracked to make it succeed */
 TEST_FUNCTION(destroying_one_out_of_2_senders_works)
 {
     // arrange
@@ -679,6 +682,216 @@ TEST_FUNCTION(destroying_one_out_of_2_senders_works)
     socketlistener_stop(socket_listener);
     messagesender_destroy(client_message_sender_1);
     link_destroy(client_link_1);
+    session_destroy(client_session);
+    connection_destroy(client_connection);
+    xio_destroy(socket_io);
+
+    messagereceiver_destroy(server_instance.message_receivers[0]);
+    messagereceiver_destroy(server_instance.message_receivers[1]);
+    link_destroy(server_instance.links[0]);
+    link_destroy(server_instance.links[1]);
+    session_destroy(server_instance.session);
+    connection_destroy(server_instance.connection);
+    xio_destroy(server_instance.header_detect_io);
+    xio_destroy(server_instance.underlying_io);
+    socketlistener_destroy(socket_listener);
+}
+
+static void on_connection_redirect_received(void* context, ERROR_HANDLE error)
+{
+    bool* redirect_received = (bool*)context;
+    fields info = NULL;
+    AMQP_VALUE hostname_key = amqpvalue_create_string("hostname");
+    AMQP_VALUE network_host_key = amqpvalue_create_string("network-host");
+    AMQP_VALUE port_key = amqpvalue_create_string("port");
+    AMQP_VALUE hostname_value;
+    AMQP_VALUE network_host_value;
+    AMQP_VALUE port_value;
+    const char* hostname_string;
+    const char* network_host_string;
+    uint16_t port_number;
+
+    ASSERT_IS_NOT_NULL_WITH_MSG(error, "NULL error information");
+    (void)error_get_info(error, &info);
+    ASSERT_IS_NOT_NULL_WITH_MSG(info, "NULL info in error");
+
+    hostname_value = amqpvalue_get_map_value(info, hostname_key);
+    ASSERT_IS_NOT_NULL_WITH_MSG(hostname_value, "NULL hostname_value");
+    network_host_value = amqpvalue_get_map_value(info, network_host_key);
+    ASSERT_IS_NOT_NULL_WITH_MSG(network_host_value, "NULL network_host_value");
+    port_value = amqpvalue_get_map_value(info, port_key);
+    ASSERT_IS_NOT_NULL_WITH_MSG(port_value, "NULL port_value");
+
+    (void)amqpvalue_get_string(hostname_value, &hostname_string);
+    ASSERT_ARE_EQUAL(char_ptr, test_redirect_hostname, hostname_string);
+    (void)amqpvalue_get_string(network_host_value, &network_host_string);
+    ASSERT_ARE_EQUAL(char_ptr, test_redirect_network_host, network_host_string);
+    (void)amqpvalue_get_ushort(port_value, &port_number);
+    ASSERT_ARE_EQUAL(uint16_t, test_redirect_port, port_number);
+
+    amqpvalue_destroy(hostname_key);
+    amqpvalue_destroy(network_host_key);
+    amqpvalue_destroy(port_key);
+    amqpvalue_destroy(hostname_value);
+    amqpvalue_destroy(network_host_value);
+    amqpvalue_destroy(port_value);
+
+    *redirect_received = true;
+}
+
+static bool on_new_session_endpoint_redirect(void* context, ENDPOINT_HANDLE new_endpoint)
+{
+    SERVER_INSTANCE* server = (SERVER_INSTANCE*)context;
+    AMQP_VALUE redirect_map = amqpvalue_create_map();
+    AMQP_VALUE hostname_key = amqpvalue_create_string("hostname");
+    AMQP_VALUE network_host_key = amqpvalue_create_string("network-host");
+    AMQP_VALUE port_key = amqpvalue_create_string("port");
+    AMQP_VALUE hostname_value = amqpvalue_create_string(test_redirect_hostname);
+    AMQP_VALUE network_host_value = amqpvalue_create_string(test_redirect_network_host);
+    AMQP_VALUE port_value = amqpvalue_create_ushort(test_redirect_port);
+
+    (void)new_endpoint;
+
+    (void)amqpvalue_set_map_value(redirect_map, hostname_key, hostname_value);
+    (void)amqpvalue_set_map_value(redirect_map, network_host_key, network_host_value);
+    (void)amqpvalue_set_map_value(redirect_map, port_key, port_value);
+
+    amqpvalue_destroy(hostname_key);
+    amqpvalue_destroy(hostname_value);
+    amqpvalue_destroy(network_host_key);
+    amqpvalue_destroy(network_host_value);
+    amqpvalue_destroy(port_key);
+    amqpvalue_destroy(port_value);
+
+    connection_close(server->connection, connection_error_redirect, "Redirect", redirect_map);
+    amqpvalue_destroy(redirect_map);
+
+    return false;
+}
+
+static void on_socket_accepted_redirect(void* context, const IO_INTERFACE_DESCRIPTION* interface_description, void* io_parameters)
+{
+    HEADER_DETECT_IO_CONFIG header_detect_io_config;
+    HEADER_DETECT_ENTRY header_detect_entries[1];
+    SERVER_INSTANCE* server = (SERVER_INSTANCE*)context;
+    int result;
+    AMQP_HEADER amqp_header;
+
+    server->underlying_io = xio_create(interface_description, io_parameters);
+    ASSERT_IS_NOT_NULL_WITH_MSG(server->underlying_io, "Could not create underlying IO");
+
+    amqp_header = header_detect_io_get_amqp_header();
+    header_detect_entries[0].header.header_bytes = amqp_header.header_bytes;
+    header_detect_entries[0].header.header_size = amqp_header.header_size;
+    header_detect_entries[0].io_interface_description = NULL;
+
+    header_detect_io_config.underlying_io = server->underlying_io;
+    header_detect_io_config.header_detect_entry_count = 1;
+    header_detect_io_config.header_detect_entries = header_detect_entries;
+
+    server->header_detect_io = xio_create(header_detect_io_get_interface_description(), &header_detect_io_config);
+    ASSERT_IS_NOT_NULL_WITH_MSG(server->header_detect_io, "Could not create header detect IO");
+    server->connection = connection_create(server->header_detect_io, NULL, "1", on_new_session_endpoint_redirect, server);
+    ASSERT_IS_NOT_NULL_WITH_MSG(server->connection, "Could not create server connection");
+    (void)connection_set_trace(server->connection, true);
+    result = connection_listen(server->connection);
+    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "cannot start listening");
+}
+
+TEST_FUNCTION(connection_redirect_notifies_the_user_of_the_event)
+{
+    // arrange
+    int port_number = generate_port_number();
+    SERVER_INSTANCE server_instance;
+    SOCKET_LISTENER_HANDLE socket_listener = socketlistener_create(port_number);
+    int result;
+    XIO_HANDLE socket_io;
+    CONNECTION_HANDLE client_connection;
+    SESSION_HANDLE client_session;
+    LINK_HANDLE client_link;
+    MESSAGE_SENDER_HANDLE client_message_sender;
+    bool redirect_received;
+    AMQP_VALUE source;
+    AMQP_VALUE target;
+    time_t now_time;
+    time_t start_time;
+    SOCKETIO_CONFIG socketio_config = { "localhost", 0, NULL };
+
+    server_instance.connection = NULL;
+    server_instance.session = NULL;
+    server_instance.link_count = 0;
+    server_instance.links[0] = NULL;
+    server_instance.links[1] = NULL;
+    server_instance.message_receivers[0] = NULL;
+    server_instance.message_receivers[1] = NULL;
+    server_instance.received_messages = 0;
+
+    redirect_received = false;
+
+    result = socketlistener_start(socket_listener, on_socket_accepted_redirect, &server_instance);
+    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "socketlistener_start failed");
+
+    // start the client
+    socketio_config.port = port_number;
+    socket_io = xio_create(socketio_get_interface_description(), &socketio_config);
+    ASSERT_IS_NOT_NULL_WITH_MSG(socket_io, "Could not create socket IO");
+
+    /* create the connection, session and link */
+    client_connection = connection_create(socket_io, "localhost", "some", NULL, NULL);
+    ASSERT_IS_NOT_NULL_WITH_MSG(client_connection, "Could not create client connection");
+
+    (void)connection_set_trace(client_connection, true);
+    client_session = session_create(client_connection, NULL, NULL);
+    ASSERT_IS_NOT_NULL_WITH_MSG(client_session, "Could not create client session");
+
+    connection_subscribe_on_connection_close_received(client_connection, on_connection_redirect_received, &redirect_received);
+
+    source = messaging_create_source("ingress");
+    ASSERT_IS_NOT_NULL_WITH_MSG(source, "Could not create source");
+    target = messaging_create_target("localhost/ingress");
+    ASSERT_IS_NOT_NULL_WITH_MSG(target, "Could not create target");
+
+    // link
+    client_link = link_create(client_session, "sender-link-1", role_sender, source, target);
+    ASSERT_IS_NOT_NULL_WITH_MSG(client_link, "Could not create client link");
+    result = link_set_snd_settle_mode(client_link, sender_settle_mode_unsettled);
+    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "cannot set sender settle mode on link");
+
+    amqpvalue_destroy(source);
+    amqpvalue_destroy(target);
+
+    /* create the message sender */
+    client_message_sender = messagesender_create(client_link, NULL, NULL);
+    ASSERT_IS_NOT_NULL_WITH_MSG(client_message_sender, "Could not create message sender");
+    result = messagesender_open(client_message_sender);
+    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "cannot open message sender");
+
+    // wait for either time elapsed or message received
+    start_time = time(NULL);
+    while ((now_time = time(NULL)),
+        (difftime(now_time, start_time) < TEST_TIMEOUT))
+    {
+        // schedule work for all components
+        socketlistener_dowork(socket_listener);
+        connection_dowork(client_connection);
+        connection_dowork(server_instance.connection);
+
+        // if we received the message, break
+        if (redirect_received)
+        {
+            break;
+        }
+
+        ThreadAPI_Sleep(1);
+    }
+
+    // assert
+    ASSERT_IS_TRUE_WITH_MSG(redirect_received, "Redirect information not received");
+
+    // cleanup
+    socketlistener_stop(socket_listener);
+    messagesender_destroy(client_message_sender);
+    link_destroy(client_link);
     session_destroy(client_session);
     connection_destroy(client_connection);
     xio_destroy(socket_io);


### PR DESCRIPTION
This PR adds a handler for connection_close_received.
This allows extracting the error information once a connection is closed, thus allowing the redirect implementation by the user of the connection.
An E2E local TCP test was added. This prompted adding the info argument to connection_close.
I tinkered with the idea of making multiple event handlers for redirect, etc., but that seemed as overshoot for now.
This should solve at connection level the need to bubble up the redirect information.
Another PR will be posted for the link redirect information.