### PR TITLE
Surface message disposition delivery-state

### DIFF
--- a/devdoc/amqp_management_requirements.md
+++ b/devdoc/amqp_management_requirements.md
@@ -309,7 +309,7 @@ AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE message)
 ### on_message_send_complete
 
 ```c
-void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result)
+void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state)
 ```
 
 **SRS_AMQP_MANAGEMENT_01_167: [** When `on_message_send_complete` is called with a NULL context it shall return. **]**

--- a/inc/azure_uamqp_c/message_sender.h
+++ b/inc/azure_uamqp_c/message_sender.h
@@ -35,7 +35,7 @@ DEFINE_ENUM(MESSAGE_SEND_RESULT, MESSAGE_SEND_RESULT_VALUES)
 DEFINE_ENUM(MESSAGE_SENDER_STATE, MESSAGE_SENDER_STATE_VALUES)
 
     typedef struct MESSAGE_SENDER_INSTANCE_TAG* MESSAGE_SENDER_HANDLE;
-    typedef void(*ON_MESSAGE_SEND_COMPLETE)(void* context, MESSAGE_SEND_RESULT send_result);
+    typedef void(*ON_MESSAGE_SEND_COMPLETE)(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state);
     typedef void(*ON_MESSAGE_SENDER_STATE_CHANGED)(void* context, MESSAGE_SENDER_STATE new_state, MESSAGE_SENDER_STATE previous_state);
 
     MOCKABLE_FUNCTION(, MESSAGE_SENDER_HANDLE, messagesender_create, LINK_HANDLE, link, ON_MESSAGE_SENDER_STATE_CHANGED, on_message_sender_state_changed, void*, context);

--- a/samples/eh_sender_with_sas_token_sample/main.c
+++ b/samples/eh_sender_with_sas_token_sample/main.c
@@ -62,10 +62,11 @@ static void on_cbs_put_token_complete(void* context, CBS_OPERATION_RESULT cbs_op
     }
 }
 
-static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result)
+static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state)
 {
     (void)send_result;
     (void)context;
+    (void)delivery_state;
 
     sent_messages++;
 }

--- a/samples/local_client_sample/main.c
+++ b/samples/local_client_sample/main.c
@@ -17,10 +17,11 @@
 static const size_t msg_count = 1000;
 static unsigned int sent_messages = 0;
 
-static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result)
+static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state)
 {
     (void)send_result;
     (void)context;
+    (void)delivery_state;
 
     sent_messages++;
 }

--- a/samples/message_sender_sample/main.c
+++ b/samples/message_sender_sample/main.c
@@ -26,10 +26,11 @@
 static const size_t msg_count = 1000;
 static unsigned int sent_messages = 0;
 
-static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result)
+static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state)
 {
     (void)send_result;
     (void)context;
+    (void)delivery_state;
 
     sent_messages++;
 }

--- a/samples/mssbcbs_sample/main.c
+++ b/samples/mssbcbs_sample/main.c
@@ -33,10 +33,11 @@ static void on_cbs_error(void* context)
     (void)printf("CBS error.\r\n");
 }
 
-static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result)
+static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state)
 {
     (void)send_result;
     (void)context;
+    (void)delivery_state;
 
     printf("Sent.\r\n");
     sent_messages++;

--- a/samples/websockets_sample/main.c
+++ b/samples/websockets_sample/main.c
@@ -43,10 +43,11 @@ static void on_cbs_error(void* context)
     (void)printf("CBS error.\r\n");
 }
 
-void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result)
+static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state)
 {
     (void)send_result;
     (void)context;
+    (void)delivery_state;
 
     printf("Sent.\r\n");
     sent_messages++;

--- a/src/amqp_management.c
+++ b/src/amqp_management.c
@@ -335,6 +335,7 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
 static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state)
 {
     (void)delivery_state;
+
     if (context == NULL)
     {
         /* Codes_SRS_AMQP_MANAGEMENT_01_167: [ When `on_message_send_complete` is called with a NULL context it shall return. ]*/

--- a/src/amqp_management.c
+++ b/src/amqp_management.c
@@ -332,8 +332,9 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
     return result;
 }
 
-static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result)
+static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state)
 {
+    (void)delivery_state;
     if (context == NULL)
     {
         /* Codes_SRS_AMQP_MANAGEMENT_01_167: [ When `on_message_send_complete` is called with a NULL context it shall return. ]*/

--- a/src/link.c
+++ b/src/link.c
@@ -622,22 +622,24 @@ static void link_frame_received(void* context, AMQP_VALUE performative, uint32_t
                 }
             }
 
-            if (detach_get_error(detach, &error) == 0)
+            if (detach_get_error(detach, &error) != 0)
             {
-                remove_all_pending_deliveries(link_instance, true);
+                error = NULL;
+            }
+            remove_all_pending_deliveries(link_instance, true);
+            // signal link detach received in order to handle cases like redirect
+            if (link_instance->on_link_detach_received_event_subscription.on_link_detach_received != NULL)
+            {
+                link_instance->on_link_detach_received_event_subscription.on_link_detach_received(link_instance->on_link_detach_received_event_subscription.context, error);
+            }
+
+            if (error != NULL)
+            {
                 set_link_state(link_instance, LINK_STATE_ERROR);
-
-                // signal link detach received in order to handle cases like redirect
-                if (link_instance->on_link_detach_received_event_subscription.on_link_detach_received != NULL)
-                {
-                    link_instance->on_link_detach_received_event_subscription.on_link_detach_received(link_instance->on_link_detach_received_event_subscription.context, error);
-                }
-
                 error_destroy(error);
             }
             else 
             {
-                remove_all_pending_deliveries(link_instance, true);
                 set_link_state(link_instance, LINK_STATE_DETACHED);
             }
 

--- a/tests/amqp_management_ut/amqp_management_ut.c
+++ b/tests/amqp_management_ut/amqp_management_ut.c
@@ -1858,7 +1858,7 @@ TEST_FUNCTION(on_message_send_complete_with_NULL_context_does_nothing)
     umock_c_reset_all_calls();
 
     // act
-    saved_on_message_send_complete(NULL, MESSAGE_SEND_OK);
+    saved_on_message_send_complete(NULL, MESSAGE_SEND_OK, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1892,7 +1892,7 @@ TEST_FUNCTION(when_on_message_send_complete_indicates_ERROR_the_pending_operatio
     STRICT_EXPECTED_CALL(free(IGNORED_PTR_ARG));
 
     // act
-    saved_on_message_send_complete(saved_on_message_send_complete_context, MESSAGE_SEND_ERROR);
+    saved_on_message_send_complete(saved_on_message_send_complete_context, MESSAGE_SEND_ERROR, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1926,7 +1926,7 @@ TEST_FUNCTION(when_on_message_send_complete_indicates_CANCELLED_the_pending_oper
     STRICT_EXPECTED_CALL(free(IGNORED_PTR_ARG));
 
     // act
-    saved_on_message_send_complete(saved_on_message_send_complete_context, MESSAGE_SEND_CANCELLED);
+    saved_on_message_send_complete(saved_on_message_send_complete_context, MESSAGE_SEND_CANCELLED, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1956,7 +1956,7 @@ TEST_FUNCTION(when_obtaining_the_list_item_payload_fails_an_error_is_indicated_t
     STRICT_EXPECTED_CALL(test_on_amqp_management_error((void*)0x4243));
 
     // act
-    saved_on_message_send_complete(saved_on_message_send_complete_context, MESSAGE_SEND_CANCELLED);
+    saved_on_message_send_complete(saved_on_message_send_complete_context, MESSAGE_SEND_CANCELLED, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1981,7 +1981,7 @@ TEST_FUNCTION(when_on_send_message_complete_indicates_success_it_returns)
     umock_c_reset_all_calls();
 
     // act
-    saved_on_message_send_complete(saved_on_message_send_complete_context, MESSAGE_SEND_OK);
+    saved_on_message_send_complete(saved_on_message_send_complete_context, MESSAGE_SEND_OK, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());

--- a/tests/iothub_e2e/iothub_e2e.c
+++ b/tests/iothub_e2e/iothub_e2e.c
@@ -72,8 +72,10 @@ void on_cbs_put_token_complete(void* context, CBS_OPERATION_RESULT cbs_operation
     }
 }
 
-static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result)
+static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state)
 {
+    (void)delivery_state;
+
     size_t* sent_messages = (size_t*)context;
     if (send_result == MESSAGE_SEND_OK)
     {

--- a/tests/local_client_server_tcp_e2e/local_client_server_tcp_e2e.c
+++ b/tests/local_client_server_tcp_e2e/local_client_server_tcp_e2e.c
@@ -78,8 +78,10 @@ typedef struct SERVER_INSTANCE_TAG
     XIO_HANDLE underlying_io;
 } SERVER_INSTANCE;
 
-static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result)
+static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state)
 {
+    (void)delivery_state;
+
     size_t* sent_messages = (size_t*)context;
     if (send_result == MESSAGE_SEND_OK)
     {
@@ -91,8 +93,10 @@ static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_res
     }
 }
 
-static void on_message_send_cancelled(void* context, MESSAGE_SEND_RESULT send_result)
+static void on_message_send_cancelled(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state)
 {
+    (void)delivery_state;
+
     size_t* cancelled_messages = (size_t*)context;
     if (send_result == MESSAGE_SEND_CANCELLED)
     {

--- a/tests/local_client_server_tcp_perf/local_client_server_tcp_perf.c
+++ b/tests/local_client_server_tcp_perf/local_client_server_tcp_perf.c
@@ -234,12 +234,13 @@ typedef struct CLIENT_TAG
     size_t outstanding_message_count;
 } CLIENT;
 
-static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result)
+static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_result, AMQP_VALUE delivery_state)
 {
     CLIENT* client = (CLIENT*)context;
     client->outstanding_message_count--;
     (void)send_result;
     (void)context;
+    (void)delivery_state;
 }
 
 int main(void)


### PR DESCRIPTION
Here's my changes according to issue #251 

In addition:
- I've made modifications to link.c so that the subscribe_to_detach_event callback is called regardless of whether there's an error in the DETACH frame. I did this because I've noticed some services (i.e. EventHubs) will randomly send an empty DETACH frame for no reason - clients are supposed to handle this and reconnect - which is easier to do when I can capture the event in the callback. Open to your thoughts on this though :)
- I have not done anything to make use of the new delivery-state fields in amqp_management.c yet. I do intend to revisit this, as well as DETACH events in the management links to further capture and surface errors here.