### PR TITLE
Include header files outside the `extern "C"` (fix for azure-iot-sdk-c#577)

### DIFF
--- a/inc/azure_uamqp_c/amqpvalue.h
+++ b/inc/azure_uamqp_c/amqpvalue.h
@@ -7,9 +7,9 @@
 #include "azure_uamqp_c/amqp_types.h"
 
 #ifdef __cplusplus
-extern "C" {
 #include <cstddef>
 #include <cstdint>
+extern "C" {
 #else
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
This fixes errors when compiling as C++ code, reported in Azure/azure-iot-sdk-c#577, q.v.