### PR TITLE
Moved message cleanup to sender close

### DIFF
--- a/src/message_sender.c
+++ b/src/message_sender.c
@@ -753,7 +753,6 @@ void messagesender_destroy(MESSAGE_SENDER_HANDLE message_sender)
     }
     else
     {
-        indicate_all_messages_as_error(message_sender);
         (void)messagesender_close(message_sender);
 
         free(message_sender);
@@ -805,6 +804,8 @@ int messagesender_close(MESSAGE_SENDER_HANDLE message_sender)
     }
     else
     {
+        indicate_all_messages_as_error(message_sender);
+
         if ((message_sender->message_sender_state == MESSAGE_SENDER_STATE_OPENING) ||
             (message_sender->message_sender_state == MESSAGE_SENDER_STATE_OPEN))
         {


### PR DESCRIPTION
Proposing this little tweak for consideration.

I'm encountering a crash if CBS is destroyed after sending a token but before the response is received.
I think I've traced the issue to:
1. cbs_destroy first calls amqp_management_close
2. amqp_management_close calls message_sender_close which only changes the message sender status
3. amqp_management_close then removes all the pending operations
4. cbs_destroy then calls amqp_management_destroy
5. amqp_management_destroy calls message_sender_destroy
6. message_sender_destroy calls indicate_all_messages_as_error
7. indicate_all_messages_as_error calls the amqp_management on_send_complete callback which attempts to resolve the pending operation that was already cleaned up in step 3.

I'm not entirely sure why in some (apparently not all) circumstances this crashes as singlylinkedlist_remove isn't supposed to crash if the pending operation has already been removed. I have also been unable to reproduce this in a test - so there's clearly an element to the process that I'm missing....

However I also can't think of a reason why the pending messages shouldn't be marked as error on message_sender_close rather than message_sender_destroy - so I will propose this fix in the meantime anyway :)