### PR TITLE
Added attach callback for existing link endpoint

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -505,6 +505,14 @@ static void on_frame_received(void* context, AMQP_VALUE performative, uint32_t p
                     {
                         link_endpoint->link_endpoint_state = LINK_ENDPOINT_STATE_ATTACHED;
 
+                        if (session_instance->on_link_attached != NULL)
+                        {
+                            if (!session_instance->on_link_attached(session_instance->on_link_attached_callback_context, link_endpoint, name, role, source, target))
+                            {
+                                link_endpoint->link_endpoint_state = LINK_ENDPOINT_STATE_DETACHING;
+                            }
+                        }
+
                         link_endpoint->frame_received_callback(link_endpoint->callback_context, performative, payload_size, payload_bytes);
                     }
                 }


### PR DESCRIPTION
I feel that the on_link_attach callback should be called regardless of the whether the link endpoint is newly created, or was created earlier.

I am not entirely sure I have the error scenario correct in line 512 (i.e. whether I need to do more than just setting the state to DETACHING).

Thanks,
Anna