### PR TITLE
Fix message sender shutdown order

### DIFF
--- a/src/message_sender.c
+++ b/src/message_sender.c
@@ -805,8 +805,6 @@ int messagesender_close(MESSAGE_SENDER_HANDLE message_sender)
     }
     else
     {
-        indicate_all_messages_as_error(message_sender);
-
         if ((message_sender->message_sender_state == MESSAGE_SENDER_STATE_OPENING) ||
             (message_sender->message_sender_state == MESSAGE_SENDER_STATE_OPEN))
         {
@@ -826,6 +824,8 @@ int messagesender_close(MESSAGE_SENDER_HANDLE message_sender)
         {
             result = 0;
         }
+        
+        indicate_all_messages_as_error(message_sender);
     }
 
     return result;


### PR DESCRIPTION
The current `messagesender_close` function starts by clearing any pending messages by calling `on_message_send_complete` with an error state, and then attempts to detach the link.

However, if the link detach should fail for any reason (say, the connection is in an error state), then the link will also attempt to remove it's pending deliveries (`on_session_state_change` -> `remove_all_pending_deliveries`) which also calls the `on_message_send_complete` callback a second time.

This has the potential to fail in two ways - first, the `on_message_send_complete` callback must be idempotent (with the amqp_management `on_message_send_complete` is not) and secondly, the message has already been freed by the time the link attempts to settle it.

By moving the `indicate_all_messages_as_error` call to after the attempted detach, if the link fails to detach it will settle any pending messages and remove them from the message sender, thereby eliminating the double callback.