### PR TITLE
Fix for session_destroy_link_endpoint.

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -1163,17 +1163,8 @@ void session_destroy_link_endpoint(LINK_ENDPOINT_HANDLE link_endpoint)
 {
     if (link_endpoint != NULL)
     {
-        LINK_ENDPOINT_INSTANCE* endpoint_instance = (LINK_ENDPOINT_INSTANCE*)link_endpoint;
-
-        if (endpoint_instance->link_endpoint_state == LINK_ENDPOINT_STATE_ATTACHED)
-        {
-            endpoint_instance->link_endpoint_state = LINK_ENDPOINT_STATE_DETACHING;
-        }
-        else
-        {
-            remove_link_endpoint(link_endpoint);
-            free_link_endpoint(link_endpoint);
-        }
+        remove_link_endpoint(link_endpoint);
+        free_link_endpoint(link_endpoint);
     }
 }
 


### PR DESCRIPTION
If an application calls link_destroy [void link_destroy(LINK_HANDLE link), link.c:872],

the link.c layer will then:
a. call session_destroy_link_endpoint [void session_destroy_link_endpoint(LINK_ENDPOINT_HANDLE link_endpoint), session.c:1162], AND
b. Free the link (!).

But session_destroy_link_endpoint will only remove the link endpoint if its state is different than LINK_ENDPOINT_STATE_ATTACHED [session.c:1174].

If then a message is received for the defunct link instance, session will try to route it anyway, which will result in a SEGFAULT.

Example of such scenario:
Device multiplexing where multiple links are established for all the features supposed by Azure IoT Hub.
If an error occurs during link attachment phase, app layer can decide to destroy all links of one of the devices IDs but not the session,
and a rogue message might still come from the server for a defunct link.