### PR TITLE
link desired capabilities support

### DIFF
--- a/inc/azure_uamqp_c/link.h
+++ b/inc/azure_uamqp_c/link.h
@@ -67,6 +67,8 @@ MOCKABLE_FUNCTION(, int, link_set_max_message_size, LINK_HANDLE, link, uint64_t,
 MOCKABLE_FUNCTION(, int, link_get_max_message_size, LINK_HANDLE, link, uint64_t*, max_message_size);
 MOCKABLE_FUNCTION(, int, link_get_peer_max_message_size, LINK_HANDLE, link, uint64_t*, peer_max_message_size);
 MOCKABLE_FUNCTION(, int, link_set_attach_properties, LINK_HANDLE, link, fields, attach_properties);
+MOCKABLE_FUNCTION(, int, link_set_desired_capabilities, LINK_HANDLE, link, AMQP_VALUE, desired_capabilities);
+MOCKABLE_FUNCTION(, int, link_get_desired_capabilities, LINK_HANDLE, link, AMQP_VALUE*, desired_capabilities);
 MOCKABLE_FUNCTION(, int, link_set_max_link_credit, LINK_HANDLE, link, uint32_t, max_link_credit);
 MOCKABLE_FUNCTION(, int, link_get_name, LINK_HANDLE, link, const char**, link_name);
 MOCKABLE_FUNCTION(, int, link_get_received_message_id, LINK_HANDLE, link, delivery_number*, message_id);


### PR DESCRIPTION
According to the [amqp spec](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-transport-v1.0-os.html) section 2.7.3 Attach -- Attach frame should support desired-capabilities:

![image](https://user-images.githubusercontent.com/47871814/102285262-cd25ad80-3eea-11eb-8705-b1f2e8bfdadf.png)

This PR is to address the missing attach desired-capabilities support.
