### PR TITLE
[Pending] Fixed seg fault in tearing down a failed link with unsent pending messages

### DIFF
--- a/src/message_sender.c
+++ b/src/message_sender.c
@@ -805,8 +805,6 @@ int messagesender_close(MESSAGE_SENDER_HANDLE message_sender)
     }
     else
     {
-        indicate_all_messages_as_error(message_sender);
-
         if ((message_sender->message_sender_state == MESSAGE_SENDER_STATE_OPENING) ||
             (message_sender->message_sender_state == MESSAGE_SENDER_STATE_OPEN))
         {
@@ -826,6 +824,8 @@ int messagesender_close(MESSAGE_SENDER_HANDLE message_sender)
         {
             result = 0;
         }
+
+        indicate_all_messages_as_error(message_sender);
     }
 
     return result;


### PR DESCRIPTION
https://github.com/Azure/azure-uamqp-python/pull/140

This is a fix for seg fault in azure-uamqp-python. However I'm currently clueless on how it fixes a seg fault (in what case/how the original code could trigger a seg fault). Will bring more context after I dig deeper also wondering if I could get some eyes.