### PR TITLE
error fields to delivery rejected support 

### DIFF
--- a/inc/azure_uamqp_c/messaging.h
+++ b/inc/azure_uamqp_c/messaging.h
@@ -20,7 +20,7 @@ extern "C" {
 
     MOCKABLE_FUNCTION(, AMQP_VALUE, messaging_delivery_received, uint32_t, section_number, uint64_t, section_offset);
     MOCKABLE_FUNCTION(, AMQP_VALUE, messaging_delivery_accepted);
-    MOCKABLE_FUNCTION(, AMQP_VALUE, messaging_delivery_rejected, const char*, error_condition, const char*, error_description);
+    MOCKABLE_FUNCTION(, AMQP_VALUE, messaging_delivery_rejected, const char*, error_condition, const char*, error_description, fields, error_info);
     MOCKABLE_FUNCTION(, AMQP_VALUE, messaging_delivery_released);
     MOCKABLE_FUNCTION(, AMQP_VALUE, messaging_delivery_modified, bool, delivery_failed, bool, undeliverable_here, fields, message_annotations);
 

--- a/src/amqp_management.c
+++ b/src/amqp_management.c
@@ -80,7 +80,7 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
             LogError("Could not retrieve application properties");
             amqp_management->on_amqp_management_error(amqp_management->on_amqp_management_error_context);
             /* Codes_SRS_AMQP_MANAGEMENT_01_136: [ When `on_message_received` fails due to errors in parsing the response message `on_message_received` shall call `messaging_delivery_rejected` and return the created delivery AMQP value. ]*/
-            result = messaging_delivery_rejected("amqp:internal-error", "Could not get application properties on AMQP management response.");
+            result = messaging_delivery_rejected("amqp:internal-error", "Could not get application properties on AMQP management response.", NULL);
         }
         else
         {
@@ -93,7 +93,7 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
                 LogError("Could not retrieve message properties");
                 amqp_management->on_amqp_management_error(amqp_management->on_amqp_management_error_context);
                 /* Codes_SRS_AMQP_MANAGEMENT_01_136: [ When `on_message_received` fails due to errors in parsing the response message `on_message_received` shall call `messaging_delivery_rejected` and return the created delivery AMQP value. ]*/
-                result = messaging_delivery_rejected("amqp:internal-error", "Could not get message properties on AMQP management response.");
+                result = messaging_delivery_rejected("amqp:internal-error", "Could not get message properties on AMQP management response.", NULL);
             }
             else
             {
@@ -112,7 +112,7 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
                     LogError("Could not retrieve correlation Id");
                     amqp_management->on_amqp_management_error(amqp_management->on_amqp_management_error_context);
                     /* Codes_SRS_AMQP_MANAGEMENT_01_136: [ When `on_message_received` fails due to errors in parsing the response message `on_message_received` shall call `messaging_delivery_rejected` and return the created delivery AMQP value. ]*/
-                    result = messaging_delivery_rejected("amqp:internal-error", "Could not get correlation Id from AMQP management response.");
+                    result = messaging_delivery_rejected("amqp:internal-error", "Could not get correlation Id from AMQP management response.", NULL);
                 }
                 else
                 {
@@ -122,7 +122,7 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
                         LogError("Could not retrieve correlation Id ulong value");
                         amqp_management->on_amqp_management_error(amqp_management->on_amqp_management_error_context);
                         /* Codes_SRS_AMQP_MANAGEMENT_01_136: [ When `on_message_received` fails due to errors in parsing the response message `on_message_received` shall call `messaging_delivery_rejected` and return the created delivery AMQP value. ]*/
-                        result = messaging_delivery_rejected("amqp:internal-error", "Could not get correlation Id from AMQP management response.");
+                        result = messaging_delivery_rejected("amqp:internal-error", "Could not get correlation Id from AMQP management response.", NULL);
                     }
                     else
                     {
@@ -135,7 +135,7 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
                             LogError("Could not retrieve application property map");
                             amqp_management->on_amqp_management_error(amqp_management->on_amqp_management_error_context);
                             /* Codes_SRS_AMQP_MANAGEMENT_01_136: [ When `on_message_received` fails due to errors in parsing the response message `on_message_received` shall call `messaging_delivery_rejected` and return the created delivery AMQP value. ]*/
-                            result = messaging_delivery_rejected("amqp:internal-error", "Could not get application property map from the application properties in the AMQP management response.");
+                            result = messaging_delivery_rejected("amqp:internal-error", "Could not get application property map from the application properties in the AMQP management response.", NULL);
                         }
                         else
                         {
@@ -160,7 +160,7 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
                                     LogError("Could not retrieve status code from application properties");
                                     amqp_management->on_amqp_management_error(amqp_management->on_amqp_management_error_context);
                                     /* Codes_SRS_AMQP_MANAGEMENT_01_136: [ When `on_message_received` fails due to errors in parsing the response message `on_message_received` shall call `messaging_delivery_rejected` and return the created delivery AMQP value. ]*/
-                                    result = messaging_delivery_rejected("amqp:internal-error", "Could not retrieve status code from the application properties in the AMQP management response.");
+                                    result = messaging_delivery_rejected("amqp:internal-error", "Could not retrieve status code from the application properties in the AMQP management response.", NULL);
                                 }
                                 else
                                 {
@@ -172,7 +172,7 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
                                         LogError("Could not retrieve status code int value");
                                         amqp_management->on_amqp_management_error(amqp_management->on_amqp_management_error_context);
                                         /* Codes_SRS_AMQP_MANAGEMENT_01_136: [ When `on_message_received` fails due to errors in parsing the response message `on_message_received` shall call `messaging_delivery_rejected` and return the created delivery AMQP value. ]*/
-                                        result = messaging_delivery_rejected("amqp:internal-error", "Could not retrieve status code value from the application properties in the AMQP management response.");
+                                        result = messaging_delivery_rejected("amqp:internal-error", "Could not retrieve status code value from the application properties in the AMQP management response.", NULL);
                                     }
                                     else
                                     {
@@ -289,7 +289,7 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
                                                     LogError("Could not match AMQP management response to request");
                                                     amqp_management->on_amqp_management_error(amqp_management->on_amqp_management_error_context);
                                                     /* Codes_SRS_AMQP_MANAGEMENT_01_135: [ When an error occurs in creating AMQP values (for status code, etc.) `on_message_received` shall call `messaging_delivery_released` and return the created delivery AMQP value. ]*/
-                                                    result = messaging_delivery_rejected("amqp:internal-error", "Could not match AMQP management response to request");
+                                                    result = messaging_delivery_rejected("amqp:internal-error", "Could not match AMQP management response to request", NULL);
                                                 }
                                                 else
                                                 {

--- a/src/messaging.c
+++ b/src/messaging.c
@@ -156,7 +156,7 @@ AMQP_VALUE messaging_delivery_accepted(void)
     return result;
 }
 
-AMQP_VALUE messaging_delivery_rejected(const char* error_condition, const char* error_description)
+AMQP_VALUE messaging_delivery_rejected(const char* error_condition, const char* error_description, fields error_info)
 {
     AMQP_VALUE result;
     REJECTED_HANDLE rejected = rejected_create();
@@ -188,10 +188,19 @@ AMQP_VALUE messaging_delivery_rejected(const char* error_condition, const char* 
                 }
                 else
                 {
-                    if (rejected_set_error(rejected, error_handle) != 0)
+                    if((error_info != NULL) &&
+                    (error_set_info(error_handle, error_info) != 0))
                     {
-                        LogError("Cannot set error on REJECTED state handle");
+                        LogError("Cannot set error info on error AMQP value for REJECTED state");
                         error_constructing = true;
+                    }
+                    else
+                    {
+                        if (rejected_set_error(rejected, error_handle) != 0)
+                        {
+                            LogError("Cannot set error on REJECTED state handle");
+                            error_constructing = true;
+                        }
                     }
                 }
 


### PR DESCRIPTION
As per the AMQP spec section 3.4.3 reject should accept error which is of type `error` (which is `fields`)