### PR TITLE
Change amqp_management and cbs to return async_operation_handles

### DIFF
--- a/devdoc/amqp_management_requirements.md
+++ b/devdoc/amqp_management_requirements.md
@@ -31,7 +31,7 @@ DEFINE_ENUM(AMQP_MANAGEMENT_OPEN_RESULT, AMQP_MANAGEMENT_OPEN_RESULT_VALUES)
     MOCKABLE_FUNCTION(, void, amqp_management_destroy, AMQP_MANAGEMENT_HANDLE, amqp_management);
     MOCKABLE_FUNCTION(, int, amqp_management_open_async, AMQP_MANAGEMENT_HANDLE, amqp_management, ON_AMQP_MANAGEMENT_OPEN_COMPLETE, on_amqp_management_open_complete, void*, on_amqp_management_open_complete_context, ON_AMQP_MANAGEMENT_ERROR, on_amqp_management_error, void*, on_amqp_management_error_context);
     MOCKABLE_FUNCTION(, int, amqp_management_close, AMQP_MANAGEMENT_HANDLE, amqp_management);
-    MOCKABLE_FUNCTION(, int, amqp_management_execute_operation_async, AMQP_MANAGEMENT_HANDLE, amqp_management, const char*, operation, const char*, type, const char*, locales, MESSAGE_HANDLE, message, ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE, on_execute_operation_complete, void*, context);
+    MOCKABLE_FUNCTION(, ASYNC_OPERATION_HANDLE, amqp_management_execute_operation_async, AMQP_MANAGEMENT_HANDLE, amqp_management, const char*, operation, const char*, type, const char*, locales, MESSAGE_HANDLE, message, ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE, on_execute_operation_complete, void*, context);
     MOCKABLE_FUNCTION(, void, amqp_management_set_trace, AMQP_MANAGEMENT_HANDLE, amqp_management, bool, trace_on);
     MOCKABLE_FUNCTION(, int, amqp_management_set_override_status_code_key_name, AMQP_MANAGEMENT_HANDLE, amqp_management, const char*, override_status_code_key_name);
     MOCKABLE_FUNCTION(, int, amqp_management_set_override_status_description_key_name, AMQP_MANAGEMENT_HANDLE, amqp_management, const char*, override_status_description_key_name);
@@ -175,12 +175,14 @@ also passing the context passed in `amqp_management_open_async`. **]**
 ### amqp_management_execute_operation_async
 
 ```c
-int amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_management, const char* operation, const char* type, const char* locales, MESSAGE_HANDLE message, ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE on_execute_operation_complete, void* on_execute_operation_complete_context);
+ASYNC_OPERATION_HANDLE amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_management, const char* operation, const char* type, const char* locales, MESSAGE_HANDLE message, ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE on_execute_operation_complete, void* on_execute_operation_complete_context);
 ```
 
 **SRS_AMQP_MANAGEMENT_01_055: [** `amqp_management_execute_operation_async` shall start an AMQP management operation. **]**
 
-**SRS_AMQP_MANAGEMENT_01_056: [** On success it shall return an ASYNC_OPERATION_HANDLE. **]**
+**SRS_AMQP_MANAGEMENT_01_056: [** On success it shall return an `ASYNC_OPERATION_HANDLE`. **]**
+
+**SRS_AMQP_MANAGEMENT_09_004: [** The `ASYNC_OPERATION_HANDLE` cancel function shall cancel the underlying send async operation, remove this operation from the pending list, destroy this async operation. **]**
 
 **SRS_AMQP_MANAGEMENT_01_057: [** If `amqp_management`, `operation`, `type` or `on_execute_operation_complete` is NULL, `amqp_management_execute_operation_async` shall fail and return NULL. **]**
 
@@ -190,7 +192,7 @@ int amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_manageme
 
 **SRS_AMQP_MANAGEMENT_01_103: [** Otherwise the existing message shall be cloned by using `message_clone` before being modified accordingly and used for the pending operation. **]**
 
-**SRS_AMQP_MANAGEMENT_01_081: [** If `amqp_management_execute_operation_async` is called when not OPEN, it shall fail and return NULL. **]**
+**SRS_AMQP_MANAGEMENT_01_081: [** If `amqp_management_execute_operation_async` is called when not OPEN, it shall fail and return `NULL`. **]**
 
 **SRS_AMQP_MANAGEMENT_01_104: [** If `amqp_management_execute_operation_async` is called when the AMQP management is in error, it shall fail and return a non-zero value. **]**
 

--- a/devdoc/amqp_management_requirements.md
+++ b/devdoc/amqp_management_requirements.md
@@ -180,9 +180,9 @@ int amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_manageme
 
 **SRS_AMQP_MANAGEMENT_01_055: [** `amqp_management_execute_operation_async` shall start an AMQP management operation. **]**
 
-**SRS_AMQP_MANAGEMENT_01_056: [** On success it shall return 0. **]**
+**SRS_AMQP_MANAGEMENT_01_056: [** On success it shall return an ASYNC_OPERATION_HANDLE. **]**
 
-**SRS_AMQP_MANAGEMENT_01_057: [** If `amqp_management`, `operation`, `type` or `on_execute_operation_complete` is NULL, `amqp_management_execute_operation_async` shall fail and return a non-zero value. **]**
+**SRS_AMQP_MANAGEMENT_01_057: [** If `amqp_management`, `operation`, `type` or `on_execute_operation_complete` is NULL, `amqp_management_execute_operation_async` shall fail and return NULL. **]**
 
 **SRS_AMQP_MANAGEMENT_01_105: [** `on_execute_operation_complete_context` shall be allowed to be NULL. **]**
 
@@ -190,7 +190,7 @@ int amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_manageme
 
 **SRS_AMQP_MANAGEMENT_01_103: [** Otherwise the existing message shall be cloned by using `message_clone` before being modified accordingly and used for the pending operation. **]**
 
-**SRS_AMQP_MANAGEMENT_01_081: [** If `amqp_management_execute_operation_async` is called when not OPEN, it shall fail and return a non-zero value. **]**
+**SRS_AMQP_MANAGEMENT_01_081: [** If `amqp_management_execute_operation_async` is called when not OPEN, it shall fail and return NULL. **]**
 
 **SRS_AMQP_MANAGEMENT_01_104: [** If `amqp_management_execute_operation_async` is called when the AMQP management is in error, it shall fail and return a non-zero value. **]**
 
@@ -210,7 +210,7 @@ int amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_manageme
 
 **SRS_AMQP_MANAGEMENT_01_101: [** After setting the application properties, the application properties instance shall be freed by `amqpvalue_destroy`. **]**
 
-**SRS_AMQP_MANAGEMENT_01_090: [** If any APIs used to create and set the application properties on the message fails, `amqp_management_execute_operation_async` shall fail and return a non-zero value. **]**
+**SRS_AMQP_MANAGEMENT_01_090: [** If any APIs used to create and set the application properties on the message fails, `amqp_management_execute_operation_async` shall fail and return NULL. **]**
 
 **SRS_AMQP_MANAGEMENT_01_094: [** In order to set the message Id on the message, the properties shall be obtained by calling `message_get_properties`. **]**
 
@@ -230,7 +230,7 @@ int amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_manageme
 
 **SRS_AMQP_MANAGEMENT_01_166: [** The `on_message_send_complete` callback shall be passed to the `messagesender_send_async` call. **]**
 
-**SRS_AMQP_MANAGEMENT_01_089: [** If `messagesender_send_async` fails, `amqp_management_execute_operation_async` shall fail and return a non-zero value. **]**
+**SRS_AMQP_MANAGEMENT_01_089: [** If `messagesender_send_async` fails, `amqp_management_execute_operation_async` shall fail and return NULL. **]**
 
 **SRS_AMQP_MANAGEMENT_01_091: [** Once the request message has been sent, an entry shall be stored in the pending operations list by calling `singlylinkedlist_add`. **]**
 

--- a/devdoc/cbs_requirements.md
+++ b/devdoc/cbs_requirements.md
@@ -102,7 +102,7 @@ MOCKABLE_FUNCTION(, int, cbs_put_token_async, CBS_HANDLE, cbs, const char*, type
 ```
 
 **SRS_CBS_01_049: [** `cbs_put_token_async` shall construct a request message for the `put-token` operation. **]**
-**SRS_CBS_01_081: [** On success `cbs_put_token_async` shall return 0. **]**
+**SRS_CBS_01_081: [** On success `cbs_put_token_async` shall return an ASYNC_OPERATION_HANDLE. **]**
 **SRS_CBS_01_050: [** If any of the arguments `cbs`, `type`, `audience`, `token` or `on_cbs_put_token_complete` is NULL `cbs_put_token_async` shall fail and return a non-zero value. **]**
 **SRS_CBS_01_083: [** `on_cbs_put_token_complete_context` shall be allowed to be NULL. **]**
 **SRS_CBS_01_051: [** `cbs_put_token_async` shall start the AMQP management operation by calling `amqp_management_execute_operation_async`, while passing to it: **]**
@@ -123,7 +123,7 @@ MOCKABLE_FUNCTION(, int, cbs_delete_token_async, CBS_HANDLE, cbs, const char*, t
 ```
 
 **SRS_CBS_01_059: [** `cbs_delete_token_async` shall construct a request message for the `delete-token` operation. **]**
-**SRS_CBS_01_082: [** On success `cbs_delete_token_async` shall return 0. **]**
+**SRS_CBS_01_082: [** On success `cbs_delete_token_async` shall return an ASYNC_OPERATION_HANDLE. **]**
 **SRS_CBS_01_060: [** If any of the arguments `cbs`, `type`, `audience` or `on_cbs_delete_token_complete` is NULL `cbs_put_token_async` shall fail and return a non-zero value. **]**
 **SRS_CBS_01_086: [** `on_cbs_delete_token_complete_context` shall be allowed to be NULL. **]**
 **SRS_CBS_01_061: [** `cbs_delete_token_async` shall start the AMQP management operation by calling `amqp_management_execute_operation_async`, while passing to it: **]**

--- a/devdoc/cbs_requirements.md
+++ b/devdoc/cbs_requirements.md
@@ -31,8 +31,8 @@ DEFINE_ENUM(CBS_OPEN_COMPLETE_RESULT, CBS_OPEN_COMPLETE_RESULT_VALUES)
     MOCKABLE_FUNCTION(, void, cbs_destroy, CBS_HANDLE, cbs);
     MOCKABLE_FUNCTION(, int, cbs_open_async, CBS_HANDLE, cbs, ON_CBS_OPEN_COMPLETE, on_cbs_open_complete, void*, on_cbs_open_complete_context, ON_CBS_ERROR, on_cbs_error, void*, on_cbs_error_context);
     MOCKABLE_FUNCTION(, int, cbs_close, CBS_HANDLE, cbs);
-    MOCKABLE_FUNCTION(, int, cbs_put_token_async, CBS_HANDLE, cbs, const char*, type, const char*, audience, const char*, token, ON_CBS_OPERATION_COMPLETE, on_cbs_put_token_complete, void*, on_cbs_put_token_complete_context);
-    MOCKABLE_FUNCTION(, int, cbs_delete_token_async, CBS_HANDLE, cbs, const char*, type, const char*, audience, ON_CBS_OPERATION_COMPLETE, on_cbs_delete_token_complete, void*, on_cbs_delete_token_complete_context);
+    MOCKABLE_FUNCTION(, ASYNC_OPERATION_HANDLE, cbs_put_token_async, CBS_HANDLE, cbs, const char*, type, const char*, audience, const char*, token, ON_CBS_OPERATION_COMPLETE, on_cbs_put_token_complete, void*, on_cbs_put_token_complete_context);
+    MOCKABLE_FUNCTION(, ASYNC_OPERATION_HANDLE, cbs_delete_token_async, CBS_HANDLE, cbs, const char*, type, const char*, audience, ON_CBS_OPERATION_COMPLETE, on_cbs_delete_token_complete, void*, on_cbs_delete_token_complete_context);
     MOCKABLE_FUNCTION(, int, cbs_set_trace, CBS_HANDLE, cbs, bool, trace_on);
 ```
 
@@ -98,11 +98,12 @@ MOCKABLE_FUNCTION(, int, cbs_close, CBS_HANDLE, cbs);
 ### cbs_put_token_async
 
 ```c
-MOCKABLE_FUNCTION(, int, cbs_put_token_async, CBS_HANDLE, cbs, const char*, type, const char*, audience, const char*, token, ON_CBS_OPERATION_COMPLETE, on_cbs_put_token_complete, void*, on_cbs_put_token_complete_context);
+MOCKABLE_FUNCTION(, ASYNC_OPERATION_HANDLE, cbs_put_token_async, CBS_HANDLE, cbs, const char*, type, const char*, audience, const char*, token, ON_CBS_OPERATION_COMPLETE, on_cbs_put_token_complete, void*, on_cbs_put_token_complete_context);
 ```
 
 **SRS_CBS_01_049: [** `cbs_put_token_async` shall construct a request message for the `put-token` operation. **]**
-**SRS_CBS_01_081: [** On success `cbs_put_token_async` shall return an ASYNC_OPERATION_HANDLE. **]**
+**SRS_CBS_01_081: [** On success `cbs_put_token_async` shall return an `ASYNC_OPERATION_HANDLE`. **]**
+**SRS_CBS_09_001: [** The `ASYNC_OPERATION_HANDLE` cancel function shall cancel the underlying amqp management operation, remove this operation from the pending list, destroy this async operation. **]**
 **SRS_CBS_01_050: [** If any of the arguments `cbs`, `type`, `audience`, `token` or `on_cbs_put_token_complete` is NULL `cbs_put_token_async` shall fail and return a non-zero value. **]**
 **SRS_CBS_01_083: [** `on_cbs_put_token_complete_context` shall be allowed to be NULL. **]**
 **SRS_CBS_01_051: [** `cbs_put_token_async` shall start the AMQP management operation by calling `amqp_management_execute_operation_async`, while passing to it: **]**
@@ -114,16 +115,17 @@ MOCKABLE_FUNCTION(, int, cbs_put_token_async, CBS_HANDLE, cbs, const char*, type
 **SRS_CBS_01_072: [** If constructing the message fails, `cbs_put_token_async` shall fail and return a non-zero value. **]**
 **SRS_CBS_01_084: [** If `amqp_management_execute_operation_async` fails `cbs_put_token_async` shall fail and return a non-zero value. **]**
 **SRS_CBS_01_057: [** The arguments `on_execute_operation_complete` and `context` shall be set to a callback that is to be called by the AMQP management module when the operation is complete. **]**
-**SRS_CBS_01_058: [** If `cbs_put_token_async` is called when the CBS instance is not yet open or in error, it shall fail and return a non-zero value. **]**
+**SRS_CBS_01_058: [** If `cbs_put_token_async` is called when the CBS instance is not yet open or in error, it shall fail and return `NULL`. **]**
 
 ### cbs_delete_token_async
 
 ```c
-MOCKABLE_FUNCTION(, int, cbs_delete_token_async, CBS_HANDLE, cbs, const char*, type, const char*, audience, ON_CBS_OPERATION_COMPLETE, on_cbs_delete_token_complete, void*, on_cbs_delete_token_complete_context);
+MOCKABLE_FUNCTION(, ASYNC_OPERATION_HANDLE, cbs_delete_token_async, CBS_HANDLE, cbs, const char*, type, const char*, audience, ON_CBS_OPERATION_COMPLETE, on_cbs_delete_token_complete, void*, on_cbs_delete_token_complete_context);
 ```
 
 **SRS_CBS_01_059: [** `cbs_delete_token_async` shall construct a request message for the `delete-token` operation. **]**
-**SRS_CBS_01_082: [** On success `cbs_delete_token_async` shall return an ASYNC_OPERATION_HANDLE. **]**
+**SRS_CBS_01_082: [** On success `cbs_delete_token_async` shall return an `ASYNC_OPERATION_HANDLE`. **]**
+**SRS_CBS_09_001: [** The `ASYNC_OPERATION_HANDLE` cancel function shall cancel the underlying amqp management operation, remove this operation from the pending list, destroy this async operation. **]**
 **SRS_CBS_01_060: [** If any of the arguments `cbs`, `type`, `audience` or `on_cbs_delete_token_complete` is NULL `cbs_put_token_async` shall fail and return a non-zero value. **]**
 **SRS_CBS_01_086: [** `on_cbs_delete_token_complete_context` shall be allowed to be NULL. **]**
 **SRS_CBS_01_061: [** `cbs_delete_token_async` shall start the AMQP management operation by calling `amqp_management_execute_operation_async`, while passing to it: **]**
@@ -135,7 +137,7 @@ MOCKABLE_FUNCTION(, int, cbs_delete_token_async, CBS_HANDLE, cbs, const char*, t
 **SRS_CBS_01_071: [** If constructing the message fails, `cbs_delete_token_async` shall fail and return a non-zero value. **]**
 **SRS_CBS_01_087: [** If `amqp_management_execute_operation_async` fails `cbs_put_token_async` shall fail and return a non-zero value. **]**
 **SRS_CBS_01_066: [** The arguments `on_execute_operation_complete` and `context` shall be set to a callback that is to be called by the AMQP management module when the operation is complete. **]**
-**SRS_CBS_01_067: [** If `cbs_delete_token_async` is called when the CBS instance is not yet open or in error, it shall fail and return a non-zero value. **]**
+**SRS_CBS_01_067: [** If `cbs_delete_token_async` is called when the CBS instance is not yet open or in error, it shall fail and return `NULL`. **]**
 
 ### cbs_set_trace
 

--- a/inc/azure_uamqp_c/amqp_management.h
+++ b/inc/azure_uamqp_c/amqp_management.h
@@ -6,6 +6,7 @@
 
 #include <stdbool.h>
 #include "azure_macro_utils/macro_utils.h"
+#include "azure_uamqp_c/async_operation.h"
 #include "azure_uamqp_c/session.h"
 #include "azure_uamqp_c/message.h"
 
@@ -39,7 +40,7 @@ MU_DEFINE_ENUM(AMQP_MANAGEMENT_OPEN_RESULT, AMQP_MANAGEMENT_OPEN_RESULT_VALUES)
     MOCKABLE_FUNCTION(, void, amqp_management_destroy, AMQP_MANAGEMENT_HANDLE, amqp_management);
     MOCKABLE_FUNCTION(, int, amqp_management_open_async, AMQP_MANAGEMENT_HANDLE, amqp_management, ON_AMQP_MANAGEMENT_OPEN_COMPLETE, on_amqp_management_open_complete, void*, on_amqp_management_open_complete_context, ON_AMQP_MANAGEMENT_ERROR, on_amqp_management_error, void*, on_amqp_management_error_context);
     MOCKABLE_FUNCTION(, int, amqp_management_close, AMQP_MANAGEMENT_HANDLE, amqp_management);
-    MOCKABLE_FUNCTION(, int, amqp_management_execute_operation_async, AMQP_MANAGEMENT_HANDLE, amqp_management, const char*, operation, const char*, type, const char*, locales, MESSAGE_HANDLE, message, ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE, on_execute_operation_complete, void*, context);
+    MOCKABLE_FUNCTION(, ASYNC_OPERATION_HANDLE, amqp_management_execute_operation_async, AMQP_MANAGEMENT_HANDLE, amqp_management, const char*, operation, const char*, type, const char*, locales, MESSAGE_HANDLE, message, ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE, on_execute_operation_complete, void*, context);
     MOCKABLE_FUNCTION(, void, amqp_management_set_trace, AMQP_MANAGEMENT_HANDLE, amqp_management, bool, trace_on);
     MOCKABLE_FUNCTION(, int, amqp_management_set_override_status_code_key_name, AMQP_MANAGEMENT_HANDLE, amqp_management, const char*, override_status_code_key_name);
     MOCKABLE_FUNCTION(, int, amqp_management_set_override_status_description_key_name, AMQP_MANAGEMENT_HANDLE, amqp_management, const char*, override_status_description_key_name);

--- a/inc/azure_uamqp_c/cbs.h
+++ b/inc/azure_uamqp_c/cbs.h
@@ -4,6 +4,7 @@
 #ifndef CBS_H
 #define CBS_H
 
+#include "azure_uamqp_c/async_operation.h"
 #include "azure_uamqp_c/session.h"
 #include "azure_macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
@@ -38,8 +39,8 @@ MU_DEFINE_ENUM(CBS_OPEN_COMPLETE_RESULT, CBS_OPEN_COMPLETE_RESULT_VALUES)
     MOCKABLE_FUNCTION(, void, cbs_destroy, CBS_HANDLE, cbs);
     MOCKABLE_FUNCTION(, int, cbs_open_async, CBS_HANDLE, cbs, ON_CBS_OPEN_COMPLETE, on_cbs_open_complete, void*, on_cbs_open_complete_context, ON_CBS_ERROR, on_cbs_error, void*, on_cbs_error_context);
     MOCKABLE_FUNCTION(, int, cbs_close, CBS_HANDLE, cbs);
-    MOCKABLE_FUNCTION(, int, cbs_put_token_async, CBS_HANDLE, cbs, const char*, type, const char*, audience, const char*, token, ON_CBS_OPERATION_COMPLETE, on_cbs_put_token_complete, void*, on_cbs_put_token_complete_context);
-    MOCKABLE_FUNCTION(, int, cbs_delete_token_async, CBS_HANDLE, cbs, const char*, type, const char*, audience, ON_CBS_OPERATION_COMPLETE, on_cbs_delete_token_complete, void*, on_cbs_delete_token_complete_context);
+    MOCKABLE_FUNCTION(, ASYNC_OPERATION_HANDLE, cbs_put_token_async, CBS_HANDLE, cbs, const char*, type, const char*, audience, const char*, token, ON_CBS_OPERATION_COMPLETE, on_cbs_put_token_complete, void*, on_cbs_put_token_complete_context);
+    MOCKABLE_FUNCTION(, ASYNC_OPERATION_HANDLE, cbs_delete_token_async, CBS_HANDLE, cbs, const char*, type, const char*, audience, ON_CBS_OPERATION_COMPLETE, on_cbs_delete_token_complete, void*, on_cbs_delete_token_complete_context);
     MOCKABLE_FUNCTION(, int, cbs_set_trace, CBS_HANDLE, cbs, bool, trace_on);
 
 #ifdef __cplusplus

--- a/src/amqp_management.c
+++ b/src/amqp_management.c
@@ -29,8 +29,11 @@ typedef struct OPERATION_MESSAGE_INSTANCE_TAG
     uint64_t message_id;
     bool message_send_confirmed;
     AMQP_MANAGEMENT_HANDLE amqp_management;
-    ASYNC_OPERATION_HANDLE async_operation;
+    ASYNC_OPERATION_HANDLE send_async_context;
+    ASYNC_OPERATION_HANDLE execute_async_operation;
 } OPERATION_MESSAGE_INSTANCE;
+
+DEFINE_ASYNC_OPERATION_CONTEXT(OPERATION_MESSAGE_INSTANCE);
 
 typedef enum AMQP_MANAGEMENT_STATE_TAG
 {
@@ -241,7 +244,7 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
                                                             LogError("Did not receive send confirmation for pending operation");
                                                             execute_operation_result = AMQP_MANAGEMENT_EXECUTE_OPERATION_FAILED_BAD_STATUS;
 
-                                                            if (async_operation_cancel(operation_message->async_operation) != 0)
+                                                            if (async_operation_cancel(operation_message->send_async_context) != 0)
                                                             {
                                                                 LogError("Failed cancelling pending send operation");
                                                                 is_error = true;
@@ -262,9 +265,13 @@ static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE messag
 
                                                         /* Codes_SRS_AMQP_MANAGEMENT_01_126: [ If a corresponding correlation Id is found in the pending operations list, the callback associated with the pending operation shall be called. ]*/
                                                         /* Codes_SRS_AMQP_MANAGEMENT_01_166: [ The `message` shall be passed as argument to the callback. ]*/
-                                                        operation_message->on_execute_operation_complete(operation_message->callback_context, execute_operation_result, status_code, status_description, message);
+                                                        if (operation_message->on_execute_operation_complete != NULL)
+                                                        {
+                                                            // Check for NULL in case operation has been cancelled.
+                                                            operation_message->on_execute_operation_complete(operation_message->callback_context, execute_operation_result, status_code, status_description, message);
+                                                        }
 
-                                                        free(operation_message);
+                                                        async_operation_destroy(operation_message->execute_async_operation);
 
                                                         /* Codes_SRS_AMQP_MANAGEMENT_01_129: [ After calling the callback, the pending operation shall be removed from the pending operations list by calling `singlylinkedlist_remove`. ]*/
                                                         if (singlylinkedlist_remove(amqp_management->pending_operations, list_item_handle) != 0)
@@ -365,6 +372,7 @@ static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_res
         {
             /* Codes_SRS_AMQP_MANAGEMENT_01_170: [ If `send_result` is `MESSAGE_SEND_OK`, `on_message_send_complete` shall return. ]*/
             pending_operation_message->message_send_confirmed = true;
+            pending_operation_message->send_async_context = NULL;
         }
         else if (send_result == MESSAGE_SEND_CANCELLED)
         {
@@ -385,8 +393,13 @@ static void on_message_send_complete(void* context, MESSAGE_SEND_RESULT send_res
             else
             {
                 /* Codes_SRS_AMQP_MANAGEMENT_01_173: [ - The callback associated with the pending operation shall be called with `AMQP_MANAGEMENT_EXECUTE_OPERATION_ERROR`. ]*/
-                pending_operation_message->on_execute_operation_complete(pending_operation_message->callback_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_ERROR, 0, NULL, NULL);
-                free(pending_operation_message);
+                if (pending_operation_message->on_execute_operation_complete != NULL)
+                {
+                    // Check for NULL in case operation has been cancelled.
+                    pending_operation_message->on_execute_operation_complete(pending_operation_message->callback_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_ERROR, 0, NULL, NULL);
+                }
+
+                async_operation_destroy(pending_operation_message->execute_async_operation);
             }
         }
     }
@@ -928,6 +941,7 @@ AMQP_MANAGEMENT_HANDLE amqp_management_create(SESSION_HANDLE session, const char
     }
 
 all_ok:
+    /* Codes_SRS_AMQP_MANAGEMENT_01_056: [ On success it shall return an ASYNC_OPERATION_HANDLE. ] */
     return amqp_management;
 }
 
@@ -1079,8 +1093,12 @@ int amqp_management_close(AMQP_MANAGEMENT_HANDLE amqp_management)
                 else
                 {
                     /* Codes_SRS_AMQP_MANAGEMENT_01_054: [ All pending operations shall be indicated complete with the code `AMQP_MANAGEMENT_EXECUTE_OPERATION_INSTANCE_CLOSED`. ]*/
-                    operation_message->on_execute_operation_complete(operation_message->callback_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_INSTANCE_CLOSED, 0, NULL, NULL);
-                    free(operation_message);
+                    if (operation_message->on_execute_operation_complete != NULL)
+                    {
+                        // Check for NULL in case operation has been cancelled.
+                        operation_message->on_execute_operation_complete(operation_message->callback_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_INSTANCE_CLOSED, 0, NULL, NULL);
+                    }
+                    async_operation_destroy(operation_message->execute_async_operation);
                 }
 
                 if (singlylinkedlist_remove(amqp_management->pending_operations, list_item_handle) != 0)
@@ -1101,27 +1119,56 @@ int amqp_management_close(AMQP_MANAGEMENT_HANDLE amqp_management)
     return result;
 }
 
-int amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_management, const char* operation, const char* type, const char* locales, MESSAGE_HANDLE message, ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE on_execute_operation_complete, void* on_execute_operation_complete_context)
+static void amqp_management_execute_cancel_handler(ASYNC_OPERATION_HANDLE execute_operation)
 {
-    int result;
+    OPERATION_MESSAGE_INSTANCE* instance = GET_ASYNC_OPERATION_CONTEXT(OPERATION_MESSAGE_INSTANCE, execute_operation);
 
+    if (instance->send_async_context != NULL)
+    {
+        (void)async_operation_cancel(instance->send_async_context);
+    }
+
+    LIST_ITEM_HANDLE list_node = singlylinkedlist_get_head_item(instance->amqp_management->pending_operations);
+
+    while (list_node != NULL)
+    {
+        if (singlylinkedlist_item_get_value(list_node) == instance)
+        {
+            if (singlylinkedlist_remove(instance->amqp_management->pending_operations, list_node) != 0)
+            {
+                LogError("Failed removing pending operation from list.");
+            }
+
+            async_operation_destroy(instance->execute_async_operation);
+
+            break;
+        }
+
+        list_node = singlylinkedlist_get_next_item(list_node);
+    }
+}
+
+ASYNC_OPERATION_HANDLE amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_management, const char* operation, const char* type, const char* locales, MESSAGE_HANDLE message, ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE on_execute_operation_complete, void* on_execute_operation_complete_context)
+{
+    ASYNC_OPERATION_HANDLE result;
+    
     if ((amqp_management == NULL) ||
         (operation == NULL) ||
         (type == NULL) ||
         (on_execute_operation_complete == NULL))
     {
-        /* Codes_SRS_AMQP_MANAGEMENT_01_057: [ If `amqp_management`, `operation`, `type` or `on_execute_operation_complete` is NULL, `amqp_management_execute_operation_async` shall fail and return a non-zero value. ]*/
+        /* Codes_SRS_AMQP_MANAGEMENT_01_057: [ If `amqp_management`, `operation`, `type` or `on_execute_operation_complete` is NULL, `amqp_management_execute_operation_async` shall fail and return NULL. ]*/
         LogError("Bad arguments: amqp_management = %p, operation = %p, type = %p",
             amqp_management, operation, type);
-        result = MU_FAILURE;
+        result = NULL;
     }
-    /* Codes_SRS_AMQP_MANAGEMENT_01_081: [ If `amqp_management_execute_operation_async` is called when not OPEN, it shall fail and return a non-zero value. ]*/
+    /* Codes_SRS_AMQP_MANAGEMENT_01_081: [ If `amqp_management_execute_operation_async` is called when not OPEN, it shall fail and return NULL. ]*/
     else if ((amqp_management->amqp_management_state == AMQP_MANAGEMENT_STATE_IDLE) ||
         /* Codes_SRS_AMQP_MANAGEMENT_01_104: [ If `amqp_management_execute_operation_async` is called when the AMQP management is in error, it shall fail and return a non-zero value. ]*/
         (amqp_management->amqp_management_state == AMQP_MANAGEMENT_STATE_ERROR))
     {
         LogError("amqp_management_execute_operation_async called while not open or in error");
-        result = MU_FAILURE;
+        result = NULL;
     }
     else
     {
@@ -1145,7 +1192,7 @@ int amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_manageme
 
         if (cloned_message == NULL)
         {
-            result = MU_FAILURE;
+            result = NULL;
         }
         else
         {
@@ -1154,7 +1201,7 @@ int amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_manageme
             if (message_get_application_properties(cloned_message, &application_properties) != 0)
             {
                 LogError("Could not get application properties");
-                result = MU_FAILURE;
+                result = NULL;
             }
             else
             {
@@ -1170,7 +1217,7 @@ int amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_manageme
 
                 if (application_properties == NULL)
                 {
-                    result = MU_FAILURE;
+                    result = NULL;
                 }
                 else
                 {
@@ -1185,36 +1232,40 @@ int amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_manageme
                         /* Codes_SRS_AMQP_MANAGEMENT_01_063: [ locales string No A list of locales that the sending peer permits for incoming informational text in response messages. ]*/
                         ((locales != NULL) && (add_string_key_value_pair_to_map(application_properties, "locales", locales) != 0)))
                     {
-                        result = MU_FAILURE;
+                        result = NULL;
                     }
                     else
                     {
                         /* Codes_SRS_AMQP_MANAGEMENT_01_087: [ The application properties obtained after adding the key/value pairs shall be set on the message by calling `message_set_application_properties`. ]*/
                         if (message_set_application_properties(cloned_message, application_properties) != 0)
                         {
-                            /* Codes_SRS_AMQP_MANAGEMENT_01_090: [ If any APIs used to create and set the application properties on the message fails, `amqp_management_execute_operation_async` shall fail and return a non-zero value. ]*/
+                            /* Codes_SRS_AMQP_MANAGEMENT_01_090: [ If any APIs used to create and set the application properties on the message fails, `amqp_management_execute_operation_async` shall fail and return NULL. ]*/
                             LogError("Could not set application properties");
-                            result = MU_FAILURE;
+                            result = NULL;
                         }
                         else if (set_message_id(cloned_message, amqp_management->next_message_id) != 0)
                         {
-                            result = MU_FAILURE;
+                            result = NULL;
                         }
                         else
                         {
-                            OPERATION_MESSAGE_INSTANCE* pending_operation_message = (OPERATION_MESSAGE_INSTANCE*)calloc(1, sizeof(OPERATION_MESSAGE_INSTANCE));
-                            if (pending_operation_message == NULL)
+                            result = CREATE_ASYNC_OPERATION(OPERATION_MESSAGE_INSTANCE, amqp_management_execute_cancel_handler);
+
+                            if (result == NULL)
                             {
-                                result = MU_FAILURE;
+                                LogError("Failed allocating async result");
                             }
                             else
                             {
+                                OPERATION_MESSAGE_INSTANCE* pending_operation_message = GET_ASYNC_OPERATION_CONTEXT(OPERATION_MESSAGE_INSTANCE, result);
+
                                 LIST_ITEM_HANDLE added_item;
                                 pending_operation_message->callback_context = on_execute_operation_complete_context;
                                 pending_operation_message->on_execute_operation_complete = on_execute_operation_complete;
                                 pending_operation_message->message_id = amqp_management->next_message_id;
                                 pending_operation_message->amqp_management = amqp_management;
                                 pending_operation_message->message_send_confirmed = false;
+                                pending_operation_message->execute_async_operation = result;
 
                                 /* Codes_SRS_AMQP_MANAGEMENT_01_091: [ Once the request message has been sent, an entry shall be stored in the pending operations list by calling `singlylinkedlist_add`. ]*/
                                 added_item = singlylinkedlist_add(amqp_management->pending_operations, pending_operation_message);
@@ -1222,29 +1273,26 @@ int amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_manageme
                                 {
                                     /* Codes_SRS_AMQP_MANAGEMENT_01_092: [ If `singlylinkedlist_add` fails then `amqp_management_execute_operation_async` shall fail and return a non-zero value. ]*/
                                     LogError("Could not add the operation to the pending operations list.");
-                                    free(pending_operation_message);
-                                    result = MU_FAILURE;
+                                    async_operation_destroy(result);
+                                    result = NULL;
                                 }
                                 else
                                 {
                                     /* Codes_SRS_AMQP_MANAGEMENT_01_088: [ `amqp_management_execute_operation_async` shall send the message by calling `messagesender_send_async`. ]*/
                                     /* Codes_SRS_AMQP_MANAGEMENT_01_166: [ The `on_message_send_complete` callback shall be passed to the `messagesender_send_async` call. ]*/
-                                    pending_operation_message->async_operation = messagesender_send_async(amqp_management->message_sender, cloned_message, on_message_send_complete, added_item, 0);
-                                    if (pending_operation_message->async_operation == NULL)
+                                    pending_operation_message->send_async_context = messagesender_send_async(amqp_management->message_sender, cloned_message, on_message_send_complete, added_item, 0);
+                                    if (pending_operation_message->send_async_context == NULL)
                                     {
-                                        /* Codes_SRS_AMQP_MANAGEMENT_01_089: [ If `messagesender_send_async` fails, `amqp_management_execute_operation_async` shall fail and return a non-zero value. ]*/
+                                        /* Codes_SRS_AMQP_MANAGEMENT_01_089: [ If `messagesender_send_async` fails, `amqp_management_execute_operation_async` shall fail and return NULL. ]*/
                                         LogError("Could not send request message");
                                         (void)singlylinkedlist_remove(amqp_management->pending_operations, added_item);
-                                        free(pending_operation_message);
-                                        result = MU_FAILURE;
+                                        async_operation_destroy(result);
+                                        result = NULL;
                                     }
                                     else
                                     {
                                         /* Codes_SRS_AMQP_MANAGEMENT_01_107: [ The message Id set on the message properties shall be incremented with each operation. ]*/
                                         amqp_management->next_message_id++;
-
-                                        /* Codes_SRS_AMQP_MANAGEMENT_01_056: [ On success it shall return 0. ]*/
-                                        result = 0;
                                     }
                                 }
                             }

--- a/src/cbs.c
+++ b/src/cbs.c
@@ -26,7 +26,11 @@ typedef struct CBS_OPERATION_TAG
     ON_CBS_OPERATION_COMPLETE on_cbs_operation_complete;
     void* on_cbs_operation_complete_context;
     SINGLYLINKEDLIST_HANDLE pending_operations;
+    ASYNC_OPERATION_HANDLE amqp_management_async_context;
+    ASYNC_OPERATION_HANDLE token_operation_async_context;
 } CBS_OPERATION;
+
+DEFINE_ASYNC_OPERATION_CONTEXT(CBS_OPERATION);
 
 typedef struct CBS_INSTANCE_TAG
 {
@@ -248,8 +252,9 @@ static void on_amqp_management_execute_operation_complete(void* context, AMQP_MA
                 LogError("Failed removing operation from the pending list");
             }
 
+
             /* Codes_SRS_CBS_01_096: [ The `context` for the operation shall also be freed. ]*/
-            free(cbs_operation);
+            async_operation_destroy(cbs_operation->token_operation_async_context);
         }
     }
 }
@@ -359,7 +364,7 @@ void cbs_destroy(CBS_HANDLE cbs)
             if (pending_operation != NULL)
             {
                 pending_operation->on_cbs_operation_complete(pending_operation->on_cbs_operation_complete_context, CBS_OPERATION_RESULT_INSTANCE_CLOSED, 0, NULL);
-                free(pending_operation);
+                async_operation_destroy(pending_operation->token_operation_async_context);
             }
 
             singlylinkedlist_remove(cbs->pending_operations, first_pending_operation);
@@ -460,9 +465,35 @@ int cbs_close(CBS_HANDLE cbs)
     return result;
 }
 
-int cbs_put_token_async(CBS_HANDLE cbs, const char* type, const char* audience, const char* token, ON_CBS_OPERATION_COMPLETE on_cbs_put_token_complete, void* on_cbs_put_token_complete_context)
+static void cbs_put_token_cancel_handler(ASYNC_OPERATION_HANDLE put_token_operation)
 {
-    int result;
+    CBS_OPERATION* cbs_operation = GET_ASYNC_OPERATION_CONTEXT(CBS_OPERATION, put_token_operation);
+
+    (void)async_operation_cancel(cbs_operation->amqp_management_async_context);
+
+    LIST_ITEM_HANDLE list_node = singlylinkedlist_get_head_item(cbs_operation->pending_operations);
+
+    while (list_node != NULL)
+    {
+        if (singlylinkedlist_item_get_value(list_node) == cbs_operation)
+        {
+            if (singlylinkedlist_remove(cbs_operation->pending_operations, list_node) != 0)
+            {
+                LogError("Failed removing pending operation from list.");
+            }
+
+            async_operation_destroy(cbs_operation->token_operation_async_context);
+
+            break;
+        }
+
+        list_node = singlylinkedlist_get_next_item(list_node);
+    }
+}
+
+ASYNC_OPERATION_HANDLE cbs_put_token_async(CBS_HANDLE cbs, const char* type, const char* audience, const char* token, ON_CBS_OPERATION_COMPLETE on_cbs_put_token_complete, void* on_cbs_put_token_complete_context)
+{
+    ASYNC_OPERATION_HANDLE result;
 
     /* Codes_SRS_CBS_01_083: [ `on_cbs_put_token_complete_context` shall be allowed to be NULL. ]*/
     if ((cbs == NULL) ||
@@ -474,14 +505,14 @@ int cbs_put_token_async(CBS_HANDLE cbs, const char* type, const char* audience, 
         /* Codes_SRS_CBS_01_050: [ If any of the arguments `cbs`, `type`, `audience`, `token` or `on_cbs_put_token_complete` is NULL `cbs_put_token_async` shall fail and return a non-zero value. ]*/
         LogError("Bad arguments: cbs = %p, type = %p, audience = %p, token = %p, on_cbs_put_token_complete = %p",
             cbs, type, audience, token, on_cbs_put_token_complete);
-        result = MU_FAILURE;
+        result = NULL;
     }
     else if ((cbs->cbs_state == CBS_STATE_CLOSED) ||
         (cbs->cbs_state == CBS_STATE_ERROR))
     {
         /* Codes_SRS_CBS_01_058: [ If `cbs_put_token_async` is called when the CBS instance is not yet open or in error, it shall fail and return a non-zero value. ]*/
         LogError("put token called while closed or in error");
-        result = MU_FAILURE;
+        result = NULL;
     }
     else
     {
@@ -491,7 +522,7 @@ int cbs_put_token_async(CBS_HANDLE cbs, const char* type, const char* audience, 
         {
             /* Codes_SRS_CBS_01_072: [ If constructing the message fails, `cbs_put_token_async` shall fail and return a non-zero value. ]*/
             LogError("message_create failed");
-            result = MU_FAILURE;
+            result = NULL;
         }
         else
         {
@@ -500,7 +531,7 @@ int cbs_put_token_async(CBS_HANDLE cbs, const char* type, const char* audience, 
             {
                 /* Codes_SRS_CBS_01_072: [ If constructing the message fails, `cbs_put_token_async` shall fail and return a non-zero value. ]*/
                 LogError("Failed creating token AMQP value");
-                result = MU_FAILURE;
+                result = NULL;
             }
             else
             {
@@ -509,7 +540,7 @@ int cbs_put_token_async(CBS_HANDLE cbs, const char* type, const char* audience, 
                 {
                     /* Codes_SRS_CBS_01_072: [ If constructing the message fails, `cbs_put_token_async` shall fail and return a non-zero value. ]*/
                     LogError("Failed setting the token in the message body");
-                    result = MU_FAILURE;
+                    result = NULL;
                 }
                 else
                 {
@@ -518,13 +549,13 @@ int cbs_put_token_async(CBS_HANDLE cbs, const char* type, const char* audience, 
                     {
                         /* Codes_SRS_CBS_01_072: [ If constructing the message fails, `cbs_put_token_async` shall fail and return a non-zero value. ]*/
                         LogError("Failed creating application properties map");
-                        result = MU_FAILURE;
+                        result = NULL;
                     }
                     else
                     {
                         if (add_string_key_value_pair_to_map(application_properties, "name", audience) != 0)
                         {
-                            result = MU_FAILURE;
+                            result = NULL;
                         }
                         else
                         {
@@ -532,30 +563,33 @@ int cbs_put_token_async(CBS_HANDLE cbs, const char* type, const char* audience, 
                             {
                                 /* Codes_SRS_CBS_01_072: [ If constructing the message fails, `cbs_put_token_async` shall fail and return a non-zero value. ]*/
                                 LogError("Failed setting message application properties");
-                                result = MU_FAILURE;
+                                result = NULL;
                             }
                             else
                             {
-                                CBS_OPERATION* cbs_operation = (CBS_OPERATION*)malloc(sizeof(CBS_OPERATION));
-                                if (cbs_operation == NULL)
+                                result = CREATE_ASYNC_OPERATION(CBS_OPERATION, cbs_put_token_cancel_handler);
+
+                                if (result == NULL)
                                 {
-                                    LogError("Failed allocating CBS operation instance");
-                                    result = MU_FAILURE;
+                                    LogError("Failed allocating async operation context");
                                 }
                                 else
                                 {
+                                    CBS_OPERATION* cbs_operation = GET_ASYNC_OPERATION_CONTEXT(CBS_OPERATION, result);
+
                                     LIST_ITEM_HANDLE list_item;
 
                                     cbs_operation->on_cbs_operation_complete = on_cbs_put_token_complete;
                                     cbs_operation->on_cbs_operation_complete_context = on_cbs_put_token_complete_context;
                                     cbs_operation->pending_operations = cbs->pending_operations;
+                                    cbs_operation->token_operation_async_context = result;
 
                                     list_item = singlylinkedlist_add(cbs->pending_operations, cbs_operation);
                                     if (list_item == NULL)
                                     {
-                                        free(cbs_operation);
                                         LogError("Failed adding pending operation to list");
-                                        result = MU_FAILURE;
+                                        async_operation_destroy(result);
+                                        result = NULL;
                                     }
                                     else
                                     {
@@ -569,18 +603,20 @@ int cbs_put_token_async(CBS_HANDLE cbs, const char* type, const char* audience, 
                                         /* Codes_SRS_CBS_01_005: [ operation    No    string    "put-token" ]*/
                                         /* Codes_SRS_CBS_01_006: [ Type    No    string    The type of the token being put, e.g., "amqp:jwt". ]*/
                                         /* Codes_SRS_CBS_01_007: [ name    No    string    The "audience" to which the token applies. ]*/
-                                        if (amqp_management_execute_operation_async(cbs->amqp_management, "put-token", type, NULL, message, on_amqp_management_execute_operation_complete, list_item) != 0)
+                                        
+                                        cbs_operation->amqp_management_async_context = amqp_management_execute_operation_async(cbs->amqp_management, "put-token", type, NULL, message, on_amqp_management_execute_operation_complete, list_item);
+
+                                        if (cbs_operation->amqp_management_async_context == NULL)
                                         {
                                             singlylinkedlist_remove(cbs->pending_operations, list_item);
-                                            free(cbs_operation);
                                             /* Codes_SRS_CBS_01_084: [ If `amqp_management_execute_operation_async` fails `cbs_put_token_async` shall fail and return a non-zero value. ]*/
                                             LogError("Failed starting AMQP management operation");
-                                            result = MU_FAILURE;
+                                            async_operation_destroy(result);
+                                            result = NULL;
                                         }
                                         else
                                         {
-                                            /* Codes_SRS_CBS_01_081: [ On success `cbs_put_token_async` shall return 0. ]*/
-                                            result = 0;
+                                            /* Codes_SRS_CBS_01_081: [ On success `cbs_put_token_async` shall return an ASYNC_OPERATION_HANDLE. ]*/
                                         }
                                     }
                                 }
@@ -601,9 +637,9 @@ int cbs_put_token_async(CBS_HANDLE cbs, const char* type, const char* audience, 
     return result;
 }
 
-int cbs_delete_token_async(CBS_HANDLE cbs, const char* type, const char* audience, ON_CBS_OPERATION_COMPLETE on_cbs_delete_token_complete, void* on_cbs_delete_token_complete_context)
+ASYNC_OPERATION_HANDLE cbs_delete_token_async(CBS_HANDLE cbs, const char* type, const char* audience, ON_CBS_OPERATION_COMPLETE on_cbs_delete_token_complete, void* on_cbs_delete_token_complete_context)
 {
-    int result;
+    ASYNC_OPERATION_HANDLE result;
 
     /* Codes_SRS_CBS_01_086: [ `on_cbs_delete_token_complete_context` shall be allowed to be NULL. ]*/
     if ((cbs == NULL) ||
@@ -614,14 +650,14 @@ int cbs_delete_token_async(CBS_HANDLE cbs, const char* type, const char* audienc
         /* Codes_SRS_CBS_01_060: [ If any of the arguments `cbs`, `type`, `audience` or `on_cbs_delete_token_complete` is NULL `cbs_put_token_async` shall fail and return a non-zero value. ]*/
         LogError("Bad arguments: cbs = %p, type = %p, audience = %p, on_cbs_delete_token_complete = %p",
             cbs, type, audience, on_cbs_delete_token_complete);
-        result = MU_FAILURE;
+        result = NULL;
     }
     else if ((cbs->cbs_state == CBS_STATE_CLOSED) ||
         (cbs->cbs_state == CBS_STATE_ERROR))
     {
         /* Codes_SRS_CBS_01_067: [ If `cbs_delete_token_async` is called when the CBS instance is not yet open or in error, it shall fail and return a non-zero value. ]*/
         LogError("put token called while closed or in error");
-        result = MU_FAILURE;
+        result = NULL;
     }
     else
     {
@@ -632,7 +668,7 @@ int cbs_delete_token_async(CBS_HANDLE cbs, const char* type, const char* audienc
         {
             /* Codes_SRS_CBS_01_071: [ If constructing the message fails, `cbs_delete_token_async` shall fail and return a non-zero value. ]*/
             LogError("message_create failed");
-            result = MU_FAILURE;
+            result = NULL;
         }
         else
         {
@@ -641,13 +677,13 @@ int cbs_delete_token_async(CBS_HANDLE cbs, const char* type, const char* audienc
             {
                 /* Codes_SRS_CBS_01_071: [ If constructing the message fails, `cbs_delete_token_async` shall fail and return a non-zero value. ]*/
                 LogError("Failed creating application properties map");
-                result = MU_FAILURE;
+                result = NULL;
             }
             else
             {
                 if (add_string_key_value_pair_to_map(application_properties, "name", audience) != 0)
                 {
-                    result = MU_FAILURE;
+                    result = NULL;
                 }
                 else
                 {
@@ -656,30 +692,34 @@ int cbs_delete_token_async(CBS_HANDLE cbs, const char* type, const char* audienc
                     {
                         /* Codes_SRS_CBS_01_071: [ If constructing the message fails, `cbs_delete_token_async` shall fail and return a non-zero value. ]*/
                         LogError("Failed setting message application properties");
-                        result = MU_FAILURE;
+                        result = NULL;
                     }
                     else
                     {
-                        CBS_OPERATION* cbs_operation = (CBS_OPERATION*)malloc(sizeof(CBS_OPERATION));
-                        if (cbs_operation == NULL)
+                        result = CREATE_ASYNC_OPERATION(CBS_OPERATION, cbs_put_token_cancel_handler);
+
+                        if (result == NULL)
                         {
-                            LogError("Failed allocating CBS operation instance");
-                            result = MU_FAILURE;
+                            LogError("Failed allocating async operation context");
                         }
                         else
                         {
+                            CBS_OPERATION* cbs_operation = GET_ASYNC_OPERATION_CONTEXT(CBS_OPERATION, result);
+
                             LIST_ITEM_HANDLE list_item;
 
                             cbs_operation->on_cbs_operation_complete = on_cbs_delete_token_complete;
                             cbs_operation->on_cbs_operation_complete_context = on_cbs_delete_token_complete_context;
                             cbs_operation->pending_operations = cbs->pending_operations;
+                            cbs_operation->token_operation_async_context = result;
 
                             list_item = singlylinkedlist_add(cbs->pending_operations, cbs_operation);
                             if (list_item == NULL)
                             {
-                                free(cbs_operation);
+                                //free(cbs_operation);
                                 LogError("Failed adding pending operation to list");
-                                result = MU_FAILURE;
+                                async_operation_destroy(result);
+                                result = NULL;
                             }
                             else
                             {
@@ -694,18 +734,20 @@ int cbs_delete_token_async(CBS_HANDLE cbs, const char* type, const char* audienc
                                 /* Codes_SRS_CBS_01_022: [ operation    Yes    string    "delete-token" ]*/
                                 /* Codes_SRS_CBS_01_023: [ Type    Yes    string    The type of the token being deleted, e.g., "amqp:jwt". ]*/
                                 /* Codes_SRS_CBS_01_024: [ name    Yes    string    The "audience" of the token being deleted. ]*/
-                                if (amqp_management_execute_operation_async(cbs->amqp_management, "delete-token", type, NULL, message, on_amqp_management_execute_operation_complete, list_item) != 0)
+                                cbs_operation->amqp_management_async_context = amqp_management_execute_operation_async(cbs->amqp_management, "delete-token", type, NULL, message, on_amqp_management_execute_operation_complete, list_item);
+                                
+                                if (cbs_operation->amqp_management_async_context == NULL)
                                 {
                                     /* Codes_SRS_CBS_01_087: [ If `amqp_management_execute_operation_async` fails `cbs_put_token_async` shall fail and return a non-zero value. ]*/
                                     singlylinkedlist_remove(cbs->pending_operations, list_item);
-                                    free(cbs_operation);
+                                    //free(cbs_operation);
                                     LogError("Failed starting AMQP management operation");
-                                    result = MU_FAILURE;
+                                    async_operation_destroy(result);
+                                    result = NULL;
                                 }
                                 else
                                 {
-                                    /* Codes_SRS_CBS_01_082: [ On success `cbs_delete_token_async` shall return 0. ]*/
-                                    result = 0;
+                                    /* Codes_SRS_CBS_01_082: [ On success `cbs_delete_token_async` shall return an ASYNC_OPERATION_HANDLE. ]*/
                                 }
                             }
                         }

--- a/src/cbs.c
+++ b/src/cbs.c
@@ -716,7 +716,6 @@ ASYNC_OPERATION_HANDLE cbs_delete_token_async(CBS_HANDLE cbs, const char* type, 
                             list_item = singlylinkedlist_add(cbs->pending_operations, cbs_operation);
                             if (list_item == NULL)
                             {
-                                //free(cbs_operation);
                                 LogError("Failed adding pending operation to list");
                                 async_operation_destroy(result);
                                 result = NULL;
@@ -740,7 +739,6 @@ ASYNC_OPERATION_HANDLE cbs_delete_token_async(CBS_HANDLE cbs, const char* type, 
                                 {
                                     /* Codes_SRS_CBS_01_087: [ If `amqp_management_execute_operation_async` fails `cbs_put_token_async` shall fail and return a non-zero value. ]*/
                                     singlylinkedlist_remove(cbs->pending_operations, list_item);
-                                    //free(cbs_operation);
                                     LogError("Failed starting AMQP management operation");
                                     async_operation_destroy(result);
                                     result = NULL;

--- a/tests/amqp_management_ut/amqp_management_ut.c
+++ b/tests/amqp_management_ut/amqp_management_ut.c
@@ -97,6 +97,8 @@ static AMQP_VALUE test_delivery_accepted = (AMQP_VALUE)0x4500;
 static AMQP_VALUE test_delivery_rejected = (AMQP_VALUE)0x4501;
 static AMQP_VALUE test_delivery_released = (AMQP_VALUE)0x4502;
 
+#define SIZE_OF_OPERATION_MESSAGE_INSTANCE_STRUCT 64
+
 MOCK_FUNCTION_WITH_CODE(, void, test_amqp_management_open_complete, void*, context, AMQP_MANAGEMENT_OPEN_RESULT, open_result)
 MOCK_FUNCTION_END()
 
@@ -284,7 +286,7 @@ static int ASYNC_OPERATION_HANDLE_Compare(ASYNC_OPERATION_HANDLE left, ASYNC_OPE
 typedef struct ASYNC_OPERATION_CONTEXT_STRUCT_TEST_TAG
 {
     ASYNC_OPERATION_CANCEL_HANDLER_FUNC async_operation_cancel_handler;
-    unsigned char context[64]; // 64 is the size of OPERATION_MESSAGE_INSTANCE.
+    unsigned char context[SIZE_OF_OPERATION_MESSAGE_INSTANCE_STRUCT]; // This block of memory will be used in amqp_management.c for the OPERATION_MESSAGE_INSTANCE instance.
 } ASYNC_OPERATION_CONTEXT_STRUCT_TEST;
 
 static ASYNC_OPERATION_HANDLE my_async_operation_create(ASYNC_OPERATION_CANCEL_HANDLER_FUNC async_operation_cancel_handler, size_t context_size)

--- a/tests/cbs_ut/cbs_ut.c
+++ b/tests/cbs_ut/cbs_ut.c
@@ -69,6 +69,8 @@ static ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE saved_on_execute_operation_
 static void* saved_on_execute_operation_complete_context;
 static ASYNC_OPERATION_HANDLE test_my_amqp_management_execute_operation_async_result = (ASYNC_OPERATION_HANDLE)0x4308;
 
+#define SIZE_OF_CBS_OPERATION_STRUCT 48
+
 MOCK_FUNCTION_WITH_CODE(, void, test_on_cbs_open_complete, void*, context, CBS_OPEN_COMPLETE_RESULT, open_complete_result);
 MOCK_FUNCTION_END();
 MOCK_FUNCTION_WITH_CODE(, void, test_on_cbs_error, void*, context);
@@ -195,11 +197,10 @@ static int ASYNC_OPERATION_HANDLE_Compare(ASYNC_OPERATION_HANDLE left, ASYNC_OPE
     return left != right;
 }
 
-
 typedef struct ASYNC_OPERATION_CONTEXT_STRUCT_TEST_TAG
 {
     ASYNC_OPERATION_CANCEL_HANDLER_FUNC async_operation_cancel_handler;
-    unsigned char context[48]; // 48 is the size of CBS_OPERATION.
+    unsigned char context[SIZE_OF_CBS_OPERATION_STRUCT]; // This block of memory will be used in cbs.c for the CBS_OPERATION instance.
 } ASYNC_OPERATION_CONTEXT_STRUCT_TEST;
 
 static ASYNC_OPERATION_HANDLE my_async_operation_create(ASYNC_OPERATION_CANCEL_HANDLER_FUNC async_operation_cancel_handler, size_t context_size)

--- a/tests/cbs_ut/cbs_ut.c
+++ b/tests/cbs_ut/cbs_ut.c
@@ -67,6 +67,7 @@ static ON_AMQP_MANAGEMENT_ERROR saved_on_amqp_management_error;
 static void* saved_on_amqp_management_error_context;
 static ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE saved_on_execute_operation_complete;
 static void* saved_on_execute_operation_complete_context;
+static ASYNC_OPERATION_HANDLE test_my_amqp_management_execute_operation_async_result = (ASYNC_OPERATION_HANDLE)0x4308;
 
 MOCK_FUNCTION_WITH_CODE(, void, test_on_cbs_open_complete, void*, context, CBS_OPEN_COMPLETE_RESULT, open_complete_result);
 MOCK_FUNCTION_END();
@@ -94,7 +95,8 @@ int my_amqp_management_open_async(AMQP_MANAGEMENT_HANDLE amqp_management, ON_AMQ
     return 0;
 }
 
-int my_amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_management, const char* operation, const char* type, const char* locales, MESSAGE_HANDLE message, ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE on_execute_operation_complete, void* on_execute_operation_complete_context)
+
+ASYNC_OPERATION_HANDLE my_amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_management, const char* operation, const char* type, const char* locales, MESSAGE_HANDLE message, ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE on_execute_operation_complete, void* on_execute_operation_complete_context)
 {
     (void)message;
     (void)locales;
@@ -103,7 +105,7 @@ int my_amqp_management_execute_operation_async(AMQP_MANAGEMENT_HANDLE amqp_manag
     (void)amqp_management;
     saved_on_execute_operation_complete = on_execute_operation_complete;
     saved_on_execute_operation_complete_context = on_execute_operation_complete_context;
-    return 0;
+    return test_my_amqp_management_execute_operation_async_result;
 }
 
 static const void** list_items = NULL;
@@ -182,6 +184,39 @@ IMPLEMENT_UMOCK_C_ENUM_TYPE(CBS_OPEN_COMPLETE_RESULT, CBS_OPEN_COMPLETE_RESULT_V
 TEST_DEFINE_ENUM_TYPE(CBS_OPERATION_RESULT, CBS_OPERATION_RESULT_VALUES);
 IMPLEMENT_UMOCK_C_ENUM_TYPE(CBS_OPERATION_RESULT, CBS_OPERATION_RESULT_VALUES);
 
+static void ASYNC_OPERATION_HANDLE_ToString(char* string, size_t bufferSize, ASYNC_OPERATION_HANDLE val)
+{
+    (void)bufferSize;
+    (void)sprintf(string, "%p", val);
+}
+
+static int ASYNC_OPERATION_HANDLE_Compare(ASYNC_OPERATION_HANDLE left, ASYNC_OPERATION_HANDLE right)
+{
+    return left != right;
+}
+
+
+typedef struct ASYNC_OPERATION_CONTEXT_STRUCT_TEST_TAG
+{
+    ASYNC_OPERATION_CANCEL_HANDLER_FUNC async_operation_cancel_handler;
+    unsigned char context[48]; // 48 is the size of CBS_OPERATION.
+} ASYNC_OPERATION_CONTEXT_STRUCT_TEST;
+
+static ASYNC_OPERATION_HANDLE my_async_operation_create(ASYNC_OPERATION_CANCEL_HANDLER_FUNC async_operation_cancel_handler, size_t context_size)
+{
+    (void)context_size;
+    ASYNC_OPERATION_CONTEXT_STRUCT_TEST* result = my_gballoc_malloc(sizeof(ASYNC_OPERATION_CONTEXT_STRUCT_TEST));
+    memset(result, 0, sizeof(ASYNC_OPERATION_CONTEXT_STRUCT_TEST));
+    result->async_operation_cancel_handler = async_operation_cancel_handler;
+
+    return (ASYNC_OPERATION_HANDLE)result;
+}
+
+static void my_async_operation_destroy(ASYNC_OPERATION_HANDLE async_operation)
+{
+    my_gballoc_free(async_operation);
+}
+
 static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
 {
     ASSERT_FAIL("umock_c reported error :%" PRI_MU_ENUM "", MU_ENUM_VALUE(UMOCK_C_ERROR_CODE, error_code));
@@ -225,6 +260,8 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_UMOCKC_PAIRED_CREATE_DESTROY_CALLS(amqp_management_create, amqp_management_destroy);
     REGISTER_UMOCKC_PAIRED_CREATE_DESTROY_CALLS(message_create, message_destroy);
     REGISTER_UMOCKC_PAIRED_CREATE_DESTROY_CALLS(properties_create, properties_destroy);
+    REGISTER_GLOBAL_MOCK_HOOK(async_operation_create, my_async_operation_create);
+    REGISTER_GLOBAL_MOCK_HOOK(async_operation_destroy, my_async_operation_destroy);
 
     REGISTER_UMOCK_ALIAS_TYPE(CBS_HANDLE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(SESSION_HANDLE, void*);
@@ -236,6 +273,8 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_UMOCK_ALIAS_TYPE(ON_AMQP_MANAGEMENT_EXECUTE_OPERATION_COMPLETE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(SINGLYLINKEDLIST_HANDLE, void*);
     REGISTER_UMOCK_ALIAS_TYPE(LIST_ITEM_HANDLE, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(ASYNC_OPERATION_HANDLE, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(ASYNC_OPERATION_CANCEL_HANDLER_FUNC, void*);
 }
 
 TEST_SUITE_CLEANUP(suite_cleanup)
@@ -391,7 +430,7 @@ TEST_FUNCTION(cbs_destroy_frees_all_resources_including_the_pending_operations)
     STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(test_singlylinkedlist));
     STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(test_on_cbs_put_token_complete((void*)0x4244, CBS_OPERATION_RESULT_INSTANCE_CLOSED, 0, NULL));
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(async_operation_destroy(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(singlylinkedlist_remove(test_singlylinkedlist, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(singlylinkedlist_get_head_item(test_singlylinkedlist));
     STRICT_EXPECTED_CALL(singlylinkedlist_destroy(test_singlylinkedlist));
@@ -819,7 +858,7 @@ TEST_FUNCTION(cbs_close_when_not_open_fails)
 /* cbs_put_token_async */
 
 /* Tests_SRS_CBS_01_049: [ `cbs_put_token_async` shall construct a request message for the `put-token` operation. ]*/
-/* Tests_SRS_CBS_01_081: [ On success `cbs_put_token_async` shall return 0. ]*/
+/* Tests_SRS_CBS_01_081: [ On success `cbs_put_token_async` shall return an ASYNC_OPERATION_HANDLE. ]*/
 /* Tests_SRS_CBS_01_051: [ `cbs_put_token_async` shall start the AMQP management operation by calling `amqp_management_execute_operation_async`, while passing to it: ]*/
 /* Tests_SRS_CBS_01_052: [ The `amqp_management` argument shall be the one for the AMQP management instance created in `cbs_create`. ]*/
 /* Tests_SRS_CBS_01_053: [ The `operation` argument shall be `put-token`. ]*/
@@ -835,7 +874,7 @@ TEST_FUNCTION(cbs_put_token_async_creates_the_message_and_starts_the_amqp_manage
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -855,7 +894,7 @@ TEST_FUNCTION(cbs_put_token_async_creates_the_message_and_starts_the_amqp_manage
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_value));
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_key));
     STRICT_EXPECTED_CALL(message_set_application_properties(test_message, test_map_value));
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    STRICT_EXPECTED_CALL(async_operation_create(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(singlylinkedlist_add(test_singlylinkedlist, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(amqp_management_execute_operation_async(test_amqp_management_handle, "put-token", "some_type", NULL, test_message, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_map_value));
@@ -867,7 +906,7 @@ TEST_FUNCTION(cbs_put_token_async_creates_the_message_and_starts_the_amqp_manage
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -877,14 +916,14 @@ TEST_FUNCTION(cbs_put_token_async_creates_the_message_and_starts_the_amqp_manage
 TEST_FUNCTION(cbs_put_token_async_with_NULL_cbs_handle_fails)
 {
     // arrange
-    int result;
+    ASYNC_OPERATION_HANDLE result;
 
     // act
     result = cbs_put_token_async(NULL, "some_type", "my_audience", "blah_token", test_on_cbs_put_token_complete, (void*)0x4244);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 }
 
 /* Tests_SRS_CBS_01_050: [ If any of the arguments `cbs`, `type`, `audience`, `token` or `on_cbs_put_token_complete` is NULL `cbs_put_token_async` shall fail and return a non-zero value. ]*/
@@ -892,7 +931,7 @@ TEST_FUNCTION(cbs_put_token_async_with_NULL_type_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -903,7 +942,7 @@ TEST_FUNCTION(cbs_put_token_async_with_NULL_type_fails)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -914,7 +953,7 @@ TEST_FUNCTION(cbs_put_token_async_with_NULL_audience_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -925,7 +964,7 @@ TEST_FUNCTION(cbs_put_token_async_with_NULL_audience_fails)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_IS_NULL(result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -936,7 +975,7 @@ TEST_FUNCTION(cbs_put_token_async_with_NULL_token_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -947,7 +986,7 @@ TEST_FUNCTION(cbs_put_token_async_with_NULL_token_fails)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -958,7 +997,7 @@ TEST_FUNCTION(cbs_put_token_async_with_NULL_complete_callback_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -969,7 +1008,7 @@ TEST_FUNCTION(cbs_put_token_async_with_NULL_complete_callback_fails)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -980,7 +1019,7 @@ TEST_FUNCTION(cbs_put_token_async_with_NULL_complete_context_succeeds)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -1000,7 +1039,7 @@ TEST_FUNCTION(cbs_put_token_async_with_NULL_complete_context_succeeds)
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_value));
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_key));
     STRICT_EXPECTED_CALL(message_set_application_properties(test_message, test_map_value));
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    STRICT_EXPECTED_CALL(async_operation_create(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(singlylinkedlist_add(test_singlylinkedlist, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(amqp_management_execute_operation_async(test_amqp_management_handle, "put-token", "some_type", NULL, test_message, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_map_value));
@@ -1012,7 +1051,7 @@ TEST_FUNCTION(cbs_put_token_async_with_NULL_complete_context_succeeds)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -1024,7 +1063,7 @@ TEST_FUNCTION(when_any_underlying_call_fails_cbs_put_token_async_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     size_t count;
     size_t index;
     int negativeTestsInitResult = umock_c_negative_tests_init();
@@ -1053,12 +1092,12 @@ TEST_FUNCTION(when_any_underlying_call_fails_cbs_put_token_async_fails)
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_key));
     STRICT_EXPECTED_CALL(message_set_application_properties(test_message, test_map_value))
         .SetFailReturn(42);
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
+    STRICT_EXPECTED_CALL(async_operation_create(IGNORED_PTR_ARG, IGNORED_NUM_ARG))
         .SetFailReturn(NULL);
     STRICT_EXPECTED_CALL(singlylinkedlist_add(test_singlylinkedlist, IGNORED_PTR_ARG))
         .SetFailReturn(NULL);
     STRICT_EXPECTED_CALL(amqp_management_execute_operation_async(test_amqp_management_handle, "put-token", "some_type", NULL, test_message, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .SetFailReturn(42);
+        .SetFailReturn(NULL);
 
     umock_c_negative_tests_snapshot();
 
@@ -1082,7 +1121,7 @@ TEST_FUNCTION(when_any_underlying_call_fails_cbs_put_token_async_fails)
         result = cbs_put_token_async(cbs, "some_type", "my_audience", "blah_token", test_on_cbs_put_token_complete, NULL);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, tmp_msg);
+        ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result, tmp_msg);
     }
 
     // cleanup
@@ -1095,7 +1134,7 @@ TEST_FUNCTION(cbs_put_token_async_when_not_open_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     umock_c_reset_all_calls();
 
@@ -1104,7 +1143,7 @@ TEST_FUNCTION(cbs_put_token_async_when_not_open_fails)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -1115,7 +1154,7 @@ TEST_FUNCTION(cbs_put_token_async_while_opening_succeeds)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     umock_c_reset_all_calls();
@@ -1134,7 +1173,7 @@ TEST_FUNCTION(cbs_put_token_async_while_opening_succeeds)
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_value));
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_key));
     STRICT_EXPECTED_CALL(message_set_application_properties(test_message, test_map_value));
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    STRICT_EXPECTED_CALL(async_operation_create(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(singlylinkedlist_add(test_singlylinkedlist, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(amqp_management_execute_operation_async(test_amqp_management_handle, "put-token", "some_type", NULL, test_message, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_map_value));
@@ -1146,7 +1185,7 @@ TEST_FUNCTION(cbs_put_token_async_while_opening_succeeds)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -1157,7 +1196,7 @@ TEST_FUNCTION(cbs_put_token_async_when_in_error_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -1169,7 +1208,7 @@ TEST_FUNCTION(cbs_put_token_async_when_in_error_fails)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -1178,7 +1217,7 @@ TEST_FUNCTION(cbs_put_token_async_when_in_error_fails)
 /* cbs_delete_token_async */
 
 /* Tests_SRS_CBS_01_059: [ `cbs_delete_token_async` shall construct a request message for the `delete-token` operation. ]*/
-/* Tests_SRS_CBS_01_082: [ On success `cbs_delete_token_async` shall return 0. ]*/
+/* Tests_SRS_CBS_01_082: [ On success `cbs_delete_token_async` shall return an ASYNC_OPERATION_HANDLE. ]*/
 /* Tests_SRS_CBS_01_061: [ `cbs_delete_token_async` shall start the AMQP management operation by calling `amqp_management_execute_operation_async`, while passing to it: ]*/
 /* Tests_SRS_CBS_01_085: [ The `amqp_management` argument shall be the one for the AMQP management instance created in `cbs_create`. ]*/
 /* Tests_SRS_CBS_01_062: [ The `operation` argument shall be `delete-token`. ]*/
@@ -1196,7 +1235,7 @@ TEST_FUNCTION(cbs_delete_token_async_creates_the_message_and_starts_the_amqp_man
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -1213,7 +1252,7 @@ TEST_FUNCTION(cbs_delete_token_async_creates_the_message_and_starts_the_amqp_man
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_value));
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_key));
     STRICT_EXPECTED_CALL(message_set_application_properties(test_message, test_map_value));
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    STRICT_EXPECTED_CALL(async_operation_create(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(singlylinkedlist_add(test_singlylinkedlist, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(amqp_management_execute_operation_async(test_amqp_management_handle, "delete-token", "some_type", NULL, test_message, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_map_value));
@@ -1224,7 +1263,7 @@ TEST_FUNCTION(cbs_delete_token_async_creates_the_message_and_starts_the_amqp_man
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -1234,14 +1273,14 @@ TEST_FUNCTION(cbs_delete_token_async_creates_the_message_and_starts_the_amqp_man
 TEST_FUNCTION(cbs_delete_token_with_NULL_cbs_handle_fails)
 {
     // arrange
-    int result;
+    ASYNC_OPERATION_HANDLE result;
 
     // act
     result = cbs_delete_token_async(NULL, "test_type", "my_audience", test_on_cbs_delete_token_complete, (void*)0x4244);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 }
 
 /* Tests_SRS_CBS_01_060: [ If any of the arguments `cbs`, `type`, `audience` or `on_cbs_delete_token_complete` is NULL `cbs_put_token_async` shall fail and return a non-zero value. ]*/
@@ -1249,7 +1288,7 @@ TEST_FUNCTION(cbs_delete_token_with_NULL_type_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -1260,7 +1299,7 @@ TEST_FUNCTION(cbs_delete_token_with_NULL_type_fails)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -1271,7 +1310,7 @@ TEST_FUNCTION(cbs_delete_token_with_NULL_audience_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -1282,7 +1321,7 @@ TEST_FUNCTION(cbs_delete_token_with_NULL_audience_fails)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -1293,7 +1332,7 @@ TEST_FUNCTION(cbs_delete_token_with_NULL_complete_callback_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -1304,7 +1343,7 @@ TEST_FUNCTION(cbs_delete_token_with_NULL_complete_callback_fails)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -1315,7 +1354,7 @@ TEST_FUNCTION(cbs_delete_token_async_with_NULL_complete_context_succeeds)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -1332,7 +1371,7 @@ TEST_FUNCTION(cbs_delete_token_async_with_NULL_complete_context_succeeds)
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_value));
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_key));
     STRICT_EXPECTED_CALL(message_set_application_properties(test_message, test_map_value));
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    STRICT_EXPECTED_CALL(async_operation_create(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(singlylinkedlist_add(test_singlylinkedlist, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(amqp_management_execute_operation_async(test_amqp_management_handle, "delete-token", "some_type", NULL, test_message, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_map_value));
@@ -1343,7 +1382,7 @@ TEST_FUNCTION(cbs_delete_token_async_with_NULL_complete_context_succeeds)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -1355,7 +1394,7 @@ TEST_FUNCTION(when_any_underlying_call_fails_cbs_delete_token_async_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     size_t count;
     size_t index;
     int negativeTestsInitResult = umock_c_negative_tests_init();
@@ -1380,12 +1419,12 @@ TEST_FUNCTION(when_any_underlying_call_fails_cbs_delete_token_async_fails)
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_key));
     STRICT_EXPECTED_CALL(message_set_application_properties(test_message, test_map_value))
         .SetFailReturn(42);
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG))
+    STRICT_EXPECTED_CALL(async_operation_create(IGNORED_PTR_ARG, IGNORED_NUM_ARG))
         .SetFailReturn(NULL);
     STRICT_EXPECTED_CALL(singlylinkedlist_add(test_singlylinkedlist, IGNORED_PTR_ARG))
         .SetFailReturn(NULL);
     STRICT_EXPECTED_CALL(amqp_management_execute_operation_async(test_amqp_management_handle, "delete-token", "some_type", NULL, test_message, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .SetFailReturn(42);
+        .SetFailReturn(NULL);
 
     umock_c_negative_tests_snapshot();
 
@@ -1409,7 +1448,7 @@ TEST_FUNCTION(when_any_underlying_call_fails_cbs_delete_token_async_fails)
         result = cbs_delete_token_async(cbs, "some_type", "my_audience", test_on_cbs_put_token_complete, NULL);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, tmp_msg);
+        ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result, tmp_msg);
     }
 
     // cleanup
@@ -1422,7 +1461,7 @@ TEST_FUNCTION(cbs_delete_token_async_when_not_open_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     umock_c_reset_all_calls();
 
@@ -1431,7 +1470,7 @@ TEST_FUNCTION(cbs_delete_token_async_when_not_open_fails)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -1442,7 +1481,7 @@ TEST_FUNCTION(cbs_delete_token_async_while_opening_succeeds)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     umock_c_reset_all_calls();
@@ -1458,7 +1497,7 @@ TEST_FUNCTION(cbs_delete_token_async_while_opening_succeeds)
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_value));
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_name_propery_key));
     STRICT_EXPECTED_CALL(message_set_application_properties(test_message, test_map_value));
-    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
+    STRICT_EXPECTED_CALL(async_operation_create(IGNORED_PTR_ARG, IGNORED_NUM_ARG));
     STRICT_EXPECTED_CALL(singlylinkedlist_add(test_singlylinkedlist, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(amqp_management_execute_operation_async(test_amqp_management_handle, "delete-token", "some_type", NULL, test_message, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(amqpvalue_destroy(test_map_value));
@@ -1469,7 +1508,7 @@ TEST_FUNCTION(cbs_delete_token_async_while_opening_succeeds)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_EQUAL(int, 0, result);
+    ASSERT_ARE_NOT_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -1480,7 +1519,7 @@ TEST_FUNCTION(cbs_delete_token_async_when_in_error_fails)
 {
     // arrange
     CBS_HANDLE cbs;
-    int result;
+    ASYNC_OPERATION_HANDLE result;
     cbs = cbs_create(test_session_handle);
     (void)cbs_open_async(cbs, test_on_cbs_open_complete, (void*)0x4242, test_on_cbs_error, (void*)0x4243);
     saved_on_amqp_management_open_complete(saved_on_amqp_management_open_complete_context, AMQP_MANAGEMENT_OPEN_OK);
@@ -1492,7 +1531,7 @@ TEST_FUNCTION(cbs_delete_token_async_when_in_error_fails)
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+    ASSERT_ARE_EQUAL(ASYNC_OPERATION_HANDLE, NULL, result);
 
     // cleanup
     cbs_destroy(cbs);
@@ -1833,7 +1872,7 @@ TEST_FUNCTION(on_amqp_management_operation_complete_with_OK_triggers_the_cbs_ope
     STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(test_on_cbs_put_token_complete((void*)0x4244, CBS_OPERATION_RESULT_OK, 200, "blah"));
     STRICT_EXPECTED_CALL(singlylinkedlist_remove(test_singlylinkedlist, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(async_operation_destroy(IGNORED_PTR_ARG));
 
     // act
     saved_on_execute_operation_complete(saved_on_execute_operation_complete_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_OK, 200, "blah", test_response_message);
@@ -1863,7 +1902,7 @@ TEST_FUNCTION(on_amqp_management_operation_complete_with_ERROR_triggers_the_cbs_
     STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(test_on_cbs_put_token_complete((void*)0x4244, CBS_OPERATION_RESULT_CBS_ERROR, 401, "blah"));
     STRICT_EXPECTED_CALL(singlylinkedlist_remove(test_singlylinkedlist, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(async_operation_destroy(IGNORED_PTR_ARG));
 
     // act
     saved_on_execute_operation_complete(saved_on_execute_operation_complete_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_ERROR, 401, "blah", test_response_message);
@@ -1893,7 +1932,7 @@ TEST_FUNCTION(on_amqp_management_operation_complete_with_OPERATION_FAILED_BAD_ST
     STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(test_on_cbs_put_token_complete((void*)0x4244, CBS_OPERATION_RESULT_OPERATION_FAILED, 0, "blah"));
     STRICT_EXPECTED_CALL(singlylinkedlist_remove(test_singlylinkedlist, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(async_operation_destroy(IGNORED_PTR_ARG));
 
     // act
     saved_on_execute_operation_complete(saved_on_execute_operation_complete_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_FAILED_BAD_STATUS, 0, "blah", test_response_message);
@@ -1923,7 +1962,7 @@ TEST_FUNCTION(on_amqp_management_operation_complete_with_INSTANCE_CLOSED_trigger
     STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(test_on_cbs_put_token_complete((void*)0x4244, CBS_OPERATION_RESULT_INSTANCE_CLOSED, 0, "blah"));
     STRICT_EXPECTED_CALL(singlylinkedlist_remove(test_singlylinkedlist, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(async_operation_destroy(IGNORED_PTR_ARG));
 
     // act
     saved_on_execute_operation_complete(saved_on_execute_operation_complete_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_INSTANCE_CLOSED, 0, "blah", test_response_message);
@@ -1957,7 +1996,7 @@ TEST_FUNCTION(on_amqp_management_operation_complete_with_OK_for_delete_token_tri
     STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(test_on_cbs_delete_token_complete((void*)0x4244, CBS_OPERATION_RESULT_OK, 200, "blah"));
     STRICT_EXPECTED_CALL(singlylinkedlist_remove(test_singlylinkedlist, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(async_operation_destroy(IGNORED_PTR_ARG));
 
     // act
     saved_on_execute_operation_complete(saved_on_execute_operation_complete_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_OK, 200, "blah", test_response_message);
@@ -1987,7 +2026,7 @@ TEST_FUNCTION(on_amqp_management_operation_complete_with_ERROR_for_delete_token_
     STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(test_on_cbs_delete_token_complete((void*)0x4244, CBS_OPERATION_RESULT_CBS_ERROR, 401, "blah"));
     STRICT_EXPECTED_CALL(singlylinkedlist_remove(test_singlylinkedlist, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(async_operation_destroy(IGNORED_PTR_ARG));
 
     // act
     saved_on_execute_operation_complete(saved_on_execute_operation_complete_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_ERROR, 401, "blah", test_response_message);
@@ -2017,7 +2056,7 @@ TEST_FUNCTION(on_amqp_management_operation_complete_with_OPERATION_FAILED_BAD_ST
     STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(test_on_cbs_delete_token_complete((void*)0x4244, CBS_OPERATION_RESULT_OPERATION_FAILED, 0, "blah"));
     STRICT_EXPECTED_CALL(singlylinkedlist_remove(test_singlylinkedlist, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(async_operation_destroy(IGNORED_PTR_ARG));
 
     // act
     saved_on_execute_operation_complete(saved_on_execute_operation_complete_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_FAILED_BAD_STATUS, 0, "blah", test_response_message);
@@ -2047,7 +2086,7 @@ TEST_FUNCTION(on_amqp_management_operation_complete_with_INSTANCE_CLOSED_for_del
     STRICT_EXPECTED_CALL(singlylinkedlist_item_get_value(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(test_on_cbs_delete_token_complete((void*)0x4244, CBS_OPERATION_RESULT_INSTANCE_CLOSED, 0, "blah"));
     STRICT_EXPECTED_CALL(singlylinkedlist_remove(test_singlylinkedlist, IGNORED_PTR_ARG));
-    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
+    STRICT_EXPECTED_CALL(async_operation_destroy(IGNORED_PTR_ARG));
 
     // act
     saved_on_execute_operation_complete(saved_on_execute_operation_complete_context, AMQP_MANAGEMENT_EXECUTE_OPERATION_INSTANCE_CLOSED, 0, "blah", test_response_message);

--- a/tests/iothub_e2e/iothub_e2e.c
+++ b/tests/iothub_e2e/iothub_e2e.c
@@ -168,6 +168,7 @@ TEST_FUNCTION(send_1_message_to_iothub_unsettled_auth_with_cbs)
 {
     // arrange
     int result;
+    ASYNC_OPERATION_HANDLE async_operation;
     CONNECTION_HANDLE client_connection;
     SESSION_HANDLE client_session;
     LINK_HANDLE client_link;
@@ -246,8 +247,8 @@ TEST_FUNCTION(send_1_message_to_iothub_unsettled_auth_with_cbs)
 
     auth = false;
 
-    result = cbs_put_token_async(cbs, "servicebus.windows.net:sastoken", STRING_c_str(scope_string), STRING_c_str(sas_token), on_cbs_put_token_complete, cbs);
-    ASSERT_ARE_EQUAL(int, 0, result, "cannot put cbs token");
+    async_operation = cbs_put_token_async(cbs, "servicebus.windows.net:sastoken", STRING_c_str(scope_string), STRING_c_str(sas_token), on_cbs_put_token_complete, cbs);
+    ASSERT_ARE_NOT_EQUAL(void_ptr, NULL, async_operation, "cannot put cbs token");
 
     start_time = time(NULL);
     while ((now_time = time(NULL)),


### PR DESCRIPTION
This change will allow the calling layer to cancel CBS put-token and delete-token operations, avoiding callbacks hitting contexts that have already been destroyed.