### PR TITLE
Fix double free in cbs in case a failure in message sender prevents callback to reach cbs.c

### DIFF
--- a/src/message_sender.c
+++ b/src/message_sender.c
@@ -127,31 +127,37 @@ static void on_delivery_settled(void* context, delivery_number delivery_no, LINK
                 {
                     LogError("Error getting descriptor for delivery state");
                 }
-                else if (is_accepted_type_by_descriptor(descriptor))
-                {
-                    message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_OK, described);
-                }
                 else
                 {
-                    message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_ERROR, described);
+                    if (is_accepted_type_by_descriptor(descriptor))
+                    {
+                        message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_OK, described);
+                    }
+                    else
+                    {
+                        message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_ERROR, described);
+                    }
+
+                    remove_pending_message(message_sender, pending_send);
                 }
             }
 
             break;
         case LINK_DELIVERY_SETTLE_REASON_SETTLED:
             message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_OK, NULL);
+            remove_pending_message(message_sender, pending_send);
             break;
         case LINK_DELIVERY_SETTLE_REASON_TIMEOUT:
             message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_TIMEOUT, NULL);
+            remove_pending_message(message_sender, pending_send);
             break;
         case LINK_DELIVERY_SETTLE_REASON_NOT_DELIVERED:
         default:
             message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_ERROR, NULL);
+            remove_pending_message(message_sender, pending_send);
             break;
         }
     }
-
-    remove_pending_message(message_sender, pending_send);
 }
 
 static int encode_bytes(void* context, const unsigned char* bytes, size_t length)


### PR DESCRIPTION
This bug was detected using fuzzing tests.

Root cause:
- The issue is in message_sender.c:104 (on_delivery_settled);
- A disposition is received for a pending message previously sent;
- The `delivery_state` is garbled (due to fuzzing) and cannot be decoded (with `amqpvalue_get_inplace_descriptor`);
- Since it is not decoded, the `on_message_send_complete` callback is not invoked (which would land on cbs.c:on_amqp_management_execute_operation_complete, which would release hold of the ASYNC_OPERATION_HANDLE [cbs_operation->token_operation_async_context] related to this message [cbs.c:257:async_operation_destroy]);
- However, `on_delivery_settled` proceeds to destroy the ASYNC_OPERATION_HANDLE anyway (message_sender.c:154:remove_pending_message);
- Now when the cbs instance is destroyed, it will still attempt to destroy the pending ASYNC_OPERATION_HANDLE (cbs_operation->token_operation_async_context) as it has never received a response, causing a memory access violation.

Note: there are no unit tests for message_sender.c, so no tests were updated or added.