### PR TITLE
Update submodules to remove 'www' prefix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "deps/azure-c-shared-utility"]
 	path = deps/azure-c-shared-utility
-	url = https://www.github.com/Azure/azure-c-shared-utility
+	url = https://github.com/Azure/azure-c-shared-utility
 [submodule "deps/azure-ctest"]
 	path = deps/azure-ctest
-	url = https://www.github.com/Azure/azure-ctest
+	url = https://github.com/Azure/azure-ctest
 [submodule "deps/umock-c"]
 	path = deps/umock-c
-	url = https://www.github.com/Azure/umock-c
+	url = https://github.com/Azure/umock-c
 [submodule "deps/azure-c-testrunnerswitcher"]
 	path = deps/azure-c-testrunnerswitcher
-	url = https://www.github.com/Azure/azure-c-testrunnerswitcher
+	url = https://github.com/Azure/azure-c-testrunnerswitcher
 [submodule "deps/azure-macro-utils-c"]
 	path = deps/azure-macro-utils-c
 	url = https://github.com/Azure/azure-macro-utils-c.git


### PR DESCRIPTION
When cloning this repo as a dependency of [0] and updating submodules,
Git displays warnings like this:

    warning: redirecting to https://github.com/Azure/azure-ctest.git/

Fix by removing the "www" prefix from the module URLs.

[0] https://github.com/Azure/azure-iot-sdk-c