### PR TITLE
Fixes to chain of async_operation_cancel calls found in fuzzing tests

### DIFF
--- a/src/async_operation.c
+++ b/src/async_operation.c
@@ -42,6 +42,7 @@ ASYNC_OPERATION_HANDLE async_operation_create(ASYNC_OPERATION_CANCEL_HANDLER_FUN
         else
         {
             /* Codes_SRS_ASYNC_OPERATION_01_001: [ `async_operation_create` shall return a non-NULL handle to a newly created asynchronous operation instance.]*/
+            (void)memset(async_operation, 0, context_size);
             async_operation->async_operation_cancel_handler = async_operation_cancel_handler;
         }
     }

--- a/src/link.c
+++ b/src/link.c
@@ -1343,7 +1343,7 @@ static void link_transfer_cancel_handler(ASYNC_OPERATION_HANDLE link_transfer_op
         pending_delivery->on_delivery_settled(pending_delivery->callback_context, pending_delivery->delivery_id, LINK_DELIVERY_SETTLE_REASON_CANCELLED, NULL);
     }
 
-    (void)singlylinkedlist_remove_if(((LINK_HANDLE)pending_delivery->link)->pending_deliveries, remove_pending_delivery_condition_function, pending_delivery);
+    (void)singlylinkedlist_remove_if(((LINK_HANDLE)pending_delivery->link)->pending_deliveries, remove_pending_delivery_condition_function, link_transfer_operation);
 
     async_operation_destroy(link_transfer_operation);
 }

--- a/src/message_sender.c
+++ b/src/message_sender.c
@@ -204,6 +204,7 @@ static bool is_message_in_queue(MESSAGE_SENDER_HANDLE message_sender, ASYNC_OPER
         if (message_sender->messages[i] == message)
         {
             result = true;
+            break;
         }
     }
 

--- a/src/message_sender.c
+++ b/src/message_sender.c
@@ -37,6 +37,7 @@ typedef struct MESSAGE_WITH_CALLBACK_TAG
     MESSAGE_SENDER_HANDLE message_sender;
     MESSAGE_SEND_STATE message_send_state;
     tickcounter_ms_t timeout;
+    ASYNC_OPERATION_HANDLE transfer_async_operation;
 } MESSAGE_WITH_CALLBACK;
 
 DEFINE_ASYNC_OPERATION_CONTEXT(MESSAGE_WITH_CALLBACK);
@@ -126,6 +127,7 @@ static void on_delivery_settled(void* context, delivery_number delivery_no, LINK
                 if (descriptor == NULL)
                 {
                     LogError("Error getting descriptor for delivery state");
+                    message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_ERROR, described);
                 }
                 else
                 {
@@ -137,9 +139,9 @@ static void on_delivery_settled(void* context, delivery_number delivery_no, LINK
                     {
                         message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_ERROR, described);
                     }
-
-                    remove_pending_message(message_sender, pending_send);
                 }
+
+                remove_pending_message(message_sender, pending_send);
             }
 
             break;
@@ -149,6 +151,10 @@ static void on_delivery_settled(void* context, delivery_number delivery_no, LINK
             break;
         case LINK_DELIVERY_SETTLE_REASON_TIMEOUT:
             message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_TIMEOUT, NULL);
+            remove_pending_message(message_sender, pending_send);
+            break;
+        case LINK_DELIVERY_SETTLE_REASON_CANCELLED:
+            message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_CANCELLED, NULL);
             remove_pending_message(message_sender, pending_send);
             break;
         case LINK_DELIVERY_SETTLE_REASON_NOT_DELIVERED:
@@ -186,6 +192,22 @@ static void log_message_chunk(MESSAGE_SENDER_INSTANCE* message_sender, const cha
         }
     }
 #endif
+}
+
+// Auxiliary function to verify if a given message is still in the pending messages queue.
+static bool is_message_in_queue(MESSAGE_SENDER_HANDLE message_sender, ASYNC_OPERATION_HANDLE message)
+{
+    bool result = false;
+
+    for (size_t i = 0; i < message_sender->message_count; i++)
+    {
+        if (message_sender->messages[i] == message)
+        {
+            result = true;
+        }
+    }
+
+    return result;
 }
 
 static SEND_ONE_MESSAGE_RESULT send_one_message(MESSAGE_SENDER_INSTANCE* message_sender, ASYNC_OPERATION_HANDLE pending_send, MESSAGE_HANDLE message)
@@ -554,6 +576,14 @@ static SEND_ONE_MESSAGE_RESULT send_one_message(MESSAGE_SENDER_INSTANCE* message
                     }
                     else
                     {
+                        // For messages that get atomically sent and settled by link_transfer_async,
+                        // on_delivery_settled is invoked and the message destroyed.
+                        // So at this point we shall verify if the message still exists and is in the queue.
+                        if (is_message_in_queue(message_sender, pending_send))
+                        {
+                            message_with_callback->transfer_async_operation = transfer_async_operation;
+                        }
+
                         result = SEND_ONE_MESSAGE_OK;
                     }
                 }
@@ -841,12 +871,19 @@ int messagesender_close(MESSAGE_SENDER_HANDLE message_sender)
 static void messagesender_send_cancel_handler(ASYNC_OPERATION_HANDLE send_operation)
 {
     MESSAGE_WITH_CALLBACK* message_with_callback = GET_ASYNC_OPERATION_CONTEXT(MESSAGE_WITH_CALLBACK, send_operation);
+    MESSAGE_SENDER_HANDLE messager_sender = message_with_callback->message_sender;
+
     if (message_with_callback->on_message_send_complete != NULL)
     {
         message_with_callback->on_message_send_complete(message_with_callback->context, MESSAGE_SEND_CANCELLED, NULL);
     }
 
-    remove_pending_message(message_with_callback->message_sender, send_operation);
+    if (message_with_callback->transfer_async_operation != NULL)
+    {
+        async_operation_cancel(message_with_callback->transfer_async_operation);
+    }
+
+    remove_pending_message(messager_sender, send_operation);
 }
 
 ASYNC_OPERATION_HANDLE messagesender_send_async(MESSAGE_SENDER_HANDLE message_sender, MESSAGE_HANDLE message, ON_MESSAGE_SEND_COMPLETE on_message_send_complete, void* callback_context, tickcounter_ms_t timeout)


### PR DESCRIPTION
For internal team use:
Fix has been verified against current and all previous fuzzing test dumps to guarantee no regressions:
id000000,sig06,src000026+001515,opsplice,rep2
id000000,sig06,src000036,time684207+000023,opsplice,rep4
id000000,sig06,src004958+005446,opsplice,rep8
id000000,sig06,src001600+002446,opsplice,rep2.bin (current one)