### PR TITLE
Rename data definition name to fix OACR unambiguous symbol

### DIFF
--- a/uamqp_generator/amqp_definitions.xml
+++ b/uamqp_generator/amqp_definitions.xml
@@ -246,7 +246,7 @@
     <type name="application-properties" class="restricted" source="map" provides="section">
       <descriptor name="amqp:application-properties:map" code="0x00000000:0x00000074"/>
     </type>
-    <type name="data" class="restricted" source="binary" provides="section">
+    <type name="amqp-data" class="restricted" source="binary" provides="section">
       <descriptor name="amqp:data:binary" code="0x00000000:0x00000075"/>
     </type>
     <type name="amqp-sequence" class="restricted" source="list" provides="section">


### PR DESCRIPTION
Hitting into OACR static analysis build issue on typedef for amqp_binary in https://github.com/Azure/azure-uamqp-c/blob/f7acb44aa8f61d9958ed2786831a53fd0a4a566e/inc/azure_uamqp_c/amqp_definitions_data.h

This PR tries to fix the same by renaming the type name.