### PR TITLE
Fixed race condition in sendAsync related to messages; fixed local_server_sample to no longer AV.

### DIFF
--- a/samples/local_server_sample/main.c
+++ b/samples/local_server_sample/main.c
@@ -18,117 +18,127 @@ static MESSAGE_RECEIVER_HANDLE message_receiver;
 
 static void on_message_receiver_state_changed(const void* context, MESSAGE_RECEIVER_STATE new_state, MESSAGE_RECEIVER_STATE previous_state)
 {
-    (void)context, new_state, previous_state;
+	(void)context, new_state, previous_state;
 }
 
 static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE message)
 {
-    (void)context;
-    (void)message;
+	(void)context;
+	(void)message;
 
-    printf("Message received.\r\n");
+	printf("Message received.\r\n");
 
-    return messaging_delivery_accepted();
+	return messaging_delivery_accepted();
 }
 
 static bool on_new_link_attached(void* context, LINK_ENDPOINT_HANDLE new_link_endpoint, const char* name, role role, AMQP_VALUE source, AMQP_VALUE target, fields properties)
 {
-    (void)context;
-    (void)properties;
-    link = link_create_from_endpoint(session, new_link_endpoint, name, role, source, target);
-    link_set_rcv_settle_mode(link, receiver_settle_mode_first);
-    message_receiver = messagereceiver_create(link, on_message_receiver_state_changed, NULL);
-    messagereceiver_open(message_receiver, on_message_received, NULL);
-    return true;
+	(void)context;
+	(void)properties;
+	link = link_create_from_endpoint(session, new_link_endpoint, name, role, source, target);
+	link_set_rcv_settle_mode(link, receiver_settle_mode_first);
+	message_receiver = messagereceiver_create(link, on_message_receiver_state_changed, NULL);
+	messagereceiver_open(message_receiver, on_message_received, NULL);
+//	messagereceiver_set_trace(message_receiver, true);
+	return true;
 }
 
 static bool on_new_session_endpoint(void* context, ENDPOINT_HANDLE new_endpoint)
 {
-    (void)context;
-    session = session_create_from_endpoint(connection, new_endpoint, on_new_link_attached, NULL);
-    session_set_incoming_window(session, 10000);
-    session_begin(session);
-    return true;
+	(void)context;
+	session = session_create_from_endpoint(connection, new_endpoint, on_new_link_attached, NULL);
+	session_set_incoming_window(session, 10000);
+	session_begin(session);
+	return true;
 }
 
 static void on_socket_accepted(void* context, const IO_INTERFACE_DESCRIPTION* interface_description, void* io_parameters)
 {
-    HEADER_DETECT_IO_CONFIG header_detect_io_config;
-    XIO_HANDLE underlying_io;
-    XIO_HANDLE header_detect_io;
+	HEADER_DETECT_IO_CONFIG header_detect_io_config;
+	HEADER_DETECT_ENTRY headerDetectEntries[] = {
+	{header_detect_io_get_amqp_header(), NULL} //,
+	//           {header_detect_io_get_sasl_amqp_header(), nullptr}
+	};
 
-    (void)context;
+	XIO_HANDLE underlying_io;
+	XIO_HANDLE header_detect_io;
 
-    underlying_io = xio_create(interface_description, io_parameters);
-    header_detect_io_config.underlying_io = underlying_io;
-    header_detect_io = xio_create(header_detect_io_get_interface_description(), &header_detect_io_config);
-    connection = connection_create(header_detect_io, NULL, "1", on_new_session_endpoint, NULL);
-    connection_listen(connection);
+	(void)context;
+
+	underlying_io = xio_create(interface_description, io_parameters);
+	header_detect_io_config.underlying_io = underlying_io;
+	header_detect_io_config.header_detect_entries = headerDetectEntries;
+	header_detect_io_config.header_detect_entry_count = sizeof(headerDetectEntries) / sizeof(HEADER_DETECT_ENTRY);
+
+	header_detect_io = xio_create(header_detect_io_get_interface_description(), &header_detect_io_config);
+	connection = connection_create(header_detect_io, NULL, "1", on_new_session_endpoint, NULL);
+	connection_listen(connection);
+//	connection_set_trace(connection, true);
 }
 
 int main(int argc, char** argv)
 {
-    int result;
+	int result;
 
-    (void)argc;
-    (void)argv;
+	(void)argc;
+	(void)argv;
 
-    if (platform_init() != 0)
-    {
-        result = -1;
-    }
-    else
-    {
-        size_t last_memory_used = 0;
-        SOCKET_LISTENER_HANDLE socket_listener;
+	if (platform_init() != 0)
+	{
+		result = -1;
+	}
+	else
+	{
+		size_t last_memory_used = 0;
+		SOCKET_LISTENER_HANDLE socket_listener;
 
-        gballoc_init();
+		gballoc_init();
 
-        socket_listener = socketlistener_create(5672);
-        if (socketlistener_start(socket_listener, on_socket_accepted, NULL) != 0)
-        {
-            result = -1;
-        }
-        else
-        {
-            bool keep_running = true;
-            while (keep_running)
-            {
-                size_t current_memory_used;
-                size_t maximum_memory_used;
-                socketlistener_dowork(socket_listener);
+		socket_listener = socketlistener_create(5672);
+		if (socketlistener_start(socket_listener, on_socket_accepted, NULL) != 0)
+		{
+			result = -1;
+		}
+		else
+		{
+			bool keep_running = true;
+			while (keep_running)
+			{
+				size_t current_memory_used;
+				size_t maximum_memory_used;
+				socketlistener_dowork(socket_listener);
 
-                current_memory_used = gballoc_getCurrentMemoryUsed();
-                maximum_memory_used = gballoc_getMaximumMemoryUsed();
+				current_memory_used = gballoc_getCurrentMemoryUsed();
+				maximum_memory_used = gballoc_getMaximumMemoryUsed();
 
-                if (current_memory_used != last_memory_used)
-                {
-                    printf("Current memory usage:%lu (max:%lu)\r\n", (unsigned long)current_memory_used, (unsigned long)maximum_memory_used);
-                    last_memory_used = current_memory_used;
-                }
+				if (current_memory_used != last_memory_used)
+				{
+					printf("Current memory usage:%lu (max:%lu)\r\n", (unsigned long)current_memory_used, (unsigned long)maximum_memory_used);
+					last_memory_used = current_memory_used;
+				}
 
-                if (sent_messages == msg_count)
-                {
-                    break;
-                }
+				if (sent_messages == msg_count)
+				{
+					break;
+				}
 
-                if (connection != NULL)
-                {
-                    connection_dowork(connection);
-                }
-            }
+				if (connection != NULL)
+				{
+					connection_dowork(connection);
+				}
+			}
 
-            result = 0;
-        }
+			result = 0;
+		}
 
-        socketlistener_destroy(socket_listener);
-        platform_deinit();
+		socketlistener_destroy(socket_listener);
+		platform_deinit();
 
-        printf("Max memory usage:%lu\r\n", (unsigned long)gballoc_getCurrentMemoryUsed());
-        printf("Current memory usage:%lu\r\n", (unsigned long)gballoc_getMaximumMemoryUsed());
+		printf("Max memory usage:%lu\r\n", (unsigned long)gballoc_getCurrentMemoryUsed());
+		printf("Current memory usage:%lu\r\n", (unsigned long)gballoc_getMaximumMemoryUsed());
 
-        gballoc_deinit();
-    }
+		gballoc_deinit();
+	}
 
-    return result;
+	return result;
 }

--- a/samples/local_server_sample/main.c
+++ b/samples/local_server_sample/main.c
@@ -18,127 +18,127 @@ static MESSAGE_RECEIVER_HANDLE message_receiver;
 
 static void on_message_receiver_state_changed(const void* context, MESSAGE_RECEIVER_STATE new_state, MESSAGE_RECEIVER_STATE previous_state)
 {
-	(void)context, new_state, previous_state;
+    (void)context, new_state, previous_state;
 }
 
 static AMQP_VALUE on_message_received(const void* context, MESSAGE_HANDLE message)
 {
-	(void)context;
-	(void)message;
+    (void)context;
+    (void)message;
 
-	printf("Message received.\r\n");
+    printf("Message received.\r\n");
 
-	return messaging_delivery_accepted();
+    return messaging_delivery_accepted();
 }
 
 static bool on_new_link_attached(void* context, LINK_ENDPOINT_HANDLE new_link_endpoint, const char* name, role role, AMQP_VALUE source, AMQP_VALUE target, fields properties)
 {
-	(void)context;
-	(void)properties;
-	link = link_create_from_endpoint(session, new_link_endpoint, name, role, source, target);
-	link_set_rcv_settle_mode(link, receiver_settle_mode_first);
-	message_receiver = messagereceiver_create(link, on_message_receiver_state_changed, NULL);
-	messagereceiver_open(message_receiver, on_message_received, NULL);
+    (void)context;
+    (void)properties;
+    link = link_create_from_endpoint(session, new_link_endpoint, name, role, source, target);
+    link_set_rcv_settle_mode(link, receiver_settle_mode_first);
+    message_receiver = messagereceiver_create(link, on_message_receiver_state_changed, NULL);
+    messagereceiver_open(message_receiver, on_message_received, NULL);
 //	messagereceiver_set_trace(message_receiver, true);
-	return true;
+    return true;
 }
 
 static bool on_new_session_endpoint(void* context, ENDPOINT_HANDLE new_endpoint)
 {
-	(void)context;
-	session = session_create_from_endpoint(connection, new_endpoint, on_new_link_attached, NULL);
-	session_set_incoming_window(session, 10000);
-	session_begin(session);
-	return true;
+    (void)context;
+    session = session_create_from_endpoint(connection, new_endpoint, on_new_link_attached, NULL);
+    session_set_incoming_window(session, 10000);
+    session_begin(session);
+    return true;
 }
 
 static void on_socket_accepted(void* context, const IO_INTERFACE_DESCRIPTION* interface_description, void* io_parameters)
 {
-	HEADER_DETECT_IO_CONFIG header_detect_io_config;
-	HEADER_DETECT_ENTRY headerDetectEntries[] = {
-	{header_detect_io_get_amqp_header(), NULL} //,
-	//           {header_detect_io_get_sasl_amqp_header(), nullptr}
-	};
+    HEADER_DETECT_IO_CONFIG header_detect_io_config;
+    HEADER_DETECT_ENTRY headerDetectEntries[] = {
+    {header_detect_io_get_amqp_header(), NULL} //,
+    //           {header_detect_io_get_sasl_amqp_header(), nullptr}
+    };
 
-	XIO_HANDLE underlying_io;
-	XIO_HANDLE header_detect_io;
+    XIO_HANDLE underlying_io;
+    XIO_HANDLE header_detect_io;
 
-	(void)context;
+    (void)context;
 
-	underlying_io = xio_create(interface_description, io_parameters);
-	header_detect_io_config.underlying_io = underlying_io;
-	header_detect_io_config.header_detect_entries = headerDetectEntries;
-	header_detect_io_config.header_detect_entry_count = sizeof(headerDetectEntries) / sizeof(HEADER_DETECT_ENTRY);
+    underlying_io = xio_create(interface_description, io_parameters);
+    header_detect_io_config.underlying_io = underlying_io;
+    header_detect_io_config.header_detect_entries = headerDetectEntries;
+    header_detect_io_config.header_detect_entry_count = sizeof(headerDetectEntries) / sizeof(HEADER_DETECT_ENTRY);
 
-	header_detect_io = xio_create(header_detect_io_get_interface_description(), &header_detect_io_config);
-	connection = connection_create(header_detect_io, NULL, "1", on_new_session_endpoint, NULL);
-	connection_listen(connection);
+    header_detect_io = xio_create(header_detect_io_get_interface_description(), &header_detect_io_config);
+    connection = connection_create(header_detect_io, NULL, "1", on_new_session_endpoint, NULL);
+    connection_listen(connection);
 //	connection_set_trace(connection, true);
 }
 
 int main(int argc, char** argv)
 {
-	int result;
+    int result;
 
-	(void)argc;
-	(void)argv;
+    (void)argc;
+    (void)argv;
 
-	if (platform_init() != 0)
-	{
-		result = -1;
-	}
-	else
-	{
-		size_t last_memory_used = 0;
-		SOCKET_LISTENER_HANDLE socket_listener;
+    if (platform_init() != 0)
+    {
+        result = -1;
+    }
+    else
+    {
+        size_t last_memory_used = 0;
+        SOCKET_LISTENER_HANDLE socket_listener;
 
-		gballoc_init();
+        gballoc_init();
 
-		socket_listener = socketlistener_create(5672);
-		if (socketlistener_start(socket_listener, on_socket_accepted, NULL) != 0)
-		{
-			result = -1;
-		}
-		else
-		{
-			bool keep_running = true;
-			while (keep_running)
-			{
-				size_t current_memory_used;
-				size_t maximum_memory_used;
-				socketlistener_dowork(socket_listener);
+        socket_listener = socketlistener_create(5672);
+        if (socketlistener_start(socket_listener, on_socket_accepted, NULL) != 0)
+        {
+            result = -1;
+        }
+        else
+        {
+            bool keep_running = true;
+            while (keep_running)
+            {
+                size_t current_memory_used;
+                size_t maximum_memory_used;
+                socketlistener_dowork(socket_listener);
 
-				current_memory_used = gballoc_getCurrentMemoryUsed();
-				maximum_memory_used = gballoc_getMaximumMemoryUsed();
+                current_memory_used = gballoc_getCurrentMemoryUsed();
+                maximum_memory_used = gballoc_getMaximumMemoryUsed();
 
-				if (current_memory_used != last_memory_used)
-				{
-					printf("Current memory usage:%lu (max:%lu)\r\n", (unsigned long)current_memory_used, (unsigned long)maximum_memory_used);
-					last_memory_used = current_memory_used;
-				}
+                if (current_memory_used != last_memory_used)
+                {
+                    printf("Current memory usage:%lu (max:%lu)\r\n", (unsigned long)current_memory_used, (unsigned long)maximum_memory_used);
+                    last_memory_used = current_memory_used;
+                }
 
-				if (sent_messages == msg_count)
-				{
-					break;
-				}
+                if (sent_messages == msg_count)
+                {
+                    break;
+                }
 
-				if (connection != NULL)
-				{
-					connection_dowork(connection);
-				}
-			}
+                if (connection != NULL)
+                {
+                    connection_dowork(connection);
+                }
+            }
 
-			result = 0;
-		}
+            result = 0;
+        }
 
-		socketlistener_destroy(socket_listener);
-		platform_deinit();
+        socketlistener_destroy(socket_listener);
+        platform_deinit();
 
-		printf("Max memory usage:%lu\r\n", (unsigned long)gballoc_getCurrentMemoryUsed());
-		printf("Current memory usage:%lu\r\n", (unsigned long)gballoc_getMaximumMemoryUsed());
+        printf("Max memory usage:%lu\r\n", (unsigned long)gballoc_getCurrentMemoryUsed());
+        printf("Current memory usage:%lu\r\n", (unsigned long)gballoc_getMaximumMemoryUsed());
 
-		gballoc_deinit();
-	}
+        gballoc_deinit();
+    }
 
-	return result;
+    return result;
 }

--- a/samples/local_server_sample/main.c
+++ b/samples/local_server_sample/main.c
@@ -39,7 +39,6 @@ static bool on_new_link_attached(void* context, LINK_ENDPOINT_HANDLE new_link_en
     link_set_rcv_settle_mode(link, receiver_settle_mode_first);
     message_receiver = messagereceiver_create(link, on_message_receiver_state_changed, NULL);
     messagereceiver_open(message_receiver, on_message_received, NULL);
-//	messagereceiver_set_trace(message_receiver, true);
     return true;
 }
 
@@ -73,7 +72,6 @@ static void on_socket_accepted(void* context, const IO_INTERFACE_DESCRIPTION* in
     header_detect_io = xio_create(header_detect_io_get_interface_description(), &header_detect_io_config);
     connection = connection_create(header_detect_io, NULL, "1", on_new_session_endpoint, NULL);
     connection_listen(connection);
-//	connection_set_trace(connection, true);
 }
 
 int main(int argc, char** argv)

--- a/src/message_sender.c
+++ b/src/message_sender.c
@@ -83,8 +83,9 @@ static void remove_pending_message_by_index(MESSAGE_SENDER_HANDLE message_sender
     }
     else
     {
-        free(message_sender->messages);
+        ASYNC_OPERATION_HANDLE *messages = message_sender->messages;
         message_sender->messages = NULL;
+        free(messages);
     }
 }
 
@@ -712,8 +713,9 @@ static void indicate_all_messages_as_error(MESSAGE_SENDER_INSTANCE* message_send
     {
         message_sender->message_count = 0;
 
-        free(message_sender->messages);
+        ASYNC_OPERATION_HANDLE *messages = message_sender->messages;
         message_sender->messages = NULL;
+        free(messages);
     }
 }
 


### PR DESCRIPTION
Fixes a race condition in `remove_pending_message_by_index`.

The existing code in remove_pending_message_by_index had:

```cpp
        free(message_sender->messages);
        message_sender->messages = NULL;
```

The problem is that if there was a context switch between the call to `free()` and before the `message_sender->messages` was set to NULL, then the call to reallocate the messages array in line 917:
```cpp
               ASYNC_OPERATION_HANDLE* new_messages = (ASYNC_OPERATION_HANDLE*)realloc(message_sender->messages, sizeof(ASYNC_OPERATION_HANDLE) * (message_sender->message_count + 1));
 
```
would reference freed memory and (if you were lucky) AV. If you weren't lucky, it corrupted memory.