### PR TITLE
Change the default link credit back to 10k

### DIFF
--- a/src/link.c
+++ b/src/link.c
@@ -18,7 +18,7 @@
 #include "azure_uamqp_c/amqp_frame_codec.h"
 #include "azure_uamqp_c/async_operation.h"
 
-#define DEFAULT_LINK_CREDIT 10
+#define DEFAULT_LINK_CREDIT 10000
 #define RECEIVER_MIN_LINK_CREDIT 1
 
 typedef struct DELIVERY_INSTANCE_TAG


### PR DESCRIPTION
The default link credit was accidentally changed to 10 in the recent LTS release tests.
Reverting back to the previous value of 10k