### PR TITLE
Apply allocation size limit to vbin32, str32, and sym32 decoders

### DIFF
--- a/src/amqpvalue.c
+++ b/src/amqpvalue.c
@@ -5949,7 +5949,7 @@ static int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder
                             else
                             {
                                 size_t malloc_size = (size_t)internal_decoder_data->decode_to_value->value.binary_value.length + 1;
-                                if (malloc_size == 0)
+                                if (malloc_size == 0 || malloc_size > MAX_AMQPVALUE_MALLOC_SIZE_BYTES)
                                 {
                                     internal_decoder_data->decode_to_value->value.binary_value.bytes = NULL;
                                     LogError("Invalid binary_value size exceeded max allocation");
@@ -6089,7 +6089,7 @@ static int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder
                             size_t malloc_size = (size_t)internal_decoder_data->decode_value_state.string_value_state.length + 1;
                             // If the result of malloc_size is zero it means it had a type overflow (size_t is an unsigned type).
                             // It is very unlikely but could happen.
-                            if (malloc_size == 0)
+                            if (malloc_size == 0 || malloc_size > MAX_AMQPVALUE_MALLOC_SIZE_BYTES)
                             {
                                 internal_decoder_data->decode_to_value->value.string_value.chars = NULL;
                                 LogError("Invalid string value size exceeded max allocation");
@@ -6242,7 +6242,7 @@ static int internal_decoder_decode_bytes(INTERNAL_DECODER_DATA* internal_decoder
                             size_t malloc_size = (size_t)internal_decoder_data->decode_value_state.symbol_value_state.length + 1;
                             // If the result of malloc_size is zero it means it had a type overflow (size_t is an unsigned type).
                             // It is very unlikely but could happen.
-                            if (malloc_size == 0)
+                            if (malloc_size == 0 || malloc_size > MAX_AMQPVALUE_MALLOC_SIZE_BYTES)
                             {
                                 internal_decoder_data->decode_to_value->value.symbol_value.chars = NULL;
                                 LogError("Invalid symbol value size exceeded max allocation");

--- a/tests/amqpvalue_ut/amqpvalue_ut.c
+++ b/tests/amqpvalue_ut/amqpvalue_ut.c
@@ -16604,4 +16604,92 @@ TEST_FUNCTION(amqpvalue_decode_bytes_with_descriptors_at_max_depth_succeeds)
     amqpvalue_decoder_destroy(amqpvalue_decoder);
 }
 
+/* Tests for vbin32 allocation size limit */
+TEST_FUNCTION(amqpvalue_decode_vbin32_with_size_exceeding_max_fails)
+{
+    // arrange
+    int result;
+    AMQPVALUE_DECODER_HANDLE amqpvalue_decoder = amqpvalue_decoder_create(value_decoded_callback, test_context);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(gballoc_calloc(IGNORED_ARG, IGNORED_ARG))
+        .IgnoreAllCalls();
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG))
+        .IgnoreAllCalls();
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG))
+        .IgnoreAllCalls();
+
+    // vbin32 encoding: constructor byte 0xB0, then 4 bytes of length (big-endian)
+    // MAX_AMQPVALUE_MALLOC_SIZE_BYTES is 100*1024*1024 = 104857600 = 0x06400000
+    // Use a length that exceeds this: 0x06400001 = 104857601
+    unsigned char bytes[] = { 0xB0, 0x06, 0x40, 0x00, 0x01 };
+
+    // act
+    result = amqpvalue_decode_bytes(amqpvalue_decoder, bytes, sizeof(bytes));
+
+    // assert
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+
+    // cleanup
+    amqpvalue_decoder_destroy(amqpvalue_decoder);
+}
+
+/* Tests for str32 allocation size limit */
+TEST_FUNCTION(amqpvalue_decode_str32_with_size_exceeding_max_fails)
+{
+    // arrange
+    int result;
+    AMQPVALUE_DECODER_HANDLE amqpvalue_decoder = amqpvalue_decoder_create(value_decoded_callback, test_context);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(gballoc_calloc(IGNORED_ARG, IGNORED_ARG))
+        .IgnoreAllCalls();
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG))
+        .IgnoreAllCalls();
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG))
+        .IgnoreAllCalls();
+
+    // str32 encoding: constructor byte 0xB1, then 4 bytes of length (big-endian)
+    // Use a length that exceeds MAX_AMQPVALUE_MALLOC_SIZE_BYTES: 0x06400001
+    unsigned char bytes[] = { 0xB1, 0x06, 0x40, 0x00, 0x01 };
+
+    // act
+    result = amqpvalue_decode_bytes(amqpvalue_decoder, bytes, sizeof(bytes));
+
+    // assert
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+
+    // cleanup
+    amqpvalue_decoder_destroy(amqpvalue_decoder);
+}
+
+/* Tests for sym32 allocation size limit */
+TEST_FUNCTION(amqpvalue_decode_sym32_with_size_exceeding_max_fails)
+{
+    // arrange
+    int result;
+    AMQPVALUE_DECODER_HANDLE amqpvalue_decoder = amqpvalue_decoder_create(value_decoded_callback, test_context);
+    umock_c_reset_all_calls();
+
+    STRICT_EXPECTED_CALL(gballoc_calloc(IGNORED_ARG, IGNORED_ARG))
+        .IgnoreAllCalls();
+    STRICT_EXPECTED_CALL(gballoc_malloc(IGNORED_ARG))
+        .IgnoreAllCalls();
+    STRICT_EXPECTED_CALL(gballoc_free(IGNORED_ARG))
+        .IgnoreAllCalls();
+
+    // sym32 encoding: constructor byte 0xB3, then 4 bytes of length (big-endian)
+    // Use a length that exceeds MAX_AMQPVALUE_MALLOC_SIZE_BYTES: 0x06400001
+    unsigned char bytes[] = { 0xB3, 0x06, 0x40, 0x00, 0x01 };
+
+    // act
+    result = amqpvalue_decode_bytes(amqpvalue_decoder, bytes, sizeof(bytes));
+
+    // assert
+    ASSERT_ARE_NOT_EQUAL(int, 0, result);
+
+    // cleanup
+    amqpvalue_decoder_destroy(amqpvalue_decoder);
+}
+
 END_TEST_SUITE(amqpvalue_ut)


### PR DESCRIPTION
## Summary
Extends the existing MAX_AMQPVALUE_MALLOC_SIZE_BYTES guard (100 MB, introduced for list32) to the vbin32 (0xB0), str32 (0xB1), and sym32 (0xB3) decode paths. Without this check, a crafted 4-byte length field can request an unbounded malloc on 64-bit platforms where the existing overflow-to-zero check is ineffective.

## Changes
- `src/amqpvalue.c`: Added `|| malloc_size > MAX_AMQPVALUE_MALLOC_SIZE_BYTES` to the allocation guard in each of the three 32-bit variable-width type decoders.
- `tests/amqpvalue_ut/amqpvalue_ut.c`: Added 3 unit tests verifying that declared lengths exceeding 100 MB are rejected for vbin32, str32, and sym32.

## Testing
- All existing and new unit tests pass in Ubuntu 24.04 container.