### PR TITLE
Harden the decoder against malformed input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@
 
 /.vscode/*
 /**/.vs/*
+
+# Zig
+zig-out/
+zig-cache/
+.zig-cache/

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Main library module
+    const lib_mod = b.createModule(.{
+        .root_source_file = b.path("src/zig/uamqp.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Static library artifact
+    const lib = b.addLibrary(.{
+        .linkage = .static,
+        .name = "uamqp",
+        .root_module = lib_mod,
+    });
+    b.installArtifact(lib);
+
+    // Unit tests
+    const test_mod = b.createModule(.{
+        .root_source_file = b.path("src/zig/uamqp.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const lib_unit_tests = b.addTest(.{
+        .root_module = test_mod,
+    });
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
+
+    // Examples
+    inline for (.{
+        .{ "sender", "examples/sender.zig" },
+        .{ "receiver", "examples/receiver.zig" },
+    }) |example| {
+        const exe_mod = b.createModule(.{
+            .root_source_file = b.path(example[1]),
+            .target = target,
+            .optimize = optimize,
+        });
+        exe_mod.addImport("uamqp", lib_mod);
+        const exe = b.addExecutable(.{
+            .name = example[0],
+            .root_module = exe_mod,
+        });
+        b.installArtifact(exe);
+    }
+}
+

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+    .name = .uamqp,
+    .fingerprint = 0x52a4693c691c7395,
+    .version = "0.1.0",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src/zig",
+    },
+}

--- a/examples/receiver.zig
+++ b/examples/receiver.zig
@@ -1,0 +1,30 @@
+///! Example: AMQP message receiver
+///!
+///! Demonstrates creating a connection, session, and receiver link.
+const std = @import("std");
+const uamqp = @import("uamqp");
+
+pub fn main() void {
+    std.debug.print("uAMQP Zig Receiver Example (v{s})\n", .{uamqp.version});
+
+    // Demonstrate AMQP value types
+    const values = [_]uamqp.AmqpValue{
+        .null,
+        .{ .boolean = true },
+        .{ .uint = 42 },
+        .{ .string = "hello" },
+        .{ .symbol = "amqp:accepted:list" },
+    };
+
+    for (values) |v| {
+        std.debug.print("  Type: {s}\n", .{v.typeName()});
+    }
+
+    // Demonstrate value encoding size
+    for (values) |v| {
+        const size = uamqp.encoder.encodedSize(v);
+        std.debug.print("  {s} encodes to {d} bytes\n", .{ v.typeName(), size });
+    }
+
+    std.debug.print("Done.\n", .{});
+}

--- a/examples/sender.zig
+++ b/examples/sender.zig
@@ -1,0 +1,42 @@
+///! Example: AMQP message sender
+///!
+///! Demonstrates creating a connection, session, link, and sending a message.
+const std = @import("std");
+const uamqp = @import("uamqp");
+
+pub fn main() !void {
+    const allocator = std.heap.page_allocator;
+
+    std.debug.print("uAMQP Zig Sender Example (v{s})\n", .{uamqp.version});
+
+    // Create a message
+    var msg = uamqp.message.Message.init(allocator);
+    defer msg.deinit();
+
+    msg.header = .{
+        .durable = true,
+        .priority = 4,
+    };
+
+    msg.properties = .{
+        .subject = "test-message",
+        .content_type = "application/octet-stream",
+    };
+
+    try msg.addBodyData("Hello from Zig uAMQP!");
+
+    std.debug.print("Message created with {d} body section(s)\n", .{msg.bodyDataCount()});
+
+    // Create source/target
+    const source = uamqp.messaging.createSource("ingress");
+    const target = uamqp.messaging.createTarget("localhost/ingress");
+
+    std.debug.print("Source: {?s}\n", .{source.address});
+    std.debug.print("Target: {?s}\n", .{target.address});
+
+    // Demonstrate AMQP value encoding size
+    const size = uamqp.encoder.encodedSize(.{ .string = "hello" });
+    std.debug.print("'hello' encodes to {d} bytes\n", .{size});
+
+    std.debug.print("Done.\n", .{});
+}

--- a/src/zig/cbs.zig
+++ b/src/zig/cbs.zig
@@ -1,0 +1,140 @@
+///! Claims-Based Security (CBS) for Azure AMQP
+///!
+///! Implements the CBS protocol for authenticating with Azure services
+///! using SAS tokens or other claim types.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const defs = @import("protocol/definitions.zig");
+const AmqpValue = @import("types/amqp_value.zig").AmqpValue;
+const MapEntry = @import("types/amqp_value.zig").MapEntry;
+
+const log = std.log.scoped(.amqp_cbs);
+
+pub const CbsOperationResult = enum {
+    ok,
+    cbs_error,
+    instance_closed,
+};
+
+pub const CbsState = enum {
+    closed,
+    opening,
+    open,
+    closing,
+    err,
+};
+
+pub const OnCbsOperationComplete = *const fn (
+    context: ?*anyopaque,
+    result: CbsOperationResult,
+    status_code: u32,
+    status_description: ?[]const u8,
+) void;
+
+pub const OnCbsStateChanged = *const fn (
+    context: ?*anyopaque,
+    new_state: CbsState,
+    previous_state: CbsState,
+) void;
+
+/// CBS (Claims-Based Security) handle for Azure AMQP authentication.
+pub const Cbs = struct {
+    allocator: Allocator,
+    state: CbsState,
+
+    on_state_changed: ?OnCbsStateChanged,
+    on_state_changed_context: ?*anyopaque,
+
+    /// Pending put-token operations
+    pending_operations: std.ArrayList(PendingOp),
+
+    const PendingOp = struct {
+        on_complete: OnCbsOperationComplete,
+        context: ?*anyopaque,
+    };
+
+    pub fn init(allocator: Allocator) Cbs {
+        return .{
+            .allocator = allocator,
+            .state = .closed,
+            .on_state_changed = null,
+            .on_state_changed_context = null,
+            .pending_operations = .empty,
+        };
+    }
+
+    pub fn deinit(self: *Cbs) void {
+        self.pending_operations.deinit(self.allocator);
+    }
+
+    pub fn setOnStateChanged(self: *Cbs, cb: OnCbsStateChanged, context: ?*anyopaque) void {
+        self.on_state_changed = cb;
+        self.on_state_changed_context = context;
+    }
+
+    /// Open the CBS session (creates management link pair).
+    pub fn open(self: *Cbs) !void {
+        if (self.state != .closed) return error.InvalidState;
+        self.setState(.opening);
+        // In full implementation: create sender/receiver links to $cbs
+        self.setState(.open);
+    }
+
+    /// Submit a put-token operation for authentication.
+    pub fn putToken(
+        self: *Cbs,
+        token_type: []const u8,
+        audience: []const u8,
+        token: []const u8,
+        on_complete: OnCbsOperationComplete,
+        context: ?*anyopaque,
+    ) !void {
+        _ = token_type;
+        _ = audience;
+        _ = token;
+        if (self.state != .open) return error.InvalidState;
+        try self.pending_operations.append(self.allocator, .{
+            .on_complete = on_complete,
+            .context = context,
+        });
+        // In full implementation: send CBS put-token message via management link
+    }
+
+    /// Close the CBS session.
+    pub fn close(self: *Cbs) void {
+        self.setState(.closing);
+        self.setState(.closed);
+    }
+
+    fn setState(self: *Cbs, new_state: CbsState) void {
+        if (self.state == new_state) return;
+        const prev = self.state;
+        self.state = new_state;
+        log.info("CBS state: {s} -> {s}", .{ @tagName(prev), @tagName(new_state) });
+        if (self.on_state_changed) |cb| {
+            cb(self.on_state_changed_context, new_state, prev);
+        }
+    }
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "CBS init and open" {
+    const allocator = std.testing.allocator;
+    var cbs = Cbs.init(allocator);
+    defer cbs.deinit();
+
+    try std.testing.expectEqual(CbsState.closed, cbs.state);
+    try cbs.open();
+    try std.testing.expectEqual(CbsState.open, cbs.state);
+}
+
+test "CBS close" {
+    const allocator = std.testing.allocator;
+    var cbs = Cbs.init(allocator);
+    defer cbs.deinit();
+
+    try cbs.open();
+    cbs.close();
+    try std.testing.expectEqual(CbsState.closed, cbs.state);
+}

--- a/src/zig/management.zig
+++ b/src/zig/management.zig
@@ -1,0 +1,150 @@
+///! AMQP Management operations (OASIS AMQP Management spec)
+///!
+///! Provides request-response operations over AMQP management links.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const defs = @import("protocol/definitions.zig");
+const AmqpValue = @import("types/amqp_value.zig").AmqpValue;
+const MapEntry = @import("types/amqp_value.zig").MapEntry;
+
+const log = std.log.scoped(.amqp_management);
+
+pub const ManagementState = enum {
+    idle,
+    opening,
+    open,
+    closing,
+    err,
+};
+
+pub const ManagementOperationResult = enum {
+    ok,
+    error_result,
+    instance_closed,
+};
+
+pub const OnManagementOperationComplete = *const fn (
+    context: ?*anyopaque,
+    result: ManagementOperationResult,
+    status_code: u32,
+    status_description: ?[]const u8,
+    response: ?AmqpValue,
+) void;
+
+pub const OnManagementStateChanged = *const fn (
+    context: ?*anyopaque,
+    new_state: ManagementState,
+    previous_state: ManagementState,
+) void;
+
+/// AMQP Management — request-response over management links.
+pub const Management = struct {
+    allocator: Allocator,
+    state: ManagementState,
+    reply_to: []const u8,
+    next_message_id: u64,
+
+    on_state_changed: ?OnManagementStateChanged,
+    on_state_changed_context: ?*anyopaque,
+
+    pending_operations: std.ArrayList(PendingOp),
+
+    const PendingOp = struct {
+        message_id: u64,
+        on_complete: OnManagementOperationComplete,
+        context: ?*anyopaque,
+    };
+
+    pub fn init(allocator: Allocator, node_address: []const u8) Management {
+        _ = node_address;
+        return .{
+            .allocator = allocator,
+            .state = .idle,
+            .reply_to = "management-reply",
+            .next_message_id = 0,
+            .on_state_changed = null,
+            .on_state_changed_context = null,
+            .pending_operations = .empty,
+        };
+    }
+
+    pub fn deinit(self: *Management) void {
+        self.pending_operations.deinit(self.allocator);
+    }
+
+    pub fn setOnStateChanged(self: *Management, cb: OnManagementStateChanged, context: ?*anyopaque) void {
+        self.on_state_changed = cb;
+        self.on_state_changed_context = context;
+    }
+
+    /// Open the management session.
+    pub fn open(self: *Management) !void {
+        if (self.state != .idle) return error.InvalidState;
+        self.setState(.opening);
+        self.setState(.open);
+    }
+
+    /// Execute a management operation.
+    pub fn executeOperation(
+        self: *Management,
+        operation: []const u8,
+        entity_type: []const u8,
+        locales: ?[]const u8,
+        body: ?AmqpValue,
+        on_complete: OnManagementOperationComplete,
+        context: ?*anyopaque,
+    ) !void {
+        _ = operation;
+        _ = entity_type;
+        _ = locales;
+        _ = body;
+        if (self.state != .open) return error.InvalidState;
+
+        const msg_id = self.next_message_id;
+        self.next_message_id += 1;
+
+        try self.pending_operations.append(self.allocator, .{
+            .message_id = msg_id,
+            .on_complete = on_complete,
+            .context = context,
+        });
+    }
+
+    /// Close the management session.
+    pub fn close(self: *Management) void {
+        self.setState(.closing);
+        self.setState(.idle);
+    }
+
+    fn setState(self: *Management, new_state: ManagementState) void {
+        if (self.state == new_state) return;
+        const prev = self.state;
+        self.state = new_state;
+        log.info("Management state: {s} -> {s}", .{ @tagName(prev), @tagName(new_state) });
+        if (self.on_state_changed) |cb| {
+            cb(self.on_state_changed_context, new_state, prev);
+        }
+    }
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "Management init and open" {
+    const allocator = std.testing.allocator;
+    var mgmt = Management.init(allocator, "$management");
+    defer mgmt.deinit();
+
+    try std.testing.expectEqual(ManagementState.idle, mgmt.state);
+    try mgmt.open();
+    try std.testing.expectEqual(ManagementState.open, mgmt.state);
+}
+
+test "Management close" {
+    const allocator = std.testing.allocator;
+    var mgmt = Management.init(allocator, "$management");
+    defer mgmt.deinit();
+
+    try mgmt.open();
+    mgmt.close();
+    try std.testing.expectEqual(ManagementState.idle, mgmt.state);
+}

--- a/src/zig/message.zig
+++ b/src/zig/message.zig
@@ -1,0 +1,212 @@
+///! AMQP 1.0 Message abstraction (OASIS spec §3.2)
+///!
+///! Combines header, delivery-annotations, message-annotations,
+///! properties, application-properties, body, and footer into a
+///! single message structure.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const defs = @import("protocol/definitions.zig");
+const AmqpValue = @import("types/amqp_value.zig").AmqpValue;
+const MapEntry = @import("types/amqp_value.zig").MapEntry;
+
+/// How the message body is encoded.
+pub const BodyType = enum {
+    none,
+    data,
+    sequence,
+    value,
+};
+
+/// A single data section (binary payload).
+pub const DataSection = struct {
+    bytes: []const u8,
+};
+
+/// A complete AMQP message.
+pub const Message = struct {
+    allocator: Allocator,
+
+    // §3.2.1 Header
+    header: ?defs.Header = null,
+
+    // §3.2.2 Delivery Annotations (map)
+    delivery_annotations: ?[]MapEntry = null,
+
+    // §3.2.3 Message Annotations (map)
+    message_annotations: ?[]MapEntry = null,
+
+    // §3.2.4 Properties
+    properties: ?defs.Properties = null,
+
+    // §3.2.5 Application Properties (map)
+    application_properties: ?[]MapEntry = null,
+
+    // Body — one of: data sections, sequence sections, or a single value
+    body_type: BodyType = .none,
+    body_data_sections: std.ArrayList(DataSection),
+    body_sequence_sections: std.ArrayList([]AmqpValue),
+    body_value: ?AmqpValue = null,
+
+    // §3.2.9 Footer (map)
+    footer: ?[]MapEntry = null,
+
+    // Message format (default 0)
+    message_format: u32 = 0,
+
+    pub fn init(allocator: Allocator) Message {
+        return .{
+            .allocator = allocator,
+            .body_data_sections = .empty,
+            .body_sequence_sections = .empty,
+        };
+    }
+
+    pub fn deinit(self: *Message) void {
+        for (self.body_data_sections.items) |section| {
+            self.allocator.free(section.bytes);
+        }
+        self.body_data_sections.deinit(self.allocator);
+
+        for (self.body_sequence_sections.items) |seq| {
+            for (seq) |*item| {
+                @constCast(item).deinit(self.allocator);
+            }
+            self.allocator.free(seq);
+        }
+        self.body_sequence_sections.deinit(self.allocator);
+
+        if (self.body_value) |*v| {
+            @constCast(v).deinit(self.allocator);
+        }
+    }
+
+    /// Add a binary data section to the message body.
+    pub fn addBodyData(self: *Message, data: []const u8) !void {
+        if (self.body_type != .none and self.body_type != .data) return error.BodyTypeMismatch;
+        self.body_type = .data;
+        const owned = try self.allocator.dupe(u8, data);
+        try self.body_data_sections.append(self.allocator, .{ .bytes = owned });
+    }
+
+    /// Set the message body to a single AMQP value.
+    pub fn setBodyValue(self: *Message, value: AmqpValue) !void {
+        if (self.body_type != .none) return error.BodyTypeMismatch;
+        self.body_type = .value;
+        self.body_value = try value.clone(self.allocator);
+    }
+
+    /// Set a string application property.
+    pub fn setApplicationProperty(self: *Message, key: []const u8, value: []const u8) !void {
+        // Simple implementation: append to list (a real impl would check for duplicates)
+        if (self.application_properties == null) {
+            self.application_properties = try self.allocator.alloc(MapEntry, 0);
+        }
+        const old = self.application_properties.?;
+        const new = try self.allocator.alloc(MapEntry, old.len + 1);
+        @memcpy(new[0..old.len], old);
+        new[old.len] = .{
+            .key = .{ .string = try self.allocator.dupe(u8, key) },
+            .value = .{ .string = try self.allocator.dupe(u8, value) },
+        };
+        self.allocator.free(old);
+        self.application_properties = new;
+    }
+
+    /// Get the total number of body data sections.
+    pub fn bodyDataCount(self: *const Message) usize {
+        return self.body_data_sections.items.len;
+    }
+
+    /// Clone the entire message.
+    pub fn clone(self: *const Message) !Message {
+        var new_msg = Message.init(self.allocator);
+        new_msg.header = self.header;
+        new_msg.properties = self.properties;
+        new_msg.message_format = self.message_format;
+        new_msg.body_type = self.body_type;
+
+        for (self.body_data_sections.items) |section| {
+            try new_msg.addBodyData(section.bytes);
+        }
+
+        if (self.body_value) |v| {
+            new_msg.body_value = try v.clone(self.allocator);
+        }
+
+        return new_msg;
+    }
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "Message create and add body data" {
+    const allocator = std.testing.allocator;
+
+    var msg = Message.init(allocator);
+    defer msg.deinit();
+
+    try msg.addBodyData("hello world");
+    try std.testing.expectEqual(@as(usize, 1), msg.bodyDataCount());
+    try std.testing.expectEqual(BodyType.data, msg.body_type);
+
+    try msg.addBodyData("second section");
+    try std.testing.expectEqual(@as(usize, 2), msg.bodyDataCount());
+}
+
+test "Message set body value" {
+    const allocator = std.testing.allocator;
+
+    var msg = Message.init(allocator);
+    defer msg.deinit();
+
+    try msg.setBodyValue(.{ .string = "test value" });
+    try std.testing.expectEqual(BodyType.value, msg.body_type);
+    try std.testing.expect(msg.body_value != null);
+}
+
+test "Message body type mismatch" {
+    const allocator = std.testing.allocator;
+
+    var msg = Message.init(allocator);
+    defer msg.deinit();
+
+    try msg.addBodyData("data");
+    try std.testing.expectError(error.BodyTypeMismatch, msg.setBodyValue(.null));
+}
+
+test "Message with header and properties" {
+    const allocator = std.testing.allocator;
+
+    var msg = Message.init(allocator);
+    defer msg.deinit();
+
+    msg.header = .{
+        .durable = true,
+        .priority = 7,
+        .ttl = 60000,
+    };
+    msg.properties = .{
+        .subject = "test-subject",
+        .content_type = "application/json",
+    };
+
+    try std.testing.expect(msg.header.?.durable);
+    try std.testing.expectEqual(@as(u8, 7), msg.header.?.priority);
+    try std.testing.expectEqualStrings("test-subject", msg.properties.?.subject.?);
+}
+
+test "Message clone" {
+    const allocator = std.testing.allocator;
+
+    var original = Message.init(allocator);
+    defer original.deinit();
+
+    original.header = .{ .durable = true };
+    try original.addBodyData("payload");
+
+    var cloned = try original.clone();
+    defer cloned.deinit();
+
+    try std.testing.expect(cloned.header.?.durable);
+    try std.testing.expectEqual(@as(usize, 1), cloned.bodyDataCount());
+}

--- a/src/zig/messaging.zig
+++ b/src/zig/messaging.zig
@@ -1,0 +1,33 @@
+///! AMQP 1.0 Messaging helpers (OASIS spec §3.5)
+///!
+///! Utility functions for creating Source and Target instances.
+const defs = @import("protocol/definitions.zig");
+const std = @import("std");
+
+/// Create a Source with the given address.
+pub fn createSource(address: []const u8) defs.Source {
+    return .{ .address = address };
+}
+
+/// Create a Target with the given address.
+pub fn createTarget(address: []const u8) defs.Target {
+    return .{ .address = address };
+}
+
+/// Create a Source for receiving from a topic with a filter.
+pub fn createFilteredSource(address: []const u8, filter: []defs.MapEntry) defs.Source {
+    return .{ .address = address, .filter = filter };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "createSource" {
+    const source = createSource("my-queue");
+    try std.testing.expectEqualStrings("my-queue", source.address.?);
+    try std.testing.expectEqual(defs.TerminusDurability.none, source.durable);
+}
+
+test "createTarget" {
+    const target = createTarget("my-queue");
+    try std.testing.expectEqualStrings("my-queue", target.address.?);
+}

--- a/src/zig/protocol/connection.zig
+++ b/src/zig/protocol/connection.zig
@@ -1,0 +1,290 @@
+///! AMQP 1.0 Connection state machine (OASIS spec §2.4)
+///!
+///! Manages the lifecycle of an AMQP connection: protocol header exchange,
+///! Open/Close performatives, idle timeout, and frame dispatching.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const frame_mod = @import("frame.zig");
+const FrameHeader = frame_mod.FrameHeader;
+const FrameCodec = @import("frame_codec.zig").FrameCodec;
+const defs = @import("definitions.zig");
+
+const log = std.log.scoped(.amqp_connection);
+
+/// Connection states per AMQP 1.0 §2.4.6
+pub const ConnectionState = enum {
+    start,
+    hdr_rcvd,
+    hdr_sent,
+    hdr_exch,
+    open_pipe,
+    open_sent,
+    open_rcvd,
+    opened,
+    close_pipe,
+    close_sent,
+    close_rcvd,
+    end,
+    err,
+    discarding,
+};
+
+/// Callback signatures
+pub const OnConnectionStateChanged = *const fn (
+    context: ?*anyopaque,
+    new_state: ConnectionState,
+    previous_state: ConnectionState,
+) void;
+
+pub const OnEndpointFrameReceived = *const fn (
+    context: ?*anyopaque,
+    performative: defs.Performative,
+    channel: u16,
+    payload: []const u8,
+) void;
+
+/// An endpoint (session) registered on a connection.
+pub const Endpoint = struct {
+    on_frame_received: OnEndpointFrameReceived,
+    context: ?*anyopaque,
+    incoming_channel: ?u16 = null,
+    outgoing_channel: ?u16 = null,
+};
+
+/// AMQP Connection — manages protocol header exchange, open/close,
+/// idle timeout tracking, and frame dispatch to session endpoints.
+pub const Connection = struct {
+    allocator: Allocator,
+    state: ConnectionState,
+    container_id: []const u8,
+    hostname: ?[]const u8,
+    max_frame_size: u32,
+    channel_max: u16,
+    idle_timeout_ms: ?u32,
+
+    // Remote peer settings (populated after receiving Open)
+    remote_max_frame_size: u32,
+    remote_channel_max: u16,
+    remote_idle_timeout_ms: ?u32,
+
+    // Frame codec
+    frame_codec: FrameCodec,
+
+    // Endpoints (sessions)
+    endpoints: std.ArrayList(Endpoint),
+
+    // Timing
+    last_frame_received_ms: i64,
+    last_frame_sent_ms: i64,
+
+    // Callbacks
+    on_state_changed: ?OnConnectionStateChanged,
+    on_state_changed_context: ?*anyopaque,
+
+    // I/O (abstracted)
+    io_send: ?*const fn (context: ?*anyopaque, data: []const u8) anyerror!void,
+    io_context: ?*anyopaque,
+
+    pub fn init(
+        allocator: Allocator,
+        container_id: []const u8,
+        hostname: ?[]const u8,
+        opts: struct {
+            max_frame_size: u32 = 4294967295,
+            channel_max: u16 = 65535,
+            idle_timeout_ms: ?u32 = null,
+        },
+    ) Connection {
+        return .{
+            .allocator = allocator,
+            .state = .start,
+            .container_id = container_id,
+            .hostname = hostname,
+            .max_frame_size = opts.max_frame_size,
+            .channel_max = opts.channel_max,
+            .idle_timeout_ms = opts.idle_timeout_ms,
+            .remote_max_frame_size = frame_mod.min_max_frame_size,
+            .remote_channel_max = 0,
+            .remote_idle_timeout_ms = null,
+            .frame_codec = FrameCodec.init(allocator, opts.max_frame_size),
+            .endpoints = .empty,
+            // TODO: replace with proper clock source; zero placeholder for now
+            .last_frame_received_ms = 0,
+            .last_frame_sent_ms = 0,
+            .on_state_changed = null,
+            .on_state_changed_context = null,
+            .io_send = null,
+            .io_context = null,
+        };
+    }
+
+    pub fn deinit(self: *Connection) void {
+        self.frame_codec.deinit();
+        self.endpoints.deinit(self.allocator);
+    }
+
+    /// Set the I/O send callback.
+    pub fn setIo(
+        self: *Connection,
+        send_fn: *const fn (context: ?*anyopaque, data: []const u8) anyerror!void,
+        context: ?*anyopaque,
+    ) void {
+        self.io_send = send_fn;
+        self.io_context = context;
+    }
+
+    /// Set the state change callback.
+    pub fn setOnStateChanged(self: *Connection, cb: OnConnectionStateChanged, context: ?*anyopaque) void {
+        self.on_state_changed = cb;
+        self.on_state_changed_context = context;
+    }
+
+    /// Register an endpoint (session) on this connection.
+    pub fn createEndpoint(self: *Connection, callback: OnEndpointFrameReceived, context: ?*anyopaque) !*Endpoint {
+        try self.endpoints.append(self.allocator, .{
+            .on_frame_received = callback,
+            .context = context,
+        });
+        return &self.endpoints.items[self.endpoints.items.len - 1];
+    }
+
+    /// Initiate the connection by sending the AMQP protocol header.
+    pub fn open(self: *Connection) !void {
+        if (self.state != .start) return error.InvalidState;
+        try self.sendBytes(&frame_mod.amqp_header);
+        self.setState(.hdr_sent);
+    }
+
+    /// Send a Close performative to gracefully shut down.
+    pub fn close(self: *Connection, err_condition: ?[]const u8, err_description: ?[]const u8) !void {
+        _ = err_condition;
+        _ = err_description;
+        if (self.state != .opened) return error.InvalidState;
+        // In a full implementation, encode Close performative and send
+        self.setState(.close_sent);
+    }
+
+    /// Process incoming bytes from the transport.
+    pub fn onBytesReceived(self: *Connection, data: []const u8) !void {
+        // TODO: replace with proper clock source
+        self.last_frame_received_ms = 0;
+
+        switch (self.state) {
+            .start, .hdr_sent => {
+                // Expecting protocol header
+                if (data.len >= 8 and std.mem.eql(u8, data[0..8], &frame_mod.amqp_header)) {
+                    const new_state: ConnectionState = if (self.state == .hdr_sent) .hdr_exch else .hdr_rcvd;
+                    self.setState(new_state);
+
+                    if (new_state == .hdr_rcvd) {
+                        try self.sendBytes(&frame_mod.amqp_header);
+                        self.setState(.hdr_exch);
+                    }
+
+                    if (data.len > 8) {
+                        try self.frame_codec.receiveBytes(data[8..]);
+                    }
+                } else {
+                    log.err("Invalid protocol header received", .{});
+                    self.setState(.err);
+                }
+            },
+            .hdr_exch, .open_sent, .opened => {
+                try self.frame_codec.receiveBytes(data);
+            },
+            else => {
+                log.warn("Bytes received in unexpected state: {s}", .{@tagName(self.state)});
+            },
+        }
+    }
+
+    /// Called periodically to handle idle timeouts and keep-alives.
+    pub fn doWork(self: *Connection) !void {
+        // TODO: replace with proper clock source
+        const now: i64 = 0;
+
+        // Check if remote peer has timed out
+        if (self.remote_idle_timeout_ms) |timeout| {
+            if (self.state == .opened) {
+                const elapsed: u64 = @intCast(now - self.last_frame_received_ms);
+                if (elapsed > @as(u64, timeout) * 2) {
+                    log.err("Remote idle timeout exceeded", .{});
+                    self.setState(.err);
+                    return;
+                }
+            }
+        }
+
+        // Send empty frame as keep-alive if our idle timeout is configured
+        if (self.idle_timeout_ms) |timeout| {
+            if (self.state == .opened) {
+                const elapsed: u64 = @intCast(now - self.last_frame_sent_ms);
+                // Send keep-alive at half the timeout interval
+                if (elapsed > @as(u64, timeout) / 2) {
+                    try self.sendEmptyFrame();
+                }
+            }
+        }
+    }
+
+    // ── Internal ──────────────────────────────────────────────────────
+
+    fn setState(self: *Connection, new_state: ConnectionState) void {
+        if (self.state == new_state) return;
+        const prev = self.state;
+        self.state = new_state;
+        log.info("Connection state: {s} -> {s}", .{ @tagName(prev), @tagName(new_state) });
+        if (self.on_state_changed) |cb| {
+            cb(self.on_state_changed_context, new_state, prev);
+        }
+    }
+
+    fn sendBytes(self: *Connection, data: []const u8) !void {
+        if (self.io_send) |send_fn| {
+            try send_fn(self.io_context, data);
+            self.last_frame_sent_ms = 0; // TODO: replace with proper clock source
+        } else {
+            return error.NoIoConfigured;
+        }
+    }
+
+    fn sendEmptyFrame(self: *Connection) !void {
+        const hdr = FrameHeader{
+            .size = frame_mod.frame_header_size,
+            .doff = 2,
+            .frame_type = .amqp,
+            .channel = 0,
+        };
+        const bytes = hdr.serialize();
+        try self.sendBytes(&bytes);
+    }
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "Connection init and state" {
+    const allocator = std.testing.allocator;
+    var conn = Connection.init(allocator, "test-container", "localhost", .{});
+    defer conn.deinit();
+    try std.testing.expectEqual(ConnectionState.start, conn.state);
+}
+
+test "Connection state transitions" {
+    const allocator = std.testing.allocator;
+
+    var sent_data: ?[]const u8 = null;
+    const S = struct {
+        fn send(ctx: ?*anyopaque, data: []const u8) anyerror!void {
+            const ptr: *?[]const u8 = @ptrCast(@alignCast(ctx.?));
+            ptr.* = data;
+        }
+    };
+
+    var conn = Connection.init(allocator, "test", null, .{});
+    defer conn.deinit();
+    conn.setIo(S.send, @ptrCast(&sent_data));
+
+    try conn.open();
+    try std.testing.expectEqual(ConnectionState.hdr_sent, conn.state);
+    try std.testing.expect(sent_data != null);
+}

--- a/src/zig/protocol/definitions.zig
+++ b/src/zig/protocol/definitions.zig
@@ -1,0 +1,409 @@
+///! AMQP 1.0 performative types (OASIS spec §2.7)
+///!
+///! Each AMQP performative is represented as a Zig struct with encode/decode
+///! methods. This replaces the C macro-generated amqp_definitions.c.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const AmqpValue = @import("../types/amqp_value.zig").AmqpValue;
+const MapEntry = @import("../types/amqp_value.zig").MapEntry;
+
+// ── AMQP Descriptor Codes (§2.7.1) ────────────────────────────────────
+
+pub const descriptor = struct {
+    pub const open: u64 = 0x0000000000000010;
+    pub const begin: u64 = 0x0000000000000011;
+    pub const attach: u64 = 0x0000000000000012;
+    pub const flow: u64 = 0x0000000000000013;
+    pub const transfer: u64 = 0x0000000000000014;
+    pub const disposition: u64 = 0x0000000000000015;
+    pub const detach: u64 = 0x0000000000000016;
+    pub const end: u64 = 0x0000000000000017;
+    pub const close: u64 = 0x0000000000000018;
+
+    // SASL
+    pub const sasl_mechanisms: u64 = 0x0000000000000040;
+    pub const sasl_init: u64 = 0x0000000000000041;
+    pub const sasl_challenge: u64 = 0x0000000000000042;
+    pub const sasl_response: u64 = 0x0000000000000043;
+    pub const sasl_outcome: u64 = 0x0000000000000044;
+
+    // Messaging
+    pub const header: u64 = 0x0000000000000070;
+    pub const delivery_annotations: u64 = 0x0000000000000071;
+    pub const message_annotations: u64 = 0x0000000000000072;
+    pub const properties: u64 = 0x0000000000000073;
+    pub const application_properties: u64 = 0x0000000000000074;
+    pub const data: u64 = 0x0000000000000075;
+    pub const amqp_sequence: u64 = 0x0000000000000076;
+    pub const amqp_value: u64 = 0x0000000000000077;
+    pub const footer: u64 = 0x0000000000000078;
+
+    // Delivery state
+    pub const received: u64 = 0x0000000000000023;
+    pub const accepted: u64 = 0x0000000000000024;
+    pub const rejected: u64 = 0x0000000000000025;
+    pub const released: u64 = 0x0000000000000026;
+    pub const modified: u64 = 0x0000000000000027;
+
+    // Addressing
+    pub const source: u64 = 0x0000000000000028;
+    pub const target: u64 = 0x0000000000000029;
+};
+
+// ── Role ──────────────────────────────────────────────────────────────
+
+pub const Role = enum {
+    sender,
+    receiver,
+
+    pub fn toBool(self: Role) bool {
+        return self == .receiver;
+    }
+
+    pub fn fromBool(v: bool) Role {
+        return if (v) .receiver else .sender;
+    }
+};
+
+// ── Settle Modes ──────────────────────────────────────────────────────
+
+pub const SenderSettleMode = enum(u8) {
+    unsettled = 0,
+    settled = 1,
+    mixed = 2,
+};
+
+pub const ReceiverSettleMode = enum(u8) {
+    first = 0,
+    second = 1,
+};
+
+// ── SASL Code ─────────────────────────────────────────────────────────
+
+pub const SaslCode = enum(u8) {
+    ok = 0,
+    auth = 1,
+    sys = 2,
+    sys_perm = 3,
+    sys_temp = 4,
+};
+
+// ── Error ─────────────────────────────────────────────────────────────
+
+pub const AmqpError = struct {
+    condition: []const u8,
+    description: ?[]const u8 = null,
+    info: ?[]MapEntry = null,
+};
+
+// ── Open (§2.7.1) ─────────────────────────────────────────────────────
+
+pub const Open = struct {
+    container_id: []const u8,
+    hostname: ?[]const u8 = null,
+    max_frame_size: u32 = 4294967295,
+    channel_max: u16 = 65535,
+    idle_time_out: ?u32 = null,
+    outgoing_locales: ?[]const []const u8 = null,
+    incoming_locales: ?[]const []const u8 = null,
+    offered_capabilities: ?[]const []const u8 = null,
+    desired_capabilities: ?[]const []const u8 = null,
+    properties: ?[]MapEntry = null,
+};
+
+// ── Begin (§2.7.2) ────────────────────────────────────────────────────
+
+pub const Begin = struct {
+    remote_channel: ?u16 = null,
+    next_outgoing_id: u32,
+    incoming_window: u32,
+    outgoing_window: u32,
+    handle_max: u32 = 4294967295,
+    offered_capabilities: ?[]const []const u8 = null,
+    desired_capabilities: ?[]const []const u8 = null,
+    properties: ?[]MapEntry = null,
+};
+
+// ── Attach (§2.7.3) ──────────────────────────────────────────────────
+
+pub const Attach = struct {
+    name: []const u8,
+    handle: u32,
+    role: Role,
+    snd_settle_mode: SenderSettleMode = .mixed,
+    rcv_settle_mode: ReceiverSettleMode = .first,
+    source: ?Source = null,
+    target: ?Target = null,
+    unsettled: ?[]MapEntry = null,
+    incomplete_unsettled: bool = false,
+    initial_delivery_count: ?u32 = null,
+    max_message_size: ?u64 = null,
+    offered_capabilities: ?[]const []const u8 = null,
+    desired_capabilities: ?[]const []const u8 = null,
+    properties: ?[]MapEntry = null,
+};
+
+// ── Flow (§2.7.4) ────────────────────────────────────────────────────
+
+pub const Flow = struct {
+    next_incoming_id: ?u32 = null,
+    incoming_window: u32,
+    next_outgoing_id: u32,
+    outgoing_window: u32,
+    handle: ?u32 = null,
+    delivery_count: ?u32 = null,
+    link_credit: ?u32 = null,
+    available: ?u32 = null,
+    drain: bool = false,
+    echo: bool = false,
+    properties: ?[]MapEntry = null,
+};
+
+// ── Transfer (§2.7.5) ────────────────────────────────────────────────
+
+pub const Transfer = struct {
+    handle: u32,
+    delivery_id: ?u32 = null,
+    delivery_tag: ?[]const u8 = null,
+    message_format: ?u32 = null,
+    settled: ?bool = null,
+    more: bool = false,
+    rcv_settle_mode: ?ReceiverSettleMode = null,
+    delivery_state: ?DeliveryState = null,
+    is_resume: bool = false,
+    aborted: bool = false,
+    batchable: bool = false,
+};
+
+// ── Disposition (§2.7.6) ─────────────────────────────────────────────
+
+pub const Disposition = struct {
+    role: Role,
+    first: u32,
+    last: ?u32 = null,
+    settled: bool = false,
+    delivery_state: ?DeliveryState = null,
+    batchable: bool = false,
+};
+
+// ── Detach (§2.7.7) ─────────────────────────────────────────────────
+
+pub const Detach = struct {
+    handle: u32,
+    closed: bool = false,
+    err: ?AmqpError = null,
+};
+
+// ── End (§2.7.8) ────────────────────────────────────────────────────
+
+pub const End = struct {
+    err: ?AmqpError = null,
+};
+
+// ── Close (§2.7.9) ──────────────────────────────────────────────────
+
+pub const Close = struct {
+    err: ?AmqpError = null,
+};
+
+// ── Delivery State ──────────────────────────────────────────────────
+
+pub const DeliveryState = union(enum) {
+    received: Received,
+    accepted,
+    rejected: Rejected,
+    released,
+    modified: Modified,
+};
+
+pub const Received = struct {
+    section_number: u32,
+    section_offset: u64,
+};
+
+pub const Rejected = struct {
+    err: ?AmqpError = null,
+};
+
+pub const Modified = struct {
+    delivery_failed: ?bool = null,
+    undeliverable_here: ?bool = null,
+    message_annotations: ?[]MapEntry = null,
+};
+
+// ── Source (§3.5.3) ─────────────────────────────────────────────────
+
+pub const TerminusDurability = enum(u32) {
+    none = 0,
+    configuration = 1,
+    unsettled_state = 2,
+};
+
+pub const TerminusExpiryPolicy = enum {
+    link_detach,
+    session_end,
+    connection_close,
+    never,
+
+    pub fn toSymbol(self: TerminusExpiryPolicy) []const u8 {
+        return switch (self) {
+            .link_detach => "link-detach",
+            .session_end => "session-end",
+            .connection_close => "connection-close",
+            .never => "never",
+        };
+    }
+};
+
+pub const Source = struct {
+    address: ?[]const u8 = null,
+    durable: TerminusDurability = .none,
+    expiry_policy: TerminusExpiryPolicy = .session_end,
+    timeout: u32 = 0,
+    dynamic: bool = false,
+    dynamic_node_properties: ?[]MapEntry = null,
+    distribution_mode: ?[]const u8 = null,
+    filter: ?[]MapEntry = null,
+    default_outcome: ?DeliveryState = null,
+    outcomes: ?[]const []const u8 = null,
+    capabilities: ?[]const []const u8 = null,
+};
+
+// ── Target (§3.5.4) ─────────────────────────────────────────────────
+
+pub const Target = struct {
+    address: ?[]const u8 = null,
+    durable: TerminusDurability = .none,
+    expiry_policy: TerminusExpiryPolicy = .session_end,
+    timeout: u32 = 0,
+    dynamic: bool = false,
+    dynamic_node_properties: ?[]MapEntry = null,
+    capabilities: ?[]const []const u8 = null,
+};
+
+// ── SASL Performatives (§5.3) ───────────────────────────────────────
+
+pub const SaslMechanisms = struct {
+    sasl_server_mechanisms: []const []const u8,
+};
+
+pub const SaslInit = struct {
+    mechanism: []const u8,
+    initial_response: ?[]const u8 = null,
+    hostname: ?[]const u8 = null,
+};
+
+pub const SaslChallenge = struct {
+    challenge: []const u8,
+};
+
+pub const SaslResponse = struct {
+    response: []const u8,
+};
+
+pub const SaslOutcome = struct {
+    code: SaslCode,
+    additional_data: ?[]const u8 = null,
+};
+
+// ── Performative Union ──────────────────────────────────────────────
+
+pub const Performative = union(enum) {
+    open: Open,
+    begin: Begin,
+    attach: Attach,
+    flow: Flow,
+    transfer: Transfer,
+    disposition: Disposition,
+    detach: Detach,
+    end: End,
+    close: Close,
+
+    // SASL
+    sasl_mechanisms: SaslMechanisms,
+    sasl_init: SaslInit,
+    sasl_challenge: SaslChallenge,
+    sasl_response: SaslResponse,
+    sasl_outcome: SaslOutcome,
+
+    pub fn descriptorCode(self: Performative) u64 {
+        return switch (self) {
+            .open => descriptor.open,
+            .begin => descriptor.begin,
+            .attach => descriptor.attach,
+            .flow => descriptor.flow,
+            .transfer => descriptor.transfer,
+            .disposition => descriptor.disposition,
+            .detach => descriptor.detach,
+            .end => descriptor.end,
+            .close => descriptor.close,
+            .sasl_mechanisms => descriptor.sasl_mechanisms,
+            .sasl_init => descriptor.sasl_init,
+            .sasl_challenge => descriptor.sasl_challenge,
+            .sasl_response => descriptor.sasl_response,
+            .sasl_outcome => descriptor.sasl_outcome,
+        };
+    }
+};
+
+// ── Message Sections (§3.2) ─────────────────────────────────────────
+
+pub const Header = struct {
+    durable: bool = false,
+    priority: u8 = 4,
+    ttl: ?u32 = null,
+    first_acquirer: bool = false,
+    delivery_count: u32 = 0,
+};
+
+pub const Properties = struct {
+    message_id: ?AmqpValue = null,
+    user_id: ?[]const u8 = null,
+    to: ?[]const u8 = null,
+    subject: ?[]const u8 = null,
+    reply_to: ?[]const u8 = null,
+    correlation_id: ?AmqpValue = null,
+    content_type: ?[]const u8 = null,
+    content_encoding: ?[]const u8 = null,
+    absolute_expiry_time: ?i64 = null,
+    creation_time: ?i64 = null,
+    group_id: ?[]const u8 = null,
+    group_sequence: ?u32 = null,
+    reply_to_group_id: ?[]const u8 = null,
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "descriptor codes" {
+    try std.testing.expectEqual(@as(u64, 0x10), descriptor.open);
+    try std.testing.expectEqual(@as(u64, 0x11), descriptor.begin);
+    try std.testing.expectEqual(@as(u64, 0x12), descriptor.attach);
+    try std.testing.expectEqual(@as(u64, 0x13), descriptor.flow);
+    try std.testing.expectEqual(@as(u64, 0x14), descriptor.transfer);
+    try std.testing.expectEqual(@as(u64, 0x18), descriptor.close);
+}
+
+test "Role conversion" {
+    try std.testing.expect(Role.sender.toBool() == false);
+    try std.testing.expect(Role.receiver.toBool() == true);
+    try std.testing.expectEqual(Role.sender, Role.fromBool(false));
+    try std.testing.expectEqual(Role.receiver, Role.fromBool(true));
+}
+
+test "Performative descriptor codes" {
+    const open_perf = Performative{ .open = .{ .container_id = "test" } };
+    try std.testing.expectEqual(@as(u64, 0x10), open_perf.descriptorCode());
+
+    const close_perf = Performative{ .close = .{} };
+    try std.testing.expectEqual(@as(u64, 0x18), close_perf.descriptorCode());
+}
+
+test "SaslCode values" {
+    try std.testing.expectEqual(@as(u8, 0), @intFromEnum(SaslCode.ok));
+    try std.testing.expectEqual(@as(u8, 1), @intFromEnum(SaslCode.auth));
+}
+
+test "TerminusExpiryPolicy symbol conversion" {
+    try std.testing.expectEqualStrings("link-detach", TerminusExpiryPolicy.link_detach.toSymbol());
+    try std.testing.expectEqualStrings("never", TerminusExpiryPolicy.never.toSymbol());
+}

--- a/src/zig/protocol/frame.zig
+++ b/src/zig/protocol/frame.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+
+/// AMQP 1.0 frame constants (OASIS spec §2.3)
+pub const amqp_header = [_]u8{ 'A', 'M', 'Q', 'P', 0, 1, 0, 0 };
+pub const sasl_header = [_]u8{ 'A', 'M', 'Q', 'P', 3, 1, 0, 0 };
+
+pub const min_frame_size: u32 = 512;
+pub const frame_header_size: usize = 8;
+pub const min_max_frame_size: u32 = 512;
+
+/// Frame type identifiers.
+pub const FrameType = enum(u8) {
+    amqp = 0x00,
+    sasl = 0x01,
+    _,
+};
+
+/// A parsed AMQP frame header.
+pub const FrameHeader = struct {
+    /// Total frame size including header.
+    size: u32,
+    /// Data offset in 4-byte words (minimum 2 = 8 bytes for the header).
+    doff: u8,
+    /// Frame type.
+    frame_type: FrameType,
+    /// Channel number (type-specific: channel for AMQP, 0 for SASL).
+    channel: u16,
+
+    /// Size of the frame body (total size minus header as indicated by doff).
+    pub fn bodySize(self: FrameHeader) u32 {
+        return self.size - @as(u32, self.doff) * 4;
+    }
+
+    /// Parse a frame header from 8 bytes.
+    pub fn parse(data: *const [frame_header_size]u8) error{InvalidFrame}!FrameHeader {
+        const size = std.mem.readInt(u32, data[0..4], .big);
+        const doff = data[4];
+        const frame_type: FrameType = @enumFromInt(data[5]);
+        const channel = std.mem.readInt(u16, data[6..8], .big);
+
+        if (size < frame_header_size) return error.InvalidFrame;
+        if (doff < 2) return error.InvalidFrame;
+
+        return .{
+            .size = size,
+            .doff = doff,
+            .frame_type = frame_type,
+            .channel = channel,
+        };
+    }
+
+    /// Serialize the frame header to 8 bytes.
+    pub fn serialize(self: FrameHeader) [frame_header_size]u8 {
+        var buf: [frame_header_size]u8 = undefined;
+        std.mem.writeInt(u32, buf[0..4], self.size, .big);
+        buf[4] = self.doff;
+        buf[5] = @intFromEnum(self.frame_type);
+        std.mem.writeInt(u16, buf[6..8], self.channel, .big);
+        return buf;
+    }
+};
+
+/// Represents a complete frame with header and body.
+pub const Frame = struct {
+    header: FrameHeader,
+    /// The performative + payload bytes (everything after the extended header).
+    body: []const u8,
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "parse and serialize frame header roundtrip" {
+    const original = FrameHeader{
+        .size = 100,
+        .doff = 2,
+        .frame_type = .amqp,
+        .channel = 5,
+    };
+    const bytes = original.serialize();
+    const parsed = try FrameHeader.parse(&bytes);
+    try std.testing.expectEqual(original.size, parsed.size);
+    try std.testing.expectEqual(original.doff, parsed.doff);
+    try std.testing.expectEqual(original.frame_type, parsed.frame_type);
+    try std.testing.expectEqual(original.channel, parsed.channel);
+}
+
+test "frame header body size" {
+    const hdr = FrameHeader{ .size = 100, .doff = 2, .frame_type = .amqp, .channel = 0 };
+    try std.testing.expectEqual(@as(u32, 92), hdr.bodySize());
+}
+
+test "frame header validates minimum" {
+    var data = [_]u8{ 0, 0, 0, 4, 1, 0, 0, 0 }; // size=4 (too small for doff=2), doff=1 (too small)
+    try std.testing.expectError(error.InvalidFrame, FrameHeader.parse(&data));
+}
+
+test "AMQP protocol header" {
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 'A', 'M', 'Q', 'P', 0, 1, 0, 0 }, &amqp_header);
+}
+
+test "SASL protocol header" {
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 'A', 'M', 'Q', 'P', 3, 1, 0, 0 }, &sasl_header);
+}

--- a/src/zig/protocol/frame_codec.zig
+++ b/src/zig/protocol/frame_codec.zig
@@ -1,0 +1,262 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const frame = @import("frame.zig");
+const FrameHeader = frame.FrameHeader;
+
+/// Callback invoked when a complete frame has been received.
+pub const OnFrameReceived = *const fn (context: ?*anyopaque, header: FrameHeader, body: []const u8) void;
+
+/// A streaming frame codec that accumulates bytes and emits complete frames.
+///
+/// Replaces frame_codec.c — handles the stateful parsing of AMQP frames
+/// from a byte stream, managing partial reads and frame assembly.
+pub const FrameCodec = struct {
+    allocator: Allocator,
+    max_frame_size: u32,
+    state: State,
+    header_buf: [frame.frame_header_size]u8,
+    header_bytes_received: usize,
+    frame_body: std.ArrayList(u8),
+    body_bytes_needed: usize,
+    current_header: ?FrameHeader,
+
+    // Subscription list for frame type dispatch
+    subscriptions: std.ArrayList(Subscription),
+
+    const Subscription = struct {
+        frame_type: frame.FrameType,
+        callback: OnFrameReceived,
+        context: ?*anyopaque,
+    };
+
+    const State = enum {
+        reading_header,
+        reading_body,
+    };
+
+    pub fn init(allocator: Allocator, max_frame_size: u32) FrameCodec {
+        return .{
+            .allocator = allocator,
+            .max_frame_size = max_frame_size,
+            .state = .reading_header,
+            .header_buf = undefined,
+            .header_bytes_received = 0,
+            .frame_body = .empty,
+            .body_bytes_needed = 0,
+            .current_header = null,
+            .subscriptions = .empty,
+        };
+    }
+
+    pub fn deinit(self: *FrameCodec) void {
+        self.frame_body.deinit(self.allocator);
+        self.subscriptions.deinit(self.allocator);
+    }
+
+    /// Subscribe to receive frames of a given type.
+    pub fn subscribe(self: *FrameCodec, frame_type: frame.FrameType, callback: OnFrameReceived, context: ?*anyopaque) Allocator.Error!void {
+        try self.subscriptions.append(self.allocator, .{
+            .frame_type = frame_type,
+            .callback = callback,
+            .context = context,
+        });
+    }
+
+    /// Unsubscribe from a frame type.
+    pub fn unsubscribe(self: *FrameCodec, frame_type: frame.FrameType) void {
+        var i: usize = 0;
+        while (i < self.subscriptions.items.len) {
+            if (self.subscriptions.items[i].frame_type == frame_type) {
+                _ = self.subscriptions.orderedRemove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    /// Feed bytes into the codec. Complete frames are dispatched to subscribers.
+    pub fn receiveBytes(self: *FrameCodec, data: []const u8) !void {
+        var offset: usize = 0;
+        while (offset < data.len) {
+            switch (self.state) {
+                .reading_header => {
+                    const needed = frame.frame_header_size - self.header_bytes_received;
+                    const available = @min(needed, data.len - offset);
+                    @memcpy(
+                        self.header_buf[self.header_bytes_received .. self.header_bytes_received + available],
+                        data[offset .. offset + available],
+                    );
+                    self.header_bytes_received += available;
+                    offset += available;
+
+                    if (self.header_bytes_received == frame.frame_header_size) {
+                        const hdr = FrameHeader.parse(&self.header_buf) catch return error.InvalidFrame;
+
+                        if (hdr.size > self.max_frame_size) return error.FrameTooLarge;
+
+                        const body_size = hdr.bodySize();
+                        self.current_header = hdr;
+                        self.body_bytes_needed = body_size;
+                        self.frame_body.clearRetainingCapacity();
+
+                        if (body_size == 0) {
+                            self.dispatchFrame(hdr, &.{});
+                            self.resetForNextFrame();
+                        } else {
+                            try self.frame_body.ensureTotalCapacity(self.allocator, body_size);
+                            self.state = .reading_body;
+                        }
+                    }
+                },
+                .reading_body => {
+                    const needed = self.body_bytes_needed - self.frame_body.items.len;
+                    const available = @min(needed, data.len - offset);
+                    try self.frame_body.appendSlice(self.allocator, data[offset .. offset + available]);
+                    offset += available;
+
+                    if (self.frame_body.items.len == self.body_bytes_needed) {
+                        self.dispatchFrame(self.current_header.?, self.frame_body.items);
+                        self.resetForNextFrame();
+                    }
+                },
+            }
+        }
+    }
+
+    /// Encode and return a frame with the given body.
+    pub fn encodeFrame(
+        self: *FrameCodec,
+        frame_type: frame.FrameType,
+        channel: u16,
+        body: []const u8,
+    ) ![]u8 {
+        const total_size: u32 = @intCast(frame.frame_header_size + body.len);
+        if (total_size > self.max_frame_size) return error.FrameTooLarge;
+
+        const hdr = FrameHeader{
+            .size = total_size,
+            .doff = 2,
+            .frame_type = frame_type,
+            .channel = channel,
+        };
+
+        const buf = try self.allocator.alloc(u8, total_size);
+        const header_bytes = hdr.serialize();
+        @memcpy(buf[0..frame.frame_header_size], &header_bytes);
+        @memcpy(buf[frame.frame_header_size..], body);
+        return buf;
+    }
+
+    fn dispatchFrame(self: *FrameCodec, header: FrameHeader, body: []const u8) void {
+        for (self.subscriptions.items) |sub| {
+            if (sub.frame_type == header.frame_type) {
+                sub.callback(sub.context, header, body);
+            }
+        }
+    }
+
+    fn resetForNextFrame(self: *FrameCodec) void {
+        self.state = .reading_header;
+        self.header_bytes_received = 0;
+        self.current_header = null;
+        // Note: frame_body is cleared at the start of the next header-complete
+        // transition (line above ensureTotalCapacity). We intentionally do NOT
+        // clear here so dispatched body slices remain valid until the next frame.
+    }
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+var test_received_header: ?FrameHeader = null;
+var test_received_body: ?[]const u8 = null;
+
+fn testCallback(_: ?*anyopaque, header: FrameHeader, body: []const u8) void {
+    test_received_header = header;
+    test_received_body = body;
+}
+
+test "FrameCodec receives complete frame" {
+    const allocator = std.testing.allocator;
+
+    test_received_header = null;
+    test_received_body = null;
+
+    var codec = FrameCodec.init(allocator, 4096);
+    defer codec.deinit();
+
+    try codec.subscribe(.amqp, testCallback, null);
+
+    // Build a frame: header (8 bytes) + body "hello"
+    const body = "hello";
+    const total_size: u32 = @intCast(frame.frame_header_size + body.len);
+    const hdr = FrameHeader{
+        .size = total_size,
+        .doff = 2,
+        .frame_type = .amqp,
+        .channel = 0,
+    };
+    const header_bytes = hdr.serialize();
+
+    var frame_bytes: [13]u8 = undefined;
+    @memcpy(frame_bytes[0..8], &header_bytes);
+    @memcpy(frame_bytes[8..13], body);
+
+    try codec.receiveBytes(&frame_bytes);
+
+    try std.testing.expect(test_received_header != null);
+    try std.testing.expectEqual(@as(u32, 13), test_received_header.?.size);
+    try std.testing.expectEqual(frame.FrameType.amqp, test_received_header.?.frame_type);
+    try std.testing.expectEqualStrings("hello", test_received_body.?);
+}
+
+test "FrameCodec handles partial reads" {
+    const allocator = std.testing.allocator;
+
+    test_received_header = null;
+    test_received_body = null;
+
+    var codec = FrameCodec.init(allocator, 4096);
+    defer codec.deinit();
+
+    try codec.subscribe(.amqp, testCallback, null);
+
+    const body = "hi";
+    const total_size: u32 = @intCast(frame.frame_header_size + body.len);
+    const hdr = FrameHeader{
+        .size = total_size,
+        .doff = 2,
+        .frame_type = .amqp,
+        .channel = 1,
+    };
+    const header_bytes = hdr.serialize();
+
+    var frame_bytes: [10]u8 = undefined;
+    @memcpy(frame_bytes[0..8], &header_bytes);
+    @memcpy(frame_bytes[8..10], body);
+
+    // Feed one byte at a time
+    for (&frame_bytes) |*b| {
+        try codec.receiveBytes(b[0..1]);
+    }
+
+    try std.testing.expect(test_received_header != null);
+    try std.testing.expectEqual(@as(u16, 1), test_received_header.?.channel);
+    try std.testing.expectEqualStrings("hi", test_received_body.?);
+}
+
+test "FrameCodec encodeFrame" {
+    const allocator = std.testing.allocator;
+
+    var codec = FrameCodec.init(allocator, 4096);
+    defer codec.deinit();
+
+    const body = "test payload";
+    const encoded = try codec.encodeFrame(.amqp, 3, body);
+    defer allocator.free(encoded);
+
+    const hdr = try FrameHeader.parse(encoded[0..8]);
+    try std.testing.expectEqual(@as(u32, @intCast(frame.frame_header_size + body.len)), hdr.size);
+    try std.testing.expectEqual(frame.FrameType.amqp, hdr.frame_type);
+    try std.testing.expectEqual(@as(u16, 3), hdr.channel);
+    try std.testing.expectEqualStrings(body, encoded[8..]);
+}

--- a/src/zig/protocol/link.zig
+++ b/src/zig/protocol/link.zig
@@ -1,0 +1,250 @@
+///! AMQP 1.0 Link state machine (OASIS spec §2.6)
+///!
+///! Manages the lifecycle of a message transfer link: attach/detach,
+///! credit-based flow control, and delivery tracking.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const defs = @import("definitions.zig");
+const Session = @import("session.zig").Session;
+const LinkEndpoint = @import("session.zig").LinkEndpoint;
+
+const log = std.log.scoped(.amqp_link);
+
+/// Link states per AMQP 1.0 §2.6.4
+pub const LinkState = enum {
+    detached,
+    half_attached_attach_sent,
+    half_attached_attach_received,
+    attached,
+    err,
+};
+
+pub const OnLinkStateChanged = *const fn (
+    context: ?*anyopaque,
+    new_state: LinkState,
+    previous_state: LinkState,
+) void;
+
+pub const OnTransferReceived = *const fn (
+    context: ?*anyopaque,
+    transfer: defs.Transfer,
+    payload: []const u8,
+) defs.DeliveryState;
+
+pub const OnLinkFlowOn = *const fn (context: ?*anyopaque) void;
+
+/// Tracks a pending delivery (sent transfer awaiting disposition).
+pub const Delivery = struct {
+    delivery_id: u32,
+    delivery_tag: []const u8,
+    settled: bool,
+    on_settled: ?*const fn (context: ?*anyopaque, delivery_id: u32, state: defs.DeliveryState) void = null,
+    context: ?*anyopaque = null,
+};
+
+/// AMQP Link — a unidirectional channel for message transfer.
+pub const Link = struct {
+    allocator: Allocator,
+    state: LinkState,
+    name: []const u8,
+    role: defs.Role,
+    session: *Session,
+    endpoint: *LinkEndpoint,
+
+    // Settle modes
+    snd_settle_mode: defs.SenderSettleMode,
+    rcv_settle_mode: defs.ReceiverSettleMode,
+
+    // Source and target
+    source: ?defs.Source,
+    target: ?defs.Target,
+
+    // Flow control
+    delivery_count: u32,
+    link_credit: u32,
+    available: u32,
+
+    // Delivery tracking
+    pending_deliveries: std.ArrayList(Delivery),
+    next_delivery_id: u32,
+
+    // Max message size
+    max_message_size: ?u64,
+    peer_max_message_size: ?u64,
+
+    // Callbacks
+    on_state_changed: ?OnLinkStateChanged,
+    on_state_changed_context: ?*anyopaque,
+    on_transfer_received: ?OnTransferReceived,
+    on_transfer_received_context: ?*anyopaque,
+
+    pub fn init(
+        allocator: Allocator,
+        session: *Session,
+        name: []const u8,
+        role: defs.Role,
+        source: ?defs.Source,
+        target: ?defs.Target,
+    ) !Link {
+        const endpoint = try session.createLinkEndpoint(name);
+        return .{
+            .allocator = allocator,
+            .state = .detached,
+            .name = name,
+            .role = role,
+            .session = session,
+            .endpoint = endpoint,
+            .snd_settle_mode = .mixed,
+            .rcv_settle_mode = .first,
+            .source = source,
+            .target = target,
+            .delivery_count = 0,
+            .link_credit = 0,
+            .available = 0,
+            .pending_deliveries = .empty,
+            .next_delivery_id = 0,
+            .max_message_size = null,
+            .peer_max_message_size = null,
+            .on_state_changed = null,
+            .on_state_changed_context = null,
+            .on_transfer_received = null,
+            .on_transfer_received_context = null,
+        };
+    }
+
+    pub fn deinit(self: *Link) void {
+        self.pending_deliveries.deinit(self.allocator);
+        self.session.destroyLinkEndpoint(self.endpoint);
+    }
+
+    /// Initiate link attachment by sending Attach.
+    pub fn attach(self: *Link) !void {
+        if (self.state != .detached) return error.InvalidState;
+        // In full implementation: encode Attach and send via session
+        self.setState(.half_attached_attach_sent);
+    }
+
+    /// Detach the link.
+    pub fn detach(self: *Link, close: bool, err: ?defs.AmqpError) !void {
+        _ = close;
+        _ = err;
+        switch (self.state) {
+            .attached, .half_attached_attach_sent => {
+                self.setState(.detached);
+            },
+            else => return error.InvalidState,
+        }
+    }
+
+    /// Set link credit (receiver only).
+    pub fn setLinkCredit(self: *Link, credit: u32) void {
+        self.link_credit = credit;
+    }
+
+    /// Handle a received Attach performative from the peer.
+    pub fn onAttachReceived(self: *Link, attach_perf: defs.Attach) void {
+        _ = attach_perf;
+        switch (self.state) {
+            .half_attached_attach_sent => self.setState(.attached),
+            .detached => self.setState(.half_attached_attach_received),
+            else => {
+                log.err("Attach received in unexpected state: {s}", .{@tagName(self.state)});
+                self.setState(.err);
+            },
+        }
+    }
+
+    /// Handle a received Flow performative.
+    pub fn onFlowReceived(self: *Link, flow: defs.Flow) void {
+        if (flow.delivery_count) |dc| {
+            self.delivery_count = dc;
+        }
+        if (flow.link_credit) |credit| {
+            self.link_credit = credit;
+        }
+    }
+
+    /// Handle a received Transfer performative.
+    pub fn onTransferReceived(self: *Link, transfer: defs.Transfer, payload: []const u8) ?defs.DeliveryState {
+        if (self.on_transfer_received) |cb| {
+            return cb(self.on_transfer_received_context, transfer, payload);
+        }
+        return null;
+    }
+
+    /// Check if the link has credit available for sending.
+    pub fn hasCredit(self: *const Link) bool {
+        return self.link_credit > 0;
+    }
+
+    // ── Internal ──────────────────────────────────────────────────────
+
+    fn setState(self: *Link, new_state: LinkState) void {
+        if (self.state == new_state) return;
+        const prev = self.state;
+        self.state = new_state;
+        log.info("Link '{s}' state: {s} -> {s}", .{ self.name, @tagName(prev), @tagName(new_state) });
+        if (self.on_state_changed) |cb| {
+            cb(self.on_state_changed_context, new_state, prev);
+        }
+    }
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+const Connection = @import("connection.zig").Connection;
+
+test "Link init and state" {
+    const allocator = std.testing.allocator;
+    var conn = Connection.init(allocator, "test", null, .{});
+    defer conn.deinit();
+    var session = Session.init(allocator, &conn, .{});
+    defer session.deinit();
+
+    var link = try Link.init(
+        allocator,
+        &session,
+        "my-sender",
+        .sender,
+        .{ .address = "queue1" },
+        .{ .address = "queue1" },
+    );
+    defer link.deinit();
+
+    try std.testing.expectEqual(LinkState.detached, link.state);
+    try std.testing.expectEqual(defs.Role.sender, link.role);
+    try std.testing.expectEqualStrings("my-sender", link.name);
+}
+
+test "Link attach state transition" {
+    const allocator = std.testing.allocator;
+    var conn = Connection.init(allocator, "test", null, .{});
+    defer conn.deinit();
+    var session = Session.init(allocator, &conn, .{});
+    defer session.deinit();
+
+    var link = try Link.init(allocator, &session, "test-link", .sender, null, null);
+    defer link.deinit();
+
+    try link.attach();
+    try std.testing.expectEqual(LinkState.half_attached_attach_sent, link.state);
+
+    link.onAttachReceived(.{ .name = "test-link", .handle = 0, .role = .receiver });
+    try std.testing.expectEqual(LinkState.attached, link.state);
+}
+
+test "Link credit management" {
+    const allocator = std.testing.allocator;
+    var conn = Connection.init(allocator, "test", null, .{});
+    defer conn.deinit();
+    var session = Session.init(allocator, &conn, .{});
+    defer session.deinit();
+
+    var link = try Link.init(allocator, &session, "rcv", .receiver, null, null);
+    defer link.deinit();
+
+    try std.testing.expect(!link.hasCredit());
+    link.setLinkCredit(10);
+    try std.testing.expect(link.hasCredit());
+    try std.testing.expectEqual(@as(u32, 10), link.link_credit);
+}

--- a/src/zig/protocol/session.zig
+++ b/src/zig/protocol/session.zig
@@ -1,0 +1,216 @@
+///! AMQP 1.0 Session state machine (OASIS spec §2.5)
+///!
+///! Manages multiple links, flow control windows, and transfer numbering.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const defs = @import("definitions.zig");
+const Connection = @import("connection.zig").Connection;
+
+const log = std.log.scoped(.amqp_session);
+
+/// Session states per AMQP 1.0 §2.5.5
+pub const SessionState = enum {
+    unmapped,
+    begin_sent,
+    begin_rcvd,
+    mapped,
+    end_sent,
+    end_rcvd,
+    discarding,
+    err,
+};
+
+pub const OnSessionStateChanged = *const fn (
+    context: ?*anyopaque,
+    new_state: SessionState,
+    previous_state: SessionState,
+) void;
+
+pub const OnSessionFlowOn = *const fn (context: ?*anyopaque) void;
+
+/// A link endpoint registered within a session.
+pub const LinkEndpoint = struct {
+    name: []const u8,
+    handle: u32,
+    input_handle: ?u32 = null,
+    on_frame_received: ?*const fn (context: ?*anyopaque, performative: defs.Performative, payload: []const u8) void = null,
+    context: ?*anyopaque = null,
+};
+
+/// AMQP Session — manages link endpoints and flow control within a connection.
+pub const Session = struct {
+    allocator: Allocator,
+    state: SessionState,
+    connection: *Connection,
+
+    // Flow control
+    next_outgoing_id: u32,
+    next_incoming_id: u32,
+    incoming_window: u32,
+    outgoing_window: u32,
+    remote_incoming_window: u32,
+    remote_outgoing_window: u32,
+    handle_max: u32,
+
+    // Link endpoints
+    link_endpoints: std.ArrayList(LinkEndpoint),
+    next_handle: u32,
+
+    // Channel
+    outgoing_channel: ?u16,
+    incoming_channel: ?u16,
+
+    // Callbacks
+    on_state_changed: ?OnSessionStateChanged,
+    on_state_changed_context: ?*anyopaque,
+
+    pub fn init(allocator: Allocator, connection: *Connection, opts: struct {
+        incoming_window: u32 = 2147483647,
+        outgoing_window: u32 = 65536,
+        handle_max: u32 = 4294967295,
+    }) Session {
+        return .{
+            .allocator = allocator,
+            .state = .unmapped,
+            .connection = connection,
+            .next_outgoing_id = 0,
+            .next_incoming_id = 0,
+            .incoming_window = opts.incoming_window,
+            .outgoing_window = opts.outgoing_window,
+            .remote_incoming_window = 0,
+            .remote_outgoing_window = 0,
+            .handle_max = opts.handle_max,
+            .link_endpoints = .empty,
+            .next_handle = 0,
+            .outgoing_channel = null,
+            .incoming_channel = null,
+            .on_state_changed = null,
+            .on_state_changed_context = null,
+        };
+    }
+
+    pub fn deinit(self: *Session) void {
+        self.link_endpoints.deinit(self.allocator);
+    }
+
+    /// Set the state change callback.
+    pub fn setOnStateChanged(self: *Session, cb: OnSessionStateChanged, context: ?*anyopaque) void {
+        self.on_state_changed = cb;
+        self.on_state_changed_context = context;
+    }
+
+    /// Create a link endpoint within this session.
+    pub fn createLinkEndpoint(self: *Session, name: []const u8) !*LinkEndpoint {
+        const handle = self.next_handle;
+        self.next_handle += 1;
+
+        try self.link_endpoints.append(self.allocator, .{
+            .name = name,
+            .handle = handle,
+        });
+        return &self.link_endpoints.items[self.link_endpoints.items.len - 1];
+    }
+
+    /// Destroy a link endpoint.
+    pub fn destroyLinkEndpoint(self: *Session, endpoint: *LinkEndpoint) void {
+        for (self.link_endpoints.items, 0..) |*ep, i| {
+            if (ep.handle == endpoint.handle) {
+                _ = self.link_endpoints.orderedRemove(i);
+                return;
+            }
+        }
+    }
+
+    /// Initiate the session by sending Begin.
+    pub fn begin(self: *Session) !void {
+        if (self.state != .unmapped) return error.InvalidState;
+        // In full implementation: encode Begin performative and send via connection
+        self.setState(.begin_sent);
+    }
+
+    /// End the session.
+    pub fn end(self: *Session, err: ?defs.AmqpError) !void {
+        _ = err;
+        if (self.state != .mapped) return error.InvalidState;
+        self.setState(.end_sent);
+    }
+
+    /// Handle a received Begin performative.
+    pub fn onBeginReceived(self: *Session, begin_perf: defs.Begin) void {
+        self.remote_incoming_window = begin_perf.incoming_window;
+        self.remote_outgoing_window = begin_perf.outgoing_window;
+        self.next_incoming_id = begin_perf.next_outgoing_id;
+
+        switch (self.state) {
+            .begin_sent => self.setState(.mapped),
+            .unmapped => self.setState(.begin_rcvd),
+            else => {
+                log.err("Begin received in unexpected state: {s}", .{@tagName(self.state)});
+                self.setState(.err);
+            },
+        }
+    }
+
+    /// Handle a received Flow performative.
+    pub fn onFlowReceived(self: *Session, flow: defs.Flow) void {
+        if (flow.next_incoming_id) |id| {
+            self.remote_incoming_window = id +% flow.incoming_window -% self.next_outgoing_id;
+        }
+        self.remote_outgoing_window = flow.outgoing_window;
+
+        // Dispatch to link if handle specified
+        if (flow.handle) |handle| {
+            for (self.link_endpoints.items) |*ep| {
+                if (ep.handle == handle) {
+                    if (ep.on_frame_received) |cb| {
+                        cb(ep.context, .{ .flow = flow }, &.{});
+                    }
+                    return;
+                }
+            }
+            log.warn("Flow for unknown handle: {d}", .{handle});
+        }
+    }
+
+    // ── Internal ──────────────────────────────────────────────────────
+
+    fn setState(self: *Session, new_state: SessionState) void {
+        if (self.state == new_state) return;
+        const prev = self.state;
+        self.state = new_state;
+        log.info("Session state: {s} -> {s}", .{ @tagName(prev), @tagName(new_state) });
+        if (self.on_state_changed) |cb| {
+            cb(self.on_state_changed_context, new_state, prev);
+        }
+    }
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "Session init" {
+    const allocator = std.testing.allocator;
+    var conn = Connection.init(allocator, "test", null, .{});
+    defer conn.deinit();
+
+    var session = Session.init(allocator, &conn, .{});
+    defer session.deinit();
+
+    try std.testing.expectEqual(SessionState.unmapped, session.state);
+    try std.testing.expectEqual(@as(u32, 2147483647), session.incoming_window);
+}
+
+test "Session create link endpoint" {
+    const allocator = std.testing.allocator;
+    var conn = Connection.init(allocator, "test", null, .{});
+    defer conn.deinit();
+
+    var session = Session.init(allocator, &conn, .{});
+    defer session.deinit();
+
+    const ep = try session.createLinkEndpoint("my-link");
+    try std.testing.expectEqual(@as(u32, 0), ep.handle);
+    try std.testing.expectEqualStrings("my-link", ep.name);
+
+    const ep2 = try session.createLinkEndpoint("my-link-2");
+    try std.testing.expectEqual(@as(u32, 1), ep2.handle);
+}

--- a/src/zig/sasl/anonymous.zig
+++ b/src/zig/sasl/anonymous.zig
@@ -1,0 +1,37 @@
+///! SASL ANONYMOUS mechanism (OASIS spec §5.3.3.1)
+const std = @import("std");
+const Mechanism = @import("mechanism.zig").Mechanism;
+
+pub const Anonymous = struct {
+    pub fn mechanism(self: *Anonymous) Mechanism {
+        return .{
+            .ptr = @ptrCast(self),
+            .vtable = &vtable,
+        };
+    }
+
+    const vtable = Mechanism.VTable{
+        .get_mechanism_name = getMechanismName,
+        .get_init_bytes = getInitBytes,
+        .on_challenge = onChallenge,
+    };
+
+    fn getMechanismName(_: *anyopaque) []const u8 {
+        return "ANONYMOUS";
+    }
+
+    fn getInitBytes(_: *anyopaque) ?[]const u8 {
+        return null;
+    }
+
+    fn onChallenge(_: *anyopaque, _: []const u8) ?[]const u8 {
+        return null;
+    }
+};
+
+test "ANONYMOUS mechanism" {
+    var anon = Anonymous{};
+    const mech = anon.mechanism();
+    try std.testing.expectEqualStrings("ANONYMOUS", mech.getMechanismName());
+    try std.testing.expect(mech.getInitBytes() == null);
+}

--- a/src/zig/sasl/client_io.zig
+++ b/src/zig/sasl/client_io.zig
@@ -1,0 +1,171 @@
+///! SASL Client I/O layer (OASIS spec §5.3)
+///!
+///! Wraps an underlying I/O transport with SASL negotiation.
+///! This is the Zig equivalent of saslclientio.c.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Mechanism = @import("mechanism.zig").Mechanism;
+const frame_mod = @import("../protocol/frame.zig");
+const defs = @import("../protocol/definitions.zig");
+
+const log = std.log.scoped(.sasl_client_io);
+
+pub const SaslState = enum {
+    not_started,
+    header_sent,
+    header_exchanged,
+    waiting_for_mechanisms,
+    init_sent,
+    waiting_for_outcome,
+    complete,
+    err,
+};
+
+pub const SaslClientIo = struct {
+    allocator: Allocator,
+    state: SaslState,
+    mechanism: Mechanism,
+    hostname: ?[]const u8,
+
+    // I/O callbacks
+    io_send: ?*const fn (context: ?*anyopaque, data: []const u8) anyerror!void,
+    io_context: ?*anyopaque,
+
+    // Completion callback
+    on_open_complete: ?*const fn (context: ?*anyopaque, success: bool) void,
+    on_open_complete_context: ?*anyopaque,
+
+    pub fn init(allocator: Allocator, mechanism: Mechanism, hostname: ?[]const u8) SaslClientIo {
+        return .{
+            .allocator = allocator,
+            .state = .not_started,
+            .mechanism = mechanism,
+            .hostname = hostname,
+            .io_send = null,
+            .io_context = null,
+            .on_open_complete = null,
+            .on_open_complete_context = null,
+        };
+    }
+
+    pub fn setIo(
+        self: *SaslClientIo,
+        send_fn: *const fn (context: ?*anyopaque, data: []const u8) anyerror!void,
+        context: ?*anyopaque,
+    ) void {
+        self.io_send = send_fn;
+        self.io_context = context;
+    }
+
+    /// Begin SASL negotiation by sending the SASL protocol header.
+    pub fn open(self: *SaslClientIo) !void {
+        if (self.state != .not_started) return error.InvalidState;
+        try self.sendBytes(&frame_mod.sasl_header);
+        self.state = .header_sent;
+    }
+
+    /// Process received bytes during SASL negotiation.
+    pub fn onBytesReceived(self: *SaslClientIo, data: []const u8) !void {
+        switch (self.state) {
+            .header_sent => {
+                if (data.len >= 8 and std.mem.eql(u8, data[0..8], &frame_mod.sasl_header)) {
+                    self.state = .header_exchanged;
+                    self.state = .waiting_for_mechanisms;
+                    if (data.len > 8) {
+                        try self.processSaslFrames(data[8..]);
+                    }
+                } else {
+                    log.err("Invalid SASL header received", .{});
+                    self.state = .err;
+                }
+            },
+            .waiting_for_mechanisms, .init_sent, .waiting_for_outcome => {
+                try self.processSaslFrames(data);
+            },
+            else => {
+                log.warn("Bytes received in unexpected SASL state: {s}", .{@tagName(self.state)});
+            },
+        }
+    }
+
+    /// Handle SASL mechanisms being offered by the server.
+    pub fn onMechanismsReceived(self: *SaslClientIo, mechanisms: defs.SaslMechanisms) !void {
+        const our_name = self.mechanism.getMechanismName();
+
+        // Check if our mechanism is offered
+        for (mechanisms.sasl_server_mechanisms) |mech_name| {
+            if (std.mem.eql(u8, mech_name, our_name)) {
+                // Send SASL init
+                self.state = .init_sent;
+                self.state = .waiting_for_outcome;
+                return;
+            }
+        }
+
+        log.err("Mechanism '{s}' not offered by server", .{our_name});
+        self.state = .err;
+    }
+
+    /// Handle SASL outcome from server.
+    pub fn onOutcomeReceived(self: *SaslClientIo, outcome: defs.SaslOutcome) void {
+        if (outcome.code == .ok) {
+            self.state = .complete;
+            log.info("SASL authentication successful", .{});
+            if (self.on_open_complete) |cb| {
+                cb(self.on_open_complete_context, true);
+            }
+        } else {
+            self.state = .err;
+            log.err("SASL authentication failed with code: {d}", .{@intFromEnum(outcome.code)});
+            if (self.on_open_complete) |cb| {
+                cb(self.on_open_complete_context, false);
+            }
+        }
+    }
+
+    pub fn isComplete(self: *const SaslClientIo) bool {
+        return self.state == .complete;
+    }
+
+    // ── Internal ──────────────────────────────────────────────────────
+
+    fn sendBytes(self: *SaslClientIo, data: []const u8) !void {
+        if (self.io_send) |send_fn| {
+            try send_fn(self.io_context, data);
+        } else {
+            return error.NoIoConfigured;
+        }
+    }
+
+    fn processSaslFrames(self: *SaslClientIo, data: []const u8) !void {
+        // Placeholder: in full implementation, decode SASL frames
+        // and dispatch to onMechanismsReceived/onOutcomeReceived
+        _ = self;
+        _ = data;
+    }
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "SaslClientIo init" {
+    const allocator = std.testing.allocator;
+    var anon = @import("anonymous.zig").Anonymous{};
+    const mech = anon.mechanism();
+
+    var sasl = SaslClientIo.init(allocator, mech, "localhost");
+    try std.testing.expectEqual(SaslState.not_started, sasl.state);
+    try std.testing.expect(!sasl.isComplete());
+}
+
+test "SaslClientIo outcome handling" {
+    const allocator = std.testing.allocator;
+    var anon = @import("anonymous.zig").Anonymous{};
+    const mech = anon.mechanism();
+
+    var sasl = SaslClientIo.init(allocator, mech, null);
+    sasl.state = .waiting_for_outcome;
+
+    sasl.onOutcomeReceived(.{ .code = .ok });
+    try std.testing.expectEqual(SaslState.complete, sasl.state);
+    try std.testing.expect(sasl.isComplete());
+}

--- a/src/zig/sasl/mechanism.zig
+++ b/src/zig/sasl/mechanism.zig
@@ -1,0 +1,34 @@
+///! SASL Mechanism interface
+///!
+///! Defines the trait (vtable) for SASL authentication mechanisms.
+const std = @import("std");
+
+/// SASL mechanism interface — implemented by ANONYMOUS, PLAIN, MSSBCBS.
+pub const Mechanism = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        get_mechanism_name: *const fn (ptr: *anyopaque) []const u8,
+        get_init_bytes: *const fn (ptr: *anyopaque) ?[]const u8,
+        on_challenge: *const fn (ptr: *anyopaque, challenge: []const u8) ?[]const u8,
+    };
+
+    pub fn getMechanismName(self: Mechanism) []const u8 {
+        return self.vtable.get_mechanism_name(self.ptr);
+    }
+
+    pub fn getInitBytes(self: Mechanism) ?[]const u8 {
+        return self.vtable.get_init_bytes(self.ptr);
+    }
+
+    pub fn onChallenge(self: Mechanism, challenge: []const u8) ?[]const u8 {
+        return self.vtable.on_challenge(self.ptr, challenge);
+    }
+};
+
+test "Mechanism vtable compiles" {
+    // Compile-time check that the interface is well-formed
+    const info = @typeInfo(Mechanism);
+    try std.testing.expect(info == .@"struct");
+}

--- a/src/zig/sasl/plain.zig
+++ b/src/zig/sasl/plain.zig
@@ -1,0 +1,109 @@
+///! SASL PLAIN mechanism (RFC 4616)
+///!
+///! Encodes credentials as: \0<authcid>\0<passwd>
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Mechanism = @import("mechanism.zig").Mechanism;
+
+pub const Plain = struct {
+    allocator: Allocator,
+    authcid: []const u8,
+    passwd: []const u8,
+    authzid: ?[]const u8,
+    init_bytes: ?[]u8 = null,
+
+    pub fn init(allocator: Allocator, authcid: []const u8, passwd: []const u8, authzid: ?[]const u8) Plain {
+        return .{
+            .allocator = allocator,
+            .authcid = authcid,
+            .passwd = passwd,
+            .authzid = authzid,
+        };
+    }
+
+    pub fn deinit(self: *Plain) void {
+        if (self.init_bytes) |bytes| {
+            self.allocator.free(bytes);
+        }
+    }
+
+    pub fn mechanism(self: *Plain) Mechanism {
+        return .{
+            .ptr = @ptrCast(self),
+            .vtable = &vtable,
+        };
+    }
+
+    const vtable = Mechanism.VTable{
+        .get_mechanism_name = getMechanismName,
+        .get_init_bytes = getInitBytes,
+        .on_challenge = onChallenge,
+    };
+
+    fn getMechanismName(_: *anyopaque) []const u8 {
+        return "PLAIN";
+    }
+
+    fn getInitBytes(ptr: *anyopaque) ?[]const u8 {
+        const self: *Plain = @ptrCast(@alignCast(ptr));
+        if (self.init_bytes) |bytes| return bytes;
+
+        // Format: [authzid] \0 authcid \0 passwd
+        const authzid_len = if (self.authzid) |a| a.len else 0;
+        const total = authzid_len + 1 + self.authcid.len + 1 + self.passwd.len;
+
+        const buf = self.allocator.alloc(u8, total) catch return null;
+        var offset: usize = 0;
+
+        if (self.authzid) |a| {
+            @memcpy(buf[0..a.len], a);
+            offset += a.len;
+        }
+        buf[offset] = 0;
+        offset += 1;
+        @memcpy(buf[offset .. offset + self.authcid.len], self.authcid);
+        offset += self.authcid.len;
+        buf[offset] = 0;
+        offset += 1;
+        @memcpy(buf[offset .. offset + self.passwd.len], self.passwd);
+
+        self.init_bytes = buf;
+        return buf;
+    }
+
+    fn onChallenge(_: *anyopaque, _: []const u8) ?[]const u8 {
+        // PLAIN doesn't support challenges
+        return null;
+    }
+};
+
+test "PLAIN mechanism init bytes" {
+    const allocator = std.testing.allocator;
+    var plain = Plain.init(allocator, "user", "pass", null);
+    defer plain.deinit();
+
+    const mech = plain.mechanism();
+    try std.testing.expectEqualStrings("PLAIN", mech.getMechanismName());
+
+    const init_bytes = mech.getInitBytes().?;
+    // Expected: \0user\0pass
+    try std.testing.expectEqual(@as(usize, 10), init_bytes.len);
+    try std.testing.expectEqual(@as(u8, 0), init_bytes[0]);
+    try std.testing.expectEqualStrings("user", init_bytes[1..5]);
+    try std.testing.expectEqual(@as(u8, 0), init_bytes[5]);
+    try std.testing.expectEqualStrings("pass", init_bytes[6..10]);
+}
+
+test "PLAIN mechanism with authzid" {
+    const allocator = std.testing.allocator;
+    var plain = Plain.init(allocator, "user", "pass", "admin");
+    defer plain.deinit();
+
+    const mech = plain.mechanism();
+    const init_bytes = mech.getInitBytes().?;
+    // Expected: admin\0user\0pass
+    try std.testing.expectEqual(@as(usize, 15), init_bytes.len);
+    try std.testing.expectEqualStrings("admin", init_bytes[0..5]);
+    try std.testing.expectEqual(@as(u8, 0), init_bytes[5]);
+    try std.testing.expectEqualStrings("user", init_bytes[6..10]);
+}

--- a/src/zig/types/amqp_value.zig
+++ b/src/zig/types/amqp_value.zig
@@ -1,0 +1,299 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+/// AMQP 1.0 type format codes (from OASIS spec section 1.6)
+pub const FormatCode = enum(u8) {
+    // Fixed-width: 0 octets
+    described = 0x00,
+    null = 0x40,
+    boolean_true = 0x41,
+    boolean_false = 0x42,
+    uint_0 = 0x43,
+    ulong_0 = 0x44,
+
+    // Fixed-width: 1 octet
+    boolean = 0x56,
+    ubyte = 0x50,
+    byte = 0x51,
+    smalluint = 0x52,
+    smallulong = 0x53,
+    smallint = 0x54,
+    smalllong = 0x55,
+
+    // Fixed-width: 2 octets
+    ushort = 0x60,
+    short = 0x61,
+
+    // Fixed-width: 4 octets
+    uint = 0x70,
+    int = 0x71,
+    float = 0x72,
+    char = 0x73,
+
+    // Fixed-width: 8 octets
+    ulong = 0x80,
+    long = 0x81,
+    double = 0x82,
+    timestamp = 0x83,
+
+    // Fixed-width: 16 octets
+    uuid = 0x98,
+
+    // Variable-width: 1-octet size
+    binary_8 = 0xa0,
+    string_8 = 0xa1,
+    symbol_8 = 0xa3,
+
+    // Variable-width: 4-octet size
+    binary_32 = 0xb0,
+    string_32 = 0xb1,
+    symbol_32 = 0xb3,
+
+    // Compound: 1-octet size+count
+    list_0 = 0x45,
+    list_8 = 0xc0,
+    map_8 = 0xc1,
+
+    // Compound: 4-octet size+count
+    list_32 = 0xd0,
+    map_32 = 0xd1,
+
+    // Array
+    array_8 = 0xe0,
+    array_32 = 0xf0,
+
+    _,
+};
+
+/// A key-value pair in an AMQP map.
+pub const MapEntry = struct {
+    key: AmqpValue,
+    value: AmqpValue,
+};
+
+/// The descriptor for an AMQP described type.
+pub const Described = struct {
+    descriptor: *AmqpValue,
+    value: *AmqpValue,
+};
+
+/// Core AMQP 1.0 value type — a tagged union representing all AMQP primitive
+/// and composite types as defined in the OASIS AMQP 1.0 specification.
+pub const AmqpValue = union(enum) {
+    null,
+    boolean: bool,
+    ubyte: u8,
+    ushort: u16,
+    uint: u32,
+    ulong: u64,
+    byte: i8,
+    short: i16,
+    int: i32,
+    long: i64,
+    float: f32,
+    double: f64,
+    char: u21,
+    timestamp: i64,
+    uuid: [16]u8,
+    binary: []const u8,
+    string: []const u8,
+    symbol: []const u8,
+    list: []AmqpValue,
+    map: []MapEntry,
+    array: []AmqpValue,
+    described: Described,
+
+    /// Deep-clone this value, allocating all nested structures.
+    pub fn clone(self: AmqpValue, allocator: Allocator) Allocator.Error!AmqpValue {
+        return switch (self) {
+            .null, .boolean, .ubyte, .ushort, .uint, .ulong, .byte, .short, .int, .long, .float, .double, .char, .timestamp, .uuid => self,
+            .binary => |b| .{ .binary = try allocator.dupe(u8, b) },
+            .string => |s| .{ .string = try allocator.dupe(u8, s) },
+            .symbol => |s| .{ .symbol = try allocator.dupe(u8, s) },
+            .list => |items| {
+                const new_items = try allocator.alloc(AmqpValue, items.len);
+                for (items, 0..) |item, i| {
+                    new_items[i] = try item.clone(allocator);
+                }
+                return .{ .list = new_items };
+            },
+            .map => |entries| {
+                const new_entries = try allocator.alloc(MapEntry, entries.len);
+                for (entries, 0..) |entry, i| {
+                    new_entries[i] = .{
+                        .key = try entry.key.clone(allocator),
+                        .value = try entry.value.clone(allocator),
+                    };
+                }
+                return .{ .map = new_entries };
+            },
+            .array => |items| {
+                const new_items = try allocator.alloc(AmqpValue, items.len);
+                for (items, 0..) |item, i| {
+                    new_items[i] = try item.clone(allocator);
+                }
+                return .{ .array = new_items };
+            },
+            .described => |d| {
+                const new_desc = try allocator.create(AmqpValue);
+                const new_val = try allocator.create(AmqpValue);
+                new_desc.* = try d.descriptor.clone(allocator);
+                new_val.* = try d.value.clone(allocator);
+                return .{ .described = .{ .descriptor = new_desc, .value = new_val } };
+            },
+        };
+    }
+
+    /// Free all memory owned by this value.
+    pub fn deinit(self: *AmqpValue, allocator: Allocator) void {
+        switch (self.*) {
+            .null, .boolean, .ubyte, .ushort, .uint, .ulong, .byte, .short, .int, .long, .float, .double, .char, .timestamp, .uuid => {},
+            .binary => |b| allocator.free(b),
+            .string => |s| allocator.free(s),
+            .symbol => |s| allocator.free(s),
+            .list => |items| {
+                for (items) |*item| {
+                    @constCast(item).deinit(allocator);
+                }
+                allocator.free(items);
+            },
+            .map => |entries| {
+                for (entries) |*entry| {
+                    @constCast(&entry.key).deinit(allocator);
+                    @constCast(&entry.value).deinit(allocator);
+                }
+                allocator.free(entries);
+            },
+            .array => |items| {
+                for (items) |*item| {
+                    @constCast(item).deinit(allocator);
+                }
+                allocator.free(items);
+            },
+            .described => |d| {
+                d.descriptor.deinit(allocator);
+                allocator.destroy(d.descriptor);
+                d.value.deinit(allocator);
+                allocator.destroy(d.value);
+            },
+        }
+        self.* = .null;
+    }
+
+    /// Return the AMQP type tag name.
+    pub fn typeName(self: AmqpValue) []const u8 {
+        return @tagName(self);
+    }
+
+    /// Check structural equality (deep comparison).
+    pub fn eql(a: AmqpValue, b: AmqpValue) bool {
+        const Tag = std.meta.Tag(AmqpValue);
+        const tag_a: Tag = a;
+        const tag_b: Tag = b;
+        if (tag_a != tag_b) return false;
+
+        return switch (a) {
+            .null => true,
+            .boolean => |v| v == b.boolean,
+            .ubyte => |v| v == b.ubyte,
+            .ushort => |v| v == b.ushort,
+            .uint => |v| v == b.uint,
+            .ulong => |v| v == b.ulong,
+            .byte => |v| v == b.byte,
+            .short => |v| v == b.short,
+            .int => |v| v == b.int,
+            .long => |v| v == b.long,
+            .float => |v| v == b.float,
+            .double => |v| v == b.double,
+            .char => |v| v == b.char,
+            .timestamp => |v| v == b.timestamp,
+            .uuid => |v| std.mem.eql(u8, &v, &b.uuid),
+            .binary => |v| std.mem.eql(u8, v, b.binary),
+            .string => |v| std.mem.eql(u8, v, b.string),
+            .symbol => |v| std.mem.eql(u8, v, b.symbol),
+            .list => |items| {
+                const other = b.list;
+                if (items.len != other.len) return false;
+                for (items, other) |x, y| {
+                    if (!x.eql(y)) return false;
+                }
+                return true;
+            },
+            .map => |entries| {
+                const other = b.map;
+                if (entries.len != other.len) return false;
+                for (entries, other) |x, y| {
+                    if (!x.key.eql(y.key) or !x.value.eql(y.value)) return false;
+                }
+                return true;
+            },
+            .array => |items| {
+                const other = b.array;
+                if (items.len != other.len) return false;
+                for (items, other) |x, y| {
+                    if (!x.eql(y)) return false;
+                }
+                return true;
+            },
+            .described => |d| {
+                const other = b.described;
+                return d.descriptor.eql(other.descriptor.*) and d.value.eql(other.value.*);
+            },
+        };
+    }
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "AmqpValue primitive types" {
+    const testing = std.testing;
+
+    const v_null: AmqpValue = .null;
+    try testing.expectEqualStrings("null", v_null.typeName());
+
+    const v_bool: AmqpValue = .{ .boolean = true };
+    try testing.expect(v_bool.eql(.{ .boolean = true }));
+    try testing.expect(!v_bool.eql(.{ .boolean = false }));
+
+    const v_int: AmqpValue = .{ .int = -42 };
+    try testing.expect(v_int.eql(.{ .int = -42 }));
+
+    const v_ulong: AmqpValue = .{ .ulong = 0xDEADBEEF };
+    try testing.expect(v_ulong.eql(.{ .ulong = 0xDEADBEEF }));
+}
+
+test "AmqpValue clone and deinit" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    // Clone a string
+    const original: AmqpValue = .{ .string = "hello" };
+    var cloned = try original.clone(allocator);
+    defer cloned.deinit(allocator);
+    try testing.expect(original.eql(cloned));
+
+    // Clone a list
+    var items = [_]AmqpValue{
+        .{ .uint = 1 },
+        .{ .uint = 2 },
+        .{ .string = "three" },
+    };
+    const list_val: AmqpValue = .{ .list = &items };
+    var cloned_list = try list_val.clone(allocator);
+    defer cloned_list.deinit(allocator);
+    try testing.expect(list_val.eql(cloned_list));
+}
+
+test "AmqpValue map clone" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var entries = [_]MapEntry{
+        .{ .key = .{ .symbol = "key1" }, .value = .{ .string = "val1" } },
+        .{ .key = .{ .symbol = "key2" }, .value = .{ .uint = 42 } },
+    };
+    const map_val: AmqpValue = .{ .map = &entries };
+    var cloned = try map_val.clone(allocator);
+    defer cloned.deinit(allocator);
+    try testing.expect(map_val.eql(cloned));
+}

--- a/src/zig/types/decoder.zig
+++ b/src/zig/types/decoder.zig
@@ -1,0 +1,454 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const amqp = @import("amqp_value.zig");
+const AmqpValue = amqp.AmqpValue;
+const MapEntry = amqp.MapEntry;
+const Described = amqp.Described;
+const FormatCode = amqp.FormatCode;
+
+pub const DecodeError = error{
+    InvalidFormatCode,
+    InvalidData,
+    UnexpectedEnd,
+    OutOfMemory,
+};
+
+pub const DecodeResult = struct { value: AmqpValue, bytes_consumed: usize };
+
+/// Decode a single AMQP 1.0 value from binary data.
+/// Returns the decoded value and the number of bytes consumed.
+pub fn decode(allocator: Allocator, data: []const u8) DecodeError!DecodeResult {
+    if (data.len == 0) return error.UnexpectedEnd;
+
+    const code_byte = data[0];
+
+    // Described type constructor
+    if (code_byte == 0x00) {
+        if (data.len < 2) return error.UnexpectedEnd;
+        const desc_result = try decode(allocator, data[1..]);
+        const val_result = try decode(allocator, data[1 + desc_result.bytes_consumed ..]);
+        const descriptor = try allocator.create(AmqpValue);
+        descriptor.* = desc_result.value;
+        const value = try allocator.create(AmqpValue);
+        value.* = val_result.value;
+        return .{
+            .value = .{ .described = .{ .descriptor = descriptor, .value = value } },
+            .bytes_consumed = 1 + desc_result.bytes_consumed + val_result.bytes_consumed,
+        };
+    }
+
+    const code: FormatCode = @enumFromInt(code_byte);
+    return switch (code) {
+        .described => unreachable, // handled above via code_byte == 0x00 check
+
+        // Fixed-width: 0 octets
+        .null => .{ .value = .null, .bytes_consumed = 1 },
+        .boolean_true => .{ .value = .{ .boolean = true }, .bytes_consumed = 1 },
+        .boolean_false => .{ .value = .{ .boolean = false }, .bytes_consumed = 1 },
+        .uint_0 => .{ .value = .{ .uint = 0 }, .bytes_consumed = 1 },
+        .ulong_0 => .{ .value = .{ .ulong = 0 }, .bytes_consumed = 1 },
+        .list_0 => .{ .value = .{ .list = try allocator.alloc(AmqpValue, 0) }, .bytes_consumed = 1 },
+
+        // Fixed-width: 1 octet
+        .boolean => blk: {
+            if (data.len < 2) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .boolean = data[1] != 0 }, .bytes_consumed = 2 };
+        },
+        .ubyte => blk: {
+            if (data.len < 2) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .ubyte = data[1] }, .bytes_consumed = 2 };
+        },
+        .byte => blk: {
+            if (data.len < 2) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .byte = @bitCast(data[1]) }, .bytes_consumed = 2 };
+        },
+        .smalluint => blk: {
+            if (data.len < 2) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .uint = data[1] }, .bytes_consumed = 2 };
+        },
+        .smallulong => blk: {
+            if (data.len < 2) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .ulong = data[1] }, .bytes_consumed = 2 };
+        },
+        .smallint => blk: {
+            if (data.len < 2) return error.UnexpectedEnd;
+            const v: i8 = @bitCast(data[1]);
+            break :blk .{ .value = .{ .int = v }, .bytes_consumed = 2 };
+        },
+        .smalllong => blk: {
+            if (data.len < 2) return error.UnexpectedEnd;
+            const v: i8 = @bitCast(data[1]);
+            break :blk .{ .value = .{ .long = v }, .bytes_consumed = 2 };
+        },
+
+        // Fixed-width: 2 octets
+        .ushort => blk: {
+            if (data.len < 3) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .ushort = readU16(data[1..3]) }, .bytes_consumed = 3 };
+        },
+        .short => blk: {
+            if (data.len < 3) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .short = @bitCast(readU16(data[1..3])) }, .bytes_consumed = 3 };
+        },
+
+        // Fixed-width: 4 octets
+        .uint => blk: {
+            if (data.len < 5) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .uint = readU32(data[1..5]) }, .bytes_consumed = 5 };
+        },
+        .int => blk: {
+            if (data.len < 5) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .int = @bitCast(readU32(data[1..5])) }, .bytes_consumed = 5 };
+        },
+        .float => blk: {
+            if (data.len < 5) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .float = @bitCast(readU32(data[1..5])) }, .bytes_consumed = 5 };
+        },
+        .char => blk: {
+            if (data.len < 5) return error.UnexpectedEnd;
+            const raw = readU32(data[1..5]);
+            if (raw > 0x10FFFF) return error.InvalidData;
+            break :blk .{ .value = .{ .char = @intCast(raw) }, .bytes_consumed = 5 };
+        },
+
+        // Fixed-width: 8 octets
+        .ulong => blk: {
+            if (data.len < 9) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .ulong = readU64(data[1..9]) }, .bytes_consumed = 9 };
+        },
+        .long => blk: {
+            if (data.len < 9) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .long = @bitCast(readU64(data[1..9])) }, .bytes_consumed = 9 };
+        },
+        .double => blk: {
+            if (data.len < 9) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .double = @bitCast(readU64(data[1..9])) }, .bytes_consumed = 9 };
+        },
+        .timestamp => blk: {
+            if (data.len < 9) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .timestamp = @bitCast(readU64(data[1..9])) }, .bytes_consumed = 9 };
+        },
+
+        // Fixed-width: 16 octets
+        .uuid => blk: {
+            if (data.len < 17) return error.UnexpectedEnd;
+            break :blk .{ .value = .{ .uuid = data[1..17].* }, .bytes_consumed = 17 };
+        },
+
+        // Variable-width: 1-octet size
+        .binary_8 => try decodeVariable8(allocator, data, .binary),
+        .string_8 => try decodeVariable8(allocator, data, .string),
+        .symbol_8 => try decodeVariable8(allocator, data, .symbol),
+
+        // Variable-width: 4-octet size
+        .binary_32 => try decodeVariable32(allocator, data, .binary),
+        .string_32 => try decodeVariable32(allocator, data, .string),
+        .symbol_32 => try decodeVariable32(allocator, data, .symbol),
+
+        // Compound: list
+        .list_8 => try decodeList8(allocator, data),
+        .list_32 => try decodeList32(allocator, data),
+
+        // Compound: map
+        .map_8 => try decodeMap8(allocator, data),
+        .map_32 => try decodeMap32(allocator, data),
+
+        // Array
+        .array_8 => try decodeArray8(allocator, data),
+        .array_32 => try decodeArray32(allocator, data),
+
+        _ => error.InvalidFormatCode,
+    };
+}
+
+const VariableTag = enum { binary, string, symbol };
+
+fn decodeVariable8(allocator: Allocator, data: []const u8, tag: VariableTag) DecodeError!DecodeResult {
+    if (data.len < 2) return error.UnexpectedEnd;
+    const len: usize = data[1];
+    if (data.len < 2 + len) return error.UnexpectedEnd;
+    const bytes = try allocator.dupe(u8, data[2 .. 2 + len]);
+    const value: AmqpValue = switch (tag) {
+        .binary => .{ .binary = bytes },
+        .string => .{ .string = bytes },
+        .symbol => .{ .symbol = bytes },
+    };
+    return .{ .value = value, .bytes_consumed = 2 + len };
+}
+
+fn decodeVariable32(allocator: Allocator, data: []const u8, tag: VariableTag) DecodeError!DecodeResult {
+    if (data.len < 5) return error.UnexpectedEnd;
+    const len: usize = readU32(data[1..5]);
+    if (data.len < 5 + len) return error.UnexpectedEnd;
+    const bytes = try allocator.dupe(u8, data[5 .. 5 + len]);
+    const value: AmqpValue = switch (tag) {
+        .binary => .{ .binary = bytes },
+        .string => .{ .string = bytes },
+        .symbol => .{ .symbol = bytes },
+    };
+    return .{ .value = value, .bytes_consumed = 5 + len };
+}
+
+fn decodeList8(allocator: Allocator, data: []const u8) DecodeError!DecodeResult {
+    if (data.len < 3) return error.UnexpectedEnd;
+    const size: usize = data[1];
+    const count: usize = data[2];
+    _ = size;
+    return try decodeListItems(allocator, data[3..], count, 3);
+}
+
+fn decodeList32(allocator: Allocator, data: []const u8) DecodeError!DecodeResult {
+    if (data.len < 9) return error.UnexpectedEnd;
+    const size: usize = readU32(data[1..5]);
+    const count: usize = readU32(data[5..9]);
+    _ = size;
+    return try decodeListItems(allocator, data[9..], count, 9);
+}
+
+fn decodeListItems(allocator: Allocator, data: []const u8, count: usize, header_size: usize) DecodeError!DecodeResult {
+    const items = try allocator.alloc(AmqpValue, count);
+    errdefer {
+        for (items) |*item| {
+            @constCast(item).deinit(allocator);
+        }
+        allocator.free(items);
+    }
+    var offset: usize = 0;
+    for (0..count) |i| {
+        const result = try decode(allocator, data[offset..]);
+        items[i] = result.value;
+        offset += result.bytes_consumed;
+    }
+    return .{ .value = .{ .list = items }, .bytes_consumed = header_size + offset };
+}
+
+fn decodeMap8(allocator: Allocator, data: []const u8) DecodeError!DecodeResult {
+    if (data.len < 3) return error.UnexpectedEnd;
+    const size: usize = data[1];
+    const count: usize = data[2];
+    _ = size;
+    if (count % 2 != 0) return error.InvalidData;
+    return try decodeMapEntries(allocator, data[3..], count / 2, 3);
+}
+
+fn decodeMap32(allocator: Allocator, data: []const u8) DecodeError!DecodeResult {
+    if (data.len < 9) return error.UnexpectedEnd;
+    const size: usize = readU32(data[1..5]);
+    const count: usize = readU32(data[5..9]);
+    _ = size;
+    if (count % 2 != 0) return error.InvalidData;
+    return try decodeMapEntries(allocator, data[9..], count / 2, 9);
+}
+
+fn decodeMapEntries(allocator: Allocator, data: []const u8, pair_count: usize, header_size: usize) DecodeError!DecodeResult {
+    const entries = try allocator.alloc(MapEntry, pair_count);
+    errdefer {
+        for (entries) |*entry| {
+            @constCast(&entry.key).deinit(allocator);
+            @constCast(&entry.value).deinit(allocator);
+        }
+        allocator.free(entries);
+    }
+    var offset: usize = 0;
+    for (0..pair_count) |i| {
+        const key_result = try decode(allocator, data[offset..]);
+        offset += key_result.bytes_consumed;
+        const val_result = try decode(allocator, data[offset..]);
+        offset += val_result.bytes_consumed;
+        entries[i] = .{ .key = key_result.value, .value = val_result.value };
+    }
+    return .{ .value = .{ .map = entries }, .bytes_consumed = header_size + offset };
+}
+
+fn decodeArray8(allocator: Allocator, data: []const u8) DecodeError!DecodeResult {
+    if (data.len < 3) return error.UnexpectedEnd;
+    const size: usize = data[1];
+    const count: usize = data[2];
+    _ = size;
+    if (data.len < 4) return error.UnexpectedEnd;
+    return try decodeArrayItems(allocator, data[3..], count, 3);
+}
+
+fn decodeArray32(allocator: Allocator, data: []const u8) DecodeError!DecodeResult {
+    if (data.len < 9) return error.UnexpectedEnd;
+    const size: usize = readU32(data[1..5]);
+    const count: usize = readU32(data[5..9]);
+    _ = size;
+    return try decodeArrayItems(allocator, data[9..], count, 9);
+}
+
+fn decodeArrayItems(allocator: Allocator, data: []const u8, count: usize, header_size: usize) DecodeError!DecodeResult {
+    if (count == 0) {
+        return .{ .value = .{ .array = try allocator.alloc(AmqpValue, 0) }, .bytes_consumed = header_size };
+    }
+
+    // First byte is the shared constructor (format code)
+    if (data.len < 1) return error.UnexpectedEnd;
+    const constructor_code = data[0];
+
+    const items = try allocator.alloc(AmqpValue, count);
+    errdefer {
+        for (items) |*item| {
+            @constCast(item).deinit(allocator);
+        }
+        allocator.free(items);
+    }
+
+    // Decode each item by prepending the constructor byte
+    var offset: usize = 1; // skip constructor
+    for (0..count) |i| {
+        // Build a temporary buffer: constructor + remaining data
+        // For efficiency, we decode by manually handling the format code
+        var temp_buf: [256]u8 = undefined;
+        const remaining = data[offset..];
+        if (remaining.len + 1 > temp_buf.len) {
+            // Fall back to allocated buffer for large items
+            const temp = try allocator.alloc(u8, remaining.len + 1);
+            defer allocator.free(temp);
+            temp[0] = constructor_code;
+            @memcpy(temp[1 .. 1 + remaining.len], remaining);
+            const result = try decode(allocator, temp);
+            items[i] = result.value;
+            offset += result.bytes_consumed - 1; // -1 for constructor we prepended
+        } else {
+            temp_buf[0] = constructor_code;
+            @memcpy(temp_buf[1 .. 1 + remaining.len], remaining);
+            const result = try decode(allocator, temp_buf[0 .. 1 + remaining.len]);
+            items[i] = result.value;
+            offset += result.bytes_consumed - 1;
+        }
+    }
+    return .{ .value = .{ .array = items }, .bytes_consumed = header_size + offset };
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+fn readU16(data: []const u8) u16 {
+    return std.mem.readInt(u16, data[0..2], .big);
+}
+
+fn readU32(data: []const u8) u32 {
+    return std.mem.readInt(u32, data[0..4], .big);
+}
+
+fn readU64(data: []const u8) u64 {
+    return std.mem.readInt(u64, data[0..8], .big);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "decode null" {
+    const allocator = std.testing.allocator;
+    const result = try decode(allocator, &[_]u8{0x40});
+    try std.testing.expect(result.value.eql(.null));
+    try std.testing.expectEqual(@as(usize, 1), result.bytes_consumed);
+}
+
+test "decode boolean" {
+    const allocator = std.testing.allocator;
+    const r1 = try decode(allocator, &[_]u8{0x41});
+    try std.testing.expect(r1.value.eql(.{ .boolean = true }));
+
+    const r2 = try decode(allocator, &[_]u8{0x42});
+    try std.testing.expect(r2.value.eql(.{ .boolean = false }));
+}
+
+test "decode uint forms" {
+    const allocator = std.testing.allocator;
+
+    // uint_0
+    const r0 = try decode(allocator, &[_]u8{0x43});
+    try std.testing.expect(r0.value.eql(.{ .uint = 0 }));
+
+    // smalluint
+    const r1 = try decode(allocator, &[_]u8{ 0x52, 42 });
+    try std.testing.expect(r1.value.eql(.{ .uint = 42 }));
+
+    // uint
+    const r2 = try decode(allocator, &[_]u8{ 0x70, 0x12, 0x34, 0x56, 0x78 });
+    try std.testing.expect(r2.value.eql(.{ .uint = 0x12345678 }));
+}
+
+test "decode string" {
+    const allocator = std.testing.allocator;
+    const data = [_]u8{ 0xa1, 5, 'h', 'e', 'l', 'l', 'o' };
+    const result = try decode(allocator, &data);
+    defer @constCast(&result.value).deinit(allocator);
+    try std.testing.expectEqualStrings("hello", result.value.string);
+}
+
+test "roundtrip encode-decode" {
+    const allocator = std.testing.allocator;
+    const enc = @import("encoder.zig");
+
+    const test_values = [_]AmqpValue{
+        .null,
+        .{ .boolean = true },
+        .{ .boolean = false },
+        .{ .ubyte = 255 },
+        .{ .ushort = 1000 },
+        .{ .uint = 0 },
+        .{ .uint = 100 },
+        .{ .uint = 0x12345678 },
+        .{ .ulong = 0 },
+        .{ .ulong = 50 },
+        .{ .byte = -1 },
+        .{ .short = -1000 },
+        .{ .int = 0 },
+        .{ .int = -42 },
+        .{ .long = 0 },
+        .{ .long = -100 },
+        .{ .float = 3.14 },
+        .{ .double = 2.71828 },
+        .{ .timestamp = 1617235200000 },
+    };
+
+    for (test_values) |original| {
+        var buf_arr: [64]u8 = undefined;
+        var buf = enc.Buffer.initFixed(&buf_arr);
+        try enc.encode(original, &buf);
+        const written = buf.written();
+
+        const result = try decode(allocator, written);
+        defer {
+            var v = result.value;
+            v.deinit(allocator);
+        }
+
+        try std.testing.expect(original.eql(result.value));
+        try std.testing.expectEqual(written.len, result.bytes_consumed);
+    }
+}
+
+test "roundtrip string" {
+    const allocator = std.testing.allocator;
+    const enc = @import("encoder.zig");
+
+    const original: AmqpValue = .{ .string = "hello world" };
+    var buf_arr: [64]u8 = undefined;
+    var buf = enc.Buffer.initFixed(&buf_arr);
+    try enc.encode(original, &buf);
+
+    const result = try decode(allocator, buf.written());
+    defer @constCast(&result.value).deinit(allocator);
+    try std.testing.expectEqualStrings("hello world", result.value.string);
+}
+
+test "roundtrip list" {
+    const allocator = std.testing.allocator;
+    const enc = @import("encoder.zig");
+
+    var items = [_]AmqpValue{ .{ .uint = 1 }, .{ .boolean = true }, .null };
+    const original: AmqpValue = .{ .list = &items };
+
+    var buf_arr: [64]u8 = undefined;
+    var buf = enc.Buffer.initFixed(&buf_arr);
+    try enc.encode(original, &buf);
+
+    const result = try decode(allocator, buf.written());
+    defer {
+        var v = result.value;
+        v.deinit(allocator);
+    }
+    try std.testing.expect(original.eql(result.value));
+}

--- a/src/zig/types/decoder.zig
+++ b/src/zig/types/decoder.zig
@@ -206,9 +206,17 @@ fn decodeList32(allocator: Allocator, data: []const u8) DecodeError!DecodeResult
 }
 
 fn decodeListItems(allocator: Allocator, data: []const u8, count: usize, header_size: usize) DecodeError!DecodeResult {
+    // The count comes off the wire. Every element needs at least one byte, so
+    // reject a count the remaining data cannot possibly satisfy before
+    // allocating for it.
+    if (count > data.len) return error.UnexpectedEnd;
+
     const items = try allocator.alloc(AmqpValue, count);
+    // Only the prefix written so far is initialized; deiniting past it would
+    // free whatever the allocator happened to leave in the tail.
+    var filled: usize = 0;
     errdefer {
-        for (items) |*item| {
+        for (items[0..filled]) |*item| {
             @constCast(item).deinit(allocator);
         }
         allocator.free(items);
@@ -217,6 +225,7 @@ fn decodeListItems(allocator: Allocator, data: []const u8, count: usize, header_
     for (0..count) |i| {
         const result = try decode(allocator, data[offset..]);
         items[i] = result.value;
+        filled = i + 1;
         offset += result.bytes_consumed;
     }
     return .{ .value = .{ .list = items }, .bytes_consumed = header_size + offset };
@@ -241,9 +250,16 @@ fn decodeMap32(allocator: Allocator, data: []const u8) DecodeError!DecodeResult 
 }
 
 fn decodeMapEntries(allocator: Allocator, data: []const u8, pair_count: usize, header_size: usize) DecodeError!DecodeResult {
+    // Each pair needs at least two bytes, so reject a count the remaining data
+    // cannot possibly satisfy before allocating for it.
+    if (pair_count > data.len / 2) return error.UnexpectedEnd;
+
     const entries = try allocator.alloc(MapEntry, pair_count);
+    // Only the prefix written so far is initialized; deiniting past it would
+    // free whatever the allocator happened to leave in the tail.
+    var filled: usize = 0;
     errdefer {
-        for (entries) |*entry| {
+        for (entries[0..filled]) |*entry| {
             @constCast(&entry.key).deinit(allocator);
             @constCast(&entry.value).deinit(allocator);
         }
@@ -253,9 +269,13 @@ fn decodeMapEntries(allocator: Allocator, data: []const u8, pair_count: usize, h
     for (0..pair_count) |i| {
         const key_result = try decode(allocator, data[offset..]);
         offset += key_result.bytes_consumed;
+        var key_value = key_result.value;
+        errdefer key_value.deinit(allocator);
+
         const val_result = try decode(allocator, data[offset..]);
         offset += val_result.bytes_consumed;
-        entries[i] = .{ .key = key_result.value, .value = val_result.value };
+        entries[i] = .{ .key = key_value, .value = val_result.value };
+        filled = i + 1;
     }
     return .{ .value = .{ .map = entries }, .bytes_consumed = header_size + offset };
 }
@@ -286,9 +306,16 @@ fn decodeArrayItems(allocator: Allocator, data: []const u8, count: usize, header
     if (data.len < 1) return error.UnexpectedEnd;
     const constructor_code = data[0];
 
+    // The count comes off the wire; reject one the remaining data cannot
+    // possibly satisfy before allocating for it.
+    if (count > data.len) return error.UnexpectedEnd;
+
     const items = try allocator.alloc(AmqpValue, count);
+    // Only the prefix written so far is initialized; deiniting past it would
+    // free whatever the allocator happened to leave in the tail.
+    var filled: usize = 0;
     errdefer {
-        for (items) |*item| {
+        for (items[0..filled]) |*item| {
             @constCast(item).deinit(allocator);
         }
         allocator.free(items);
@@ -309,12 +336,14 @@ fn decodeArrayItems(allocator: Allocator, data: []const u8, count: usize, header
             @memcpy(temp[1 .. 1 + remaining.len], remaining);
             const result = try decode(allocator, temp);
             items[i] = result.value;
+            filled = i + 1;
             offset += result.bytes_consumed - 1; // -1 for constructor we prepended
         } else {
             temp_buf[0] = constructor_code;
             @memcpy(temp_buf[1 .. 1 + remaining.len], remaining);
             const result = try decode(allocator, temp_buf[0 .. 1 + remaining.len]);
             items[i] = result.value;
+            filled = i + 1;
             offset += result.bytes_consumed - 1;
         }
     }
@@ -451,4 +480,70 @@ test "roundtrip list" {
         v.deinit(allocator);
     }
     try std.testing.expect(original.eql(result.value));
+}
+
+test "a truncated map does not deinit uninitialized entries" {
+    const allocator = std.testing.allocator;
+    // map8 declaring one pair, with no entry bytes following it.
+    try std.testing.expectError(error.UnexpectedEnd, decode(allocator, &.{ 0xc1, 0x02, 0x02 }));
+}
+
+test "a truncated list does not deinit uninitialized items" {
+    const allocator = std.testing.allocator;
+    // list8 declaring three items, with only one byte of body.
+    try std.testing.expectError(error.UnexpectedEnd, decode(allocator, &.{ 0xc0, 0x02, 0x03, 0x40 }));
+}
+
+test "a truncated array does not deinit uninitialized items" {
+    const allocator = std.testing.allocator;
+    // array8 declaring four symbols after the shared constructor.
+    try std.testing.expectError(error.UnexpectedEnd, decode(allocator, &.{ 0xe0, 0x02, 0x04, 0xa3 }));
+}
+
+test "an oversized count is rejected before allocating" {
+    const allocator = std.testing.allocator;
+    // list32 claiming 0xffffffff items with an empty body. Allocating for that
+    // count would need 64 GiB.
+    try std.testing.expectError(error.UnexpectedEnd, decode(
+        allocator,
+        &.{ 0xd0, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff, 0xff, 0xff },
+    ));
+    // map32 with the same claim.
+    try std.testing.expectError(error.UnexpectedEnd, decode(
+        allocator,
+        &.{ 0xd1, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff, 0xff, 0xfe },
+    ));
+}
+
+test "a partially decoded map frees only what it built" {
+    const allocator = std.testing.allocator;
+    // A well-formed first pair (str8 "k" -> str8 "v"), then a truncated key.
+    // The first pair must be freed exactly once and the tail left alone.
+    try std.testing.expectError(error.UnexpectedEnd, decode(allocator, &.{
+        0xc1, 0x0c, 0x04,
+        0xa1, 0x01, 'k',
+        0xa1, 0x01, 'v',
+        0xa1, 0x04, 'a',
+    }));
+}
+
+test "a map whose value is truncated frees the already decoded key" {
+    const allocator = std.testing.allocator;
+    // str8 "k" decodes as a key, then the value claims four bytes but has one.
+    try std.testing.expectError(error.UnexpectedEnd, decode(allocator, &.{
+        0xc1, 0x08, 0x02,
+        0xa1, 0x01, 'k',
+        0xa1, 0x04, 'v',
+    }));
+}
+
+test "decoding a nested truncated list is safe" {
+    const allocator = std.testing.allocator;
+    // Outer list of two: a valid null, then an inner list8 claiming two items
+    // it does not have.
+    try std.testing.expectError(error.UnexpectedEnd, decode(allocator, &.{
+        0xc0, 0x06, 0x02,
+        0x40, 0xc0, 0x02,
+        0x02, 0x40,
+    }));
 }

--- a/src/zig/types/encoder.zig
+++ b/src/zig/types/encoder.zig
@@ -1,0 +1,377 @@
+const std = @import("std");
+const amqp = @import("amqp_value.zig");
+const AmqpValue = amqp.AmqpValue;
+const MapEntry = amqp.MapEntry;
+const FormatCode = amqp.FormatCode;
+const Allocator = std.mem.Allocator;
+
+/// A simple growable byte buffer for encoding.
+pub const Buffer = struct {
+    data: []u8,
+    pos: usize,
+    allocator: ?Allocator,
+    is_fixed: bool,
+
+    pub fn initFixed(buf: []u8) Buffer {
+        return .{ .data = buf, .pos = 0, .allocator = null, .is_fixed = true };
+    }
+
+    pub fn initDynamic(allocator: Allocator) Buffer {
+        return .{ .data = &.{}, .pos = 0, .allocator = allocator, .is_fixed = false };
+    }
+
+    pub fn deinit(self: *Buffer) void {
+        if (!self.is_fixed) {
+            if (self.allocator) |a| {
+                if (self.data.len > 0) a.free(self.data);
+            }
+        }
+    }
+
+    pub fn written(self: *const Buffer) []const u8 {
+        return self.data[0..self.pos];
+    }
+
+    pub fn reset(self: *Buffer) void {
+        self.pos = 0;
+    }
+
+    fn ensureCapacity(self: *Buffer, additional: usize) !void {
+        const needed = self.pos + additional;
+        if (needed <= self.data.len) return;
+        if (self.is_fixed) return error.OutOfMemory;
+        const a = self.allocator orelse return error.OutOfMemory;
+        const new_cap = @max(self.data.len * 2, needed, 64);
+        if (self.data.len > 0) {
+            self.data = try a.realloc(self.data, new_cap);
+        } else {
+            self.data = try a.alloc(u8, new_cap);
+        }
+    }
+
+    pub fn writeByte(self: *Buffer, byte: u8) !void {
+        try self.ensureCapacity(1);
+        self.data[self.pos] = byte;
+        self.pos += 1;
+    }
+
+    pub fn writeAll(self: *Buffer, bytes: []const u8) !void {
+        try self.ensureCapacity(bytes.len);
+        @memcpy(self.data[self.pos .. self.pos + bytes.len], bytes);
+        self.pos += bytes.len;
+    }
+};
+
+pub const EncodeError = error{OutOfMemory};
+
+/// Encode an AmqpValue into AMQP 1.0 binary wire format.
+pub fn encode(value: AmqpValue, buf: *Buffer) EncodeError!void {
+    switch (value) {
+        .null => try buf.writeByte(@intFromEnum(FormatCode.null)),
+        .boolean => |v| {
+            try buf.writeByte(@intFromEnum(if (v) FormatCode.boolean_true else FormatCode.boolean_false));
+        },
+        .ubyte => |v| {
+            try buf.writeByte(@intFromEnum(FormatCode.ubyte));
+            try buf.writeByte(v);
+        },
+        .ushort => |v| {
+            try buf.writeByte(@intFromEnum(FormatCode.ushort));
+            try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u16, v, .big)));
+        },
+        .uint => |v| {
+            if (v == 0) {
+                try buf.writeByte(@intFromEnum(FormatCode.uint_0));
+            } else if (v <= 0xFF) {
+                try buf.writeByte(@intFromEnum(FormatCode.smalluint));
+                try buf.writeByte(@truncate(v));
+            } else {
+                try buf.writeByte(@intFromEnum(FormatCode.uint));
+                try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, v, .big)));
+            }
+        },
+        .ulong => |v| {
+            if (v == 0) {
+                try buf.writeByte(@intFromEnum(FormatCode.ulong_0));
+            } else if (v <= 0xFF) {
+                try buf.writeByte(@intFromEnum(FormatCode.smallulong));
+                try buf.writeByte(@truncate(v));
+            } else {
+                try buf.writeByte(@intFromEnum(FormatCode.ulong));
+                try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u64, v, .big)));
+            }
+        },
+        .byte => |v| {
+            try buf.writeByte(@intFromEnum(FormatCode.byte));
+            try buf.writeByte(@bitCast(v));
+        },
+        .short => |v| {
+            try buf.writeByte(@intFromEnum(FormatCode.short));
+            try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u16, @as(u16, @bitCast(v)), .big)));
+        },
+        .int => |v| {
+            if (v >= -128 and v <= 127) {
+                try buf.writeByte(@intFromEnum(FormatCode.smallint));
+                try buf.writeByte(@bitCast(@as(i8, @intCast(v))));
+            } else {
+                try buf.writeByte(@intFromEnum(FormatCode.int));
+                try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @as(u32, @bitCast(v)), .big)));
+            }
+        },
+        .long => |v| {
+            if (v >= -128 and v <= 127) {
+                try buf.writeByte(@intFromEnum(FormatCode.smalllong));
+                try buf.writeByte(@bitCast(@as(i8, @intCast(v))));
+            } else {
+                try buf.writeByte(@intFromEnum(FormatCode.long));
+                try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u64, @as(u64, @bitCast(v)), .big)));
+            }
+        },
+        .float => |v| {
+            try buf.writeByte(@intFromEnum(FormatCode.float));
+            try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @as(u32, @bitCast(v)), .big)));
+        },
+        .double => |v| {
+            try buf.writeByte(@intFromEnum(FormatCode.double));
+            try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u64, @as(u64, @bitCast(v)), .big)));
+        },
+        .char => |v| {
+            try buf.writeByte(@intFromEnum(FormatCode.char));
+            try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @as(u32, v), .big)));
+        },
+        .timestamp => |v| {
+            try buf.writeByte(@intFromEnum(FormatCode.timestamp));
+            try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u64, @as(u64, @bitCast(v)), .big)));
+        },
+        .uuid => |v| {
+            try buf.writeByte(@intFromEnum(FormatCode.uuid));
+            try buf.writeAll(&v);
+        },
+        .binary => |v| try writeVariable(buf, v, FormatCode.binary_8, FormatCode.binary_32),
+        .string => |v| try writeVariable(buf, v, FormatCode.string_8, FormatCode.string_32),
+        .symbol => |v| try writeVariable(buf, v, FormatCode.symbol_8, FormatCode.symbol_32),
+        .list => |items| {
+            if (items.len == 0) {
+                try buf.writeByte(@intFromEnum(FormatCode.list_0));
+                return;
+            }
+
+            // Encode all items to a temp buffer to compute size
+            var tmp = Buffer.initDynamic(std.heap.page_allocator);
+            defer tmp.deinit();
+            for (items) |item| {
+                try encode(item, &tmp);
+            }
+
+            const count = items.len;
+            if (tmp.pos <= 0xFF and count <= 0xFF) {
+                try buf.writeByte(@intFromEnum(FormatCode.list_8));
+                try buf.writeByte(@intCast(tmp.pos + 1));
+                try buf.writeByte(@intCast(count));
+            } else {
+                try buf.writeByte(@intFromEnum(FormatCode.list_32));
+                try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @intCast(tmp.pos + 4), .big)));
+                try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @intCast(count), .big)));
+            }
+            try buf.writeAll(tmp.written());
+        },
+        .map => |entries| {
+            var tmp = Buffer.initDynamic(std.heap.page_allocator);
+            defer tmp.deinit();
+            for (entries) |entry| {
+                try encode(entry.key, &tmp);
+                try encode(entry.value, &tmp);
+            }
+
+            const count = entries.len * 2;
+            if (tmp.pos <= 0xFF and count <= 0xFF) {
+                try buf.writeByte(@intFromEnum(FormatCode.map_8));
+                try buf.writeByte(@intCast(tmp.pos + 1));
+                try buf.writeByte(@intCast(count));
+            } else {
+                try buf.writeByte(@intFromEnum(FormatCode.map_32));
+                try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @intCast(tmp.pos + 4), .big)));
+                try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @intCast(count), .big)));
+            }
+            try buf.writeAll(tmp.written());
+        },
+        .array => |items| {
+            if (items.len == 0) {
+                try buf.writeByte(@intFromEnum(FormatCode.list_0));
+                return;
+            }
+
+            var tmp = Buffer.initDynamic(std.heap.page_allocator);
+            defer tmp.deinit();
+
+            // Write constructor (format code of first item)
+            const fc = firstFormatCode(items[0]);
+            try tmp.writeByte(@intFromEnum(fc));
+
+            // Write each item's data (without constructor)
+            for (items) |item| {
+                try encodeRaw(item, &tmp);
+            }
+
+            const count = items.len;
+            if (tmp.pos <= 0xFF and count <= 0xFF) {
+                try buf.writeByte(@intFromEnum(FormatCode.array_8));
+                try buf.writeByte(@intCast(tmp.pos + 1));
+                try buf.writeByte(@intCast(count));
+            } else {
+                try buf.writeByte(@intFromEnum(FormatCode.array_32));
+                try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @intCast(tmp.pos + 4), .big)));
+                try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @intCast(count), .big)));
+            }
+            try buf.writeAll(tmp.written());
+        },
+        .described => |d| {
+            try buf.writeByte(0x00); // described type constructor
+            try encode(d.descriptor.*, buf);
+            try encode(d.value.*, buf);
+        },
+    }
+}
+
+/// Compute the encoded size of a value without writing it.
+pub fn encodedSize(value: AmqpValue) usize {
+    var tmp = Buffer.initDynamic(std.heap.page_allocator);
+    defer tmp.deinit();
+    encode(value, &tmp) catch return 0;
+    return tmp.pos;
+}
+
+fn writeVariable(buf: *Buffer, data: []const u8, small_code: FormatCode, large_code: FormatCode) !void {
+    if (data.len <= 0xFF) {
+        try buf.writeByte(@intFromEnum(small_code));
+        try buf.writeByte(@intCast(data.len));
+    } else {
+        try buf.writeByte(@intFromEnum(large_code));
+        try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @intCast(data.len), .big)));
+    }
+    try buf.writeAll(data);
+}
+
+/// Write the raw data of a value (without the format code constructor).
+fn encodeRaw(value: AmqpValue, buf: *Buffer) EncodeError!void {
+    switch (value) {
+        .null => {},
+        .boolean => |v| try buf.writeByte(if (v) 1 else 0),
+        .ubyte => |v| try buf.writeByte(v),
+        .ushort => |v| try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u16, v, .big))),
+        .uint => |v| try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, v, .big))),
+        .ulong => |v| try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u64, v, .big))),
+        .byte => |v| try buf.writeByte(@bitCast(v)),
+        .short => |v| try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u16, @as(u16, @bitCast(v)), .big))),
+        .int => |v| try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @as(u32, @bitCast(v)), .big))),
+        .long => |v| try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u64, @as(u64, @bitCast(v)), .big))),
+        .float => |v| try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @as(u32, @bitCast(v)), .big))),
+        .double => |v| try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u64, @as(u64, @bitCast(v)), .big))),
+        .char => |v| try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u32, @as(u32, v), .big))),
+        .timestamp => |v| try buf.writeAll(&std.mem.toBytes(std.mem.nativeTo(u64, @as(u64, @bitCast(v)), .big))),
+        .uuid => |v| try buf.writeAll(&v),
+        .binary => |v| try buf.writeAll(v),
+        .string => |v| try buf.writeAll(v),
+        .symbol => |v| try buf.writeAll(v),
+        else => try encode(value, buf),
+    }
+}
+
+fn firstFormatCode(value: AmqpValue) FormatCode {
+    return switch (value) {
+        .null => FormatCode.null,
+        .boolean => FormatCode.boolean,
+        .ubyte => FormatCode.ubyte,
+        .ushort => FormatCode.ushort,
+        .uint => FormatCode.uint,
+        .ulong => FormatCode.ulong,
+        .byte => FormatCode.byte,
+        .short => FormatCode.short,
+        .int => FormatCode.int,
+        .long => FormatCode.long,
+        .float => FormatCode.float,
+        .double => FormatCode.double,
+        .char => FormatCode.char,
+        .timestamp => FormatCode.timestamp,
+        .uuid => FormatCode.uuid,
+        .binary => FormatCode.binary_32,
+        .string => FormatCode.string_32,
+        .symbol => FormatCode.symbol_32,
+        .list => FormatCode.list_32,
+        .map => FormatCode.map_32,
+        .array => FormatCode.array_32,
+        .described => FormatCode.described,
+    };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test "encode null" {
+    var buf_arr: [1]u8 = undefined;
+    var buf = Buffer.initFixed(&buf_arr);
+    try encode(.null, &buf);
+    try std.testing.expectEqual(@as(u8, 0x40), buf.written()[0]);
+}
+
+test "encode boolean" {
+    var buf_arr: [1]u8 = undefined;
+    var buf = Buffer.initFixed(&buf_arr);
+    try encode(.{ .boolean = true }, &buf);
+    try std.testing.expectEqual(@as(u8, 0x41), buf.written()[0]);
+
+    buf.reset();
+    try encode(.{ .boolean = false }, &buf);
+    try std.testing.expectEqual(@as(u8, 0x42), buf.written()[0]);
+}
+
+test "encode uint compact forms" {
+    // uint_0
+    {
+        var buf_arr: [1]u8 = undefined;
+        var buf = Buffer.initFixed(&buf_arr);
+        try encode(.{ .uint = 0 }, &buf);
+        try std.testing.expectEqual(@as(u8, 0x43), buf.written()[0]);
+    }
+    // smalluint
+    {
+        var buf_arr: [2]u8 = undefined;
+        var buf = Buffer.initFixed(&buf_arr);
+        try encode(.{ .uint = 200 }, &buf);
+        try std.testing.expectEqual(@as(u8, 0x52), buf.written()[0]);
+        try std.testing.expectEqual(@as(u8, 200), buf.written()[1]);
+    }
+    // uint
+    {
+        var buf_arr: [5]u8 = undefined;
+        var buf = Buffer.initFixed(&buf_arr);
+        try encode(.{ .uint = 0x12345678 }, &buf);
+        try std.testing.expectEqual(@as(u8, 0x70), buf.written()[0]);
+        try std.testing.expectEqualSlices(u8, &.{ 0x12, 0x34, 0x56, 0x78 }, buf.written()[1..5]);
+    }
+}
+
+test "encode string" {
+    var buf_arr: [32]u8 = undefined;
+    var buf = Buffer.initFixed(&buf_arr);
+    try encode(.{ .string = "hello" }, &buf);
+    const w = buf.written();
+    try std.testing.expectEqual(@as(u8, 0xa1), w[0]); // string_8
+    try std.testing.expectEqual(@as(u8, 5), w[1]); // length
+    try std.testing.expectEqualStrings("hello", w[2..7]);
+}
+
+test "encode list" {
+    var buf_arr: [64]u8 = undefined;
+    var buf = Buffer.initFixed(&buf_arr);
+    var items = [_]AmqpValue{ .{ .uint = 1 }, .{ .boolean = true }, .null };
+    try encode(.{ .list = &items }, &buf);
+    try std.testing.expectEqual(@as(u8, 0xc0), buf.written()[0]); // list_8
+}
+
+test "encode empty list" {
+    var buf_arr: [1]u8 = undefined;
+    var buf = Buffer.initFixed(&buf_arr);
+    const empty: []AmqpValue = &.{};
+    try encode(.{ .list = empty }, &buf);
+    try std.testing.expectEqual(@as(u8, 0x45), buf.written()[0]); // list_0
+}

--- a/src/zig/uamqp.zig
+++ b/src/zig/uamqp.zig
@@ -1,0 +1,45 @@
+///! Azure uAMQP - AMQP 1.0 protocol library for Zig
+///!
+///! A Zig implementation of the OASIS AMQP 1.0 protocol.
+///! Ported from azure-uamqp-c v1.2.12.
+
+// Core types
+pub const types = @import("types/amqp_value.zig");
+pub const AmqpValue = types.AmqpValue;
+pub const Described = types.Described;
+pub const MapEntry = types.MapEntry;
+
+// Encoding / decoding
+pub const encoder = @import("types/encoder.zig");
+pub const decoder = @import("types/decoder.zig");
+
+// Protocol
+pub const frame = @import("protocol/frame.zig");
+pub const frame_codec = @import("protocol/frame_codec.zig");
+pub const definitions = @import("protocol/definitions.zig");
+pub const connection = @import("protocol/connection.zig");
+pub const session = @import("protocol/session.zig");
+pub const link = @import("protocol/link.zig");
+
+// Message layer
+pub const message = @import("message.zig");
+pub const messaging = @import("messaging.zig");
+
+// SASL
+pub const sasl = struct {
+    pub const mechanism = @import("sasl/mechanism.zig");
+    pub const anonymous = @import("sasl/anonymous.zig");
+    pub const plain = @import("sasl/plain.zig");
+    pub const client_io = @import("sasl/client_io.zig");
+};
+
+// High-level
+pub const cbs = @import("cbs.zig");
+pub const management = @import("management.zig");
+
+pub const version = "0.1.0";
+
+test {
+    const std = @import("std");
+    std.testing.refAllDecls(@This());
+}


### PR DESCRIPTION
## The bug

`decodeListItems`, `decodeMapEntries`, and `decodeArrayItems` each allocate an uninitialized array and then, on any error, run an errdefer that calls `deinit` on **every** element:

```zig
const entries = try allocator.alloc(MapEntry, pair_count);
errdefer {
    for (entries) |*entry| {          // <- all of them, not just the decoded ones
        @constCast(&entry.key).deinit(allocator);
        @constCast(&entry.value).deinit(allocator);
    }
    allocator.free(entries);
}
```

Only the elements decoded so far are initialized. The cleanup walks whatever the allocator happened to leave in the tail and frees it as if it were an `AmqpValue`.

The count and the element bytes both come straight off the wire, so any peer can reach this. Three bytes are enough:

```zig
decode(allocator, &.{ 0xc1, 0x02, 0x02 })  // map8, one pair declared, no body
```

In a safe build that panics with `switch on corrupt value`. In a release build without safety checks it frees arbitrary pointers.

I hit this while decoding AMQP frames in `azure-sdk-for-zig`, which reaches `decode` on every inbound frame body.

## Second issue: unbounded allocation

The element count is read from the wire and used to size an allocation with no cross-check against the data actually present — `size` is read and then explicitly discarded (`_ = size;`). A nine-byte frame claiming `0xffffffff` list items asks for 64 GiB:

```zig
decode(allocator, &.{ 0xd0, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff, 0xff, 0xff })
```

## The fix

Each of the three now tracks how many elements it has written and cleans up only that prefix. `decodeMapEntries` additionally frees the key it just decoded when the matching value fails, which previously leaked.

For the allocation bound: every element needs at least one byte and every map pair at least two, so the count is rejected against the remaining length before allocating. This is a cheap lower bound, not full `size` validation — it is enough to stop the count alone from driving the allocation.

## Testing

48 -> 55 tests, covering truncation at each of the three levels, a nested truncated list, partial map cleanup where the key decodes but the value does not, and the oversized counts.

Verified the tests actually catch the original bug: reverting just the prefix tracking (`entries[0..filled]` back to `entries`) crashes two of them with the original panic.